### PR TITLE
SECOAUTH-179 improvement suggestions

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/InMemoryTokenStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/InMemoryTokenStore.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.util.Assert;
@@ -34,7 +34,7 @@ public class InMemoryTokenStore implements TokenStore {
 
 	private final ConcurrentHashMap<String, Collection<OAuth2AccessToken>> clientIdToAccessTokenStore = new ConcurrentHashMap<String, Collection<OAuth2AccessToken>>();
 
-	private final ConcurrentHashMap<String, ExpiringOAuth2RefreshToken> refreshTokenStore = new ConcurrentHashMap<String, ExpiringOAuth2RefreshToken>();
+	private final ConcurrentHashMap<String, OAuth2RefreshToken> refreshTokenStore = new ConcurrentHashMap<String, OAuth2RefreshToken>();
 
 	private final ConcurrentHashMap<String, String> accessTokenToRefreshTokenStore = new ConcurrentHashMap<String, String>();
 
@@ -116,10 +116,18 @@ public class InMemoryTokenStore implements TokenStore {
 		return accessToken;
 	}
 
+	public OAuth2Authentication readAuthentication(OAuth2AccessToken token) {
+    return readAuthentication(token.getValue());
+  }
+
 	public OAuth2Authentication readAuthentication(String token) {
 		return this.authenticationStore.get(token);
 	}
 
+	public OAuth2Authentication readAuthenticationForRefreshToken(OAuth2RefreshToken token) {
+	  return readAuthenticationForRefreshToken(token.getValue());
+	}
+	
 	public OAuth2Authentication readAuthenticationForRefreshToken(String token) {
 		return this.refreshTokenAuthenticationStore.get(token);
 	}
@@ -157,6 +165,10 @@ public class InMemoryTokenStore implements TokenStore {
 		store.get(key).add(token);
 	}
 
+  public void removeAccessToken(OAuth2AccessToken accessToken) {
+    removeAccessToken(accessToken.getValue());
+  }
+
 	public OAuth2AccessToken readAccessToken(String tokenValue) {
 		return this.accessTokenStore.get(tokenValue);
 	}
@@ -184,23 +196,27 @@ public class InMemoryTokenStore implements TokenStore {
 		}
 	}
 
-	public OAuth2Authentication readAuthentication(ExpiringOAuth2RefreshToken token) {
-		return this.authenticationStore.get(token.getValue());
-	}
-
-	public void storeRefreshToken(ExpiringOAuth2RefreshToken refreshToken, OAuth2Authentication authentication) {
+	public void storeRefreshToken(OAuth2RefreshToken refreshToken, OAuth2Authentication authentication) {
 		this.refreshTokenStore.put(refreshToken.getValue(), refreshToken);
 		this.refreshTokenAuthenticationStore.put(refreshToken.getValue(), authentication);
 	}
 
-	public ExpiringOAuth2RefreshToken readRefreshToken(String tokenValue) {
+	public OAuth2RefreshToken readRefreshToken(String tokenValue) {
 		return this.refreshTokenStore.get(tokenValue);
+	}
+
+	public void removeRefreshToken(OAuth2RefreshToken refreshToken) {
+	  removeRefreshToken(refreshToken.getValue());
 	}
 
 	public void removeRefreshToken(String tokenValue) {
 		this.refreshTokenStore.remove(tokenValue);
 		this.refreshTokenAuthenticationStore.remove(tokenValue);
 	}
+	
+  public void removeAccessTokenUsingRefreshToken(OAuth2RefreshToken refreshToken) {
+    removeAccessTokenUsingRefreshToken(refreshToken.getValue());
+  }
 
 	public void removeAccessTokenUsingRefreshToken(String refreshToken) {
 		String accessToken = this.refreshTokenToAcessTokenStore.remove(refreshToken);

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RandomValueTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RandomValueTokenServices.java
@@ -71,7 +71,7 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 		OAuth2AccessToken existingAccessToken = tokenStore.getAccessToken(authentication);
 		if (existingAccessToken != null) {
 			if (existingAccessToken.isExpired()) {
-				tokenStore.removeAccessToken(existingAccessToken.getValue());
+				tokenStore.removeAccessToken(existingAccessToken);
 			}
 			else {
 				return existingAccessToken;
@@ -95,23 +95,24 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 			throw new InvalidGrantException("Invalid refresh token: " + refreshTokenValue);
 		}
 
-		// clear out any access tokens already associated with the refresh token.
-		tokenStore.removeAccessTokenUsingRefreshToken(refreshTokenValue);
-
-		ExpiringOAuth2RefreshToken refreshToken = tokenStore.readRefreshToken(refreshTokenValue);
+		OAuth2RefreshToken refreshToken = tokenStore.readRefreshToken(refreshTokenValue);
 		if (refreshToken == null) {
 			throw new InvalidGrantException("Invalid refresh token: " + refreshTokenValue);
 		}
-		else if (isExpired(refreshToken)) {
-			tokenStore.removeRefreshToken(refreshTokenValue);
+
+		// clear out any access tokens already associated with the refresh token.
+		tokenStore.removeAccessTokenUsingRefreshToken(refreshToken);
+
+		if (isExpired(refreshToken)) {
+			tokenStore.removeRefreshToken(refreshToken);
 			throw new InvalidGrantException("Invalid refresh token: " + refreshToken);
 		}
 
 		OAuth2Authentication authentication = createRefreshedAuthentication(
-				tokenStore.readAuthenticationForRefreshToken(refreshToken.getValue()), scope);
+				tokenStore.readAuthenticationForRefreshToken(refreshToken), scope);
 
 		if (!reuseRefreshToken) {
-			tokenStore.removeRefreshToken(refreshTokenValue);
+			tokenStore.removeRefreshToken(refreshToken);
 			refreshToken = createRefreshToken(authentication);
 		}
 
@@ -148,9 +149,13 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 		return narrowed;
 	}
 
-	protected boolean isExpired(ExpiringOAuth2RefreshToken refreshToken) {
-		return refreshToken.getExpiration() == null
-				|| System.currentTimeMillis() > refreshToken.getExpiration().getTime();
+	protected boolean isExpired(OAuth2RefreshToken refreshToken) {
+	  if (refreshToken instanceof ExpiringOAuth2RefreshToken) {
+	    ExpiringOAuth2RefreshToken expiringToken = (ExpiringOAuth2RefreshToken) refreshToken;
+  		return expiringToken.getExpiration() == null
+  				|| System.currentTimeMillis() > expiringToken.getExpiration().getTime();
+	  }
+	  return false;
 	}
 	
 	public OAuth2AccessToken readAccessToken(String accessToken) {
@@ -163,11 +168,11 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 			throw new InvalidTokenException("Invalid access token: " + accessTokenValue);
 		}
 		else if (accessToken.isExpired()) {
-			tokenStore.removeAccessToken(accessTokenValue);
+			tokenStore.removeAccessToken(accessToken);
 			throw new InvalidTokenException("Invalid access token: " + accessTokenValue);
 		}
 
-		return tokenStore.readAuthentication(accessTokenValue);
+		return tokenStore.readAuthentication(accessToken);
 	}
 	
 	public String getClientId(String tokenValue) {
@@ -196,24 +201,28 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 			return false;
 		}
 		if (accessToken.getRefreshToken() != null) {
-			tokenStore.removeRefreshToken(accessToken.getRefreshToken().getValue());
+			tokenStore.removeRefreshToken(accessToken.getRefreshToken());
 		}
-		tokenStore.removeAccessToken(tokenValue);
+		tokenStore.removeAccessToken(accessToken);
 		return true;
 	}
 
 	protected ExpiringOAuth2RefreshToken createRefreshToken(OAuth2Authentication authentication) {
 		ExpiringOAuth2RefreshToken refreshToken;
 		String refreshTokenValue = UUID.randomUUID().toString();
-		refreshToken = new ExpiringOAuth2RefreshToken(refreshTokenValue, new Date(System.currentTimeMillis()
+		refreshToken = createRefreshToken(authentication, refreshTokenValue, new Date(System.currentTimeMillis()
 				+ (refreshTokenValiditySeconds * 1000L)));
 		tokenStore.storeRefreshToken(refreshToken, authentication);
 		return refreshToken;
 	}
 
+  protected ExpiringOAuth2RefreshToken createRefreshToken(OAuth2Authentication authentication, String refreshTokenValue, Date expiration) {
+    return new ExpiringOAuth2RefreshToken(refreshTokenValue, expiration);
+  }
+
 	protected OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken) {
 		String tokenValue = UUID.randomUUID().toString();
-		OAuth2AccessToken token = new OAuth2AccessToken(tokenValue);
+		OAuth2AccessToken token = createAccessToken(authentication, tokenValue);
 		int validitySeconds = getAccessTokenValiditySeconds(authentication.getAuthorizationRequest());
 		if (validitySeconds > 0) {
 			token.setExpiration(new Date(System.currentTimeMillis() + (validitySeconds * 1000L)));
@@ -222,6 +231,10 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 		token.setScope(authentication.getAuthorizationRequest().getScope());
 		return token;
 	}
+
+  protected OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, String tokenValue) {
+      return new OAuth2AccessToken(tokenValue);
+  }
 
 	/**
 	 * The access token validity period in seconds

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/TokenStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/TokenStore.java
@@ -2,7 +2,7 @@ package org.springframework.security.oauth2.provider.token;
 
 import java.util.Collection;
 
-import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 
@@ -10,7 +10,16 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
  * Persistence interface for OAuth2 tokens.
  */
 public interface TokenStore {
-	/**
+
+  /**
+   * Read the authentication stored under the specified token value.
+   * 
+   * @param token The token value under which the authentication is stored.
+   * @return The authentication, or null if none.
+   */
+  OAuth2Authentication readAuthentication(OAuth2AccessToken token);
+  
+  /**
 	 * Read the authentication stored under the specified token value.
 	 * 
 	 * @param token The token value under which the authentication is stored.
@@ -37,9 +46,9 @@ public interface TokenStore {
 	/**
 	 * Remove an access token from the database.
 	 * 
-	 * @param tokenValue The token to remove from the database.
+	 * @param token The token to remove from the database.
 	 */
-	void removeAccessToken(String tokenValue);
+	void removeAccessToken(OAuth2AccessToken token);
 
 	/**
 	 * Store the specified refresh token in the database.
@@ -47,7 +56,7 @@ public interface TokenStore {
 	 * @param refreshToken The refresh token to store.
 	 * @param authentication The authentication associated with the refresh token.
 	 */
-	void storeRefreshToken(ExpiringOAuth2RefreshToken refreshToken, OAuth2Authentication authentication);
+	void storeRefreshToken(OAuth2RefreshToken refreshToken, OAuth2Authentication authentication);
 
 	/**
 	 * Read a refresh token from the store.
@@ -55,20 +64,20 @@ public interface TokenStore {
 	 * @param tokenValue The value of the token to read.
 	 * @return The token.
 	 */
-	ExpiringOAuth2RefreshToken readRefreshToken(String tokenValue);
+	OAuth2RefreshToken readRefreshToken(String tokenValue);
 
 	/**
-	 * @param value a refreh token value
+	 * @param token a refresh token
 	 * @return the authentication originally used to grant the refresh token
 	 */
-	OAuth2Authentication readAuthenticationForRefreshToken(String value);
+	OAuth2Authentication readAuthenticationForRefreshToken(OAuth2RefreshToken token);
 
 	/**
 	 * Remove a refresh token from the database.
 	 * 
-	 * @param tokenValue The value of the token to remove from the database.
+	 * @param token The token to remove from the database.
 	 */
-	void removeRefreshToken(String tokenValue);
+	void removeRefreshToken(OAuth2RefreshToken token);
 
 	/**
 	 * Remove an access token using a refresh token. This functionality is necessary so refresh tokens can't be used to
@@ -76,7 +85,7 @@ public interface TokenStore {
 	 * 
 	 * @param refreshToken The refresh token.
 	 */
-	void removeAccessTokenUsingRefreshToken(String refreshToken);
+	void removeAccessTokenUsingRefreshToken(OAuth2RefreshToken refreshToken);
 
 	/**
 	 * Retrieve an access token stored against the provided authentication key, if it exists.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestTokenStoreBase.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestTokenStoreBase.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import org.junit.Test;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -47,8 +48,8 @@ public abstract class TestTokenStoreBase {
 
 		OAuth2AccessToken actualOAuth2AccessToken = getTokenStore().readAccessToken("testToken");
 		assertEquals(expectedOAuth2AccessToken, actualOAuth2AccessToken);
-		assertEquals(expectedAuthentication, getTokenStore().readAuthentication(expectedOAuth2AccessToken.getValue()));
-		getTokenStore().removeAccessToken("testToken");
+		assertEquals(expectedAuthentication, getTokenStore().readAuthentication(expectedOAuth2AccessToken));
+		getTokenStore().removeAccessToken(expectedOAuth2AccessToken);
 		assertNull(getTokenStore().readAccessToken("testToken"));
 		assertNull(getTokenStore().readAuthentication(expectedOAuth2AccessToken.getValue()));
 	}
@@ -62,8 +63,8 @@ public abstract class TestTokenStoreBase {
 
 		OAuth2AccessToken actualOAuth2AccessToken = getTokenStore().getAccessToken(expectedAuthentication);
 		assertEquals(expectedOAuth2AccessToken, actualOAuth2AccessToken);
-		assertEquals(expectedAuthentication, getTokenStore().readAuthentication(expectedOAuth2AccessToken.getValue()));
-		getTokenStore().removeAccessToken("testToken");
+		assertEquals(expectedAuthentication, getTokenStore().readAuthentication(expectedOAuth2AccessToken));
+		getTokenStore().removeAccessToken(expectedOAuth2AccessToken);
 		assertNull(getTokenStore().readAccessToken("testToken"));
 		assertNull(getTokenStore().readAuthentication(expectedOAuth2AccessToken.getValue()));
 		assertNull(getTokenStore().getAccessToken(expectedAuthentication));
@@ -98,16 +99,16 @@ public abstract class TestTokenStoreBase {
 
 	@Test
 	public void testStoreRefreshToken() {
-		ExpiringOAuth2RefreshToken expectedExpiringRefreshToken = new ExpiringOAuth2RefreshToken("testToken",
+		OAuth2RefreshToken expectedExpiringRefreshToken = new ExpiringOAuth2RefreshToken("testToken",
 				new Date());
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(new AuthorizationRequest("id", null,
 				null, null), new TestAuthentication("test2", false));
 		getTokenStore().storeRefreshToken(expectedExpiringRefreshToken, expectedAuthentication);
 
-		ExpiringOAuth2RefreshToken actualExpiringRefreshToken = getTokenStore().readRefreshToken("testToken");
+		OAuth2RefreshToken actualExpiringRefreshToken = getTokenStore().readRefreshToken("testToken");
 		assertEquals(expectedExpiringRefreshToken, actualExpiringRefreshToken);
-		assertEquals(expectedAuthentication, getTokenStore().readAuthenticationForRefreshToken(expectedExpiringRefreshToken.getValue()));
-		getTokenStore().removeRefreshToken("testToken");
+		assertEquals(expectedAuthentication, getTokenStore().readAuthenticationForRefreshToken(expectedExpiringRefreshToken));
+		getTokenStore().removeRefreshToken(expectedExpiringRefreshToken);
 		assertNull(getTokenStore().readRefreshToken("testToken"));
 		assertNull(getTokenStore().readAuthentication(expectedExpiringRefreshToken.getValue()));
 	}


### PR DESCRIPTION
Issue SECOAUTH-179 Improve extendability of RandomValueTokenServices by keeping storage separate from token creation

My few commits were related to the same improvements. They go a few steps further.

1 random tokenvalue and expiration date are calculated in RandomValueTokenServices and passed to a new createXXXToken method. Subclasses can override this new createXXXToken method to instantiate their own token class. This way RandomValueTokenServices is responsible for tokenvalue and expiration.

2 Optimized the TokenStore interface a little to have a more efficient store implementation. My CustomTokenStore does not use the tokenvalue as primary lookup key. With these changes I can pass around my custom primary key.
