### PR TITLE
SECOAUTH-218: Log configuration

### DIFF
--- a/spring-security-oauth/src/main/java/org/springframework/security/oauth/provider/filter/OAuthProviderProcessingFilter.java
+++ b/spring-security-oauth/src/main/java/org/springframework/security/oauth/provider/filter/OAuthProviderProcessingFilter.java
@@ -65,8 +65,8 @@ public abstract class OAuthProviderProcessingFilter implements Filter, Initializ
    * Attribute for indicating that OAuth processing has already occurred.
    */
   public static final String OAUTH_PROCESSING_HANDLED = "org.springframework.security.oauth.provider.OAuthProviderProcessingFilter#SKIP_PROCESSING";
+  private static final Log log = LogFactory.getLog(OAuthProviderProcessingFilter.class);
 
-  private final Log log = LogFactory.getLog(getClass());
   private final List<String> allowedMethods = new ArrayList<String>(Arrays.asList("GET", "POST"));
   private OAuthProcessingFilterEntryPoint authenticationEntryPoint = new OAuthProcessingFilterEntryPoint();
   protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();


### PR DESCRIPTION
Fix for SECOAUTH-218.

The org.springframework.security.oauth.provider.filter.OAuthProviderProcessingFilter class defines the logger as:

private final Log log = LogFactory.getLog(getClass());

When we extend this class, the log entries created by that class appear under the concrete class' appender. This makes it harder to tweak the log level. It should be defined as:

private static final Log log = LogFactory.getLog(OAuthProviderProcessingFilter.class);
