### PR TITLE
Fix for SECOAUTH-147 expires_in for implicit grant

### DIFF
--- a/samples/oauth2/sparklr/src/test/java/org/springframework/security/oauth2/provider/TestImplicitProvider.java
+++ b/samples/oauth2/sparklr/src/test/java/org/springframework/security/oauth2/provider/TestImplicitProvider.java
@@ -76,8 +76,27 @@ public class TestImplicitProvider {
 		// we've got the access token.
 		String fragment = redirection.getFragment();
 		assertNotNull("No fragment in redirect: "+redirection, fragment);
-		String accessToken = fragment.split("=")[1];
+		
+		String accessToken = null;
+		Long expiresIn = null;
+		String tokenType = null;
+		String[] parameters = fragment.split("&");
+		for (String parameter : parameters) {
+			String[] s=parameter.split("=");
+			String name=s[0];
+			String value=s[1];
+			if (name.equals("access_token")) {
+				accessToken = value;
+			} else if (name.equals("expires_in")) {
+				expiresIn = Long.valueOf(value);
+			} else if (name.equals("token_type")) {
+				tokenType = value;
+			}
+		}
 
+		assertNotNull(tokenType);
+		assertNotNull(expiresIn);
+		
 		// now try and use the token to access a protected resource.
 		// first make sure the resource is actually protected.
 		assertNotSame(HttpStatus.OK, serverRunning.getStatusCode("/sparklr/photos?format=json"));

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -15,6 +15,7 @@ package org.springframework.security.oauth2.provider.endpoint;
 
 import java.security.Principal;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
@@ -176,6 +177,12 @@ public class AuthorizationEndpoint implements InitializingBean {
 			url.append("#");
 		}
 		url.append("access_token="+accessToken.getValue());
+		url.append("&token_type="+accessToken.getTokenType());
+		Date expiration = accessToken.getExpiration();
+		if (expiration != null) {
+			long expires_in = (expiration.getTime() - System.currentTimeMillis()) / 1000;
+			url.append("&expires_in="+expires_in);
+		}
 		return url.toString();
 	}
 


### PR DESCRIPTION
Fix for SECOAUTH-147 Implicit grant does not include the expires_in in the redirect to the user-agent

https://jira.springsource.org/browse/SECOAUTH-147

http://forum.springsource.org/showthread.php?116424-Implicit-grant-does-not-include-the-expires_in-in-the-redirect-to-the-user-agent
