### PR TITLE
SECOAUTH-239: Renamed authentication-failed-url to user-approval-url

### DIFF
--- a/docs/oauth1.md
+++ b/docs/oauth1.md
@@ -103,7 +103,7 @@ The `provider` element is used to configure the OAuth 1.0 provider mechanism. Th
 * `authenticate-token-url`: The URL at which a request to authenticate a request token will be serviced. Default value: "/oauth_authenticate_token"
 * `access-token-url`: The URL at which a request for an access token (using an authenticated request token) will be serviced. Default value: "/oauth_access_token"
 * `access-granted-url`: The URL to which the user will be redirected upon authenticating a request token, but only if there was no callback URL supplied from the oauth consumer. Default value: "/"
-* `authentication-failed-url`: The URL to which the user will be redirected if for some reason authentication of a request token failed. Default behavior is to just issue a "401: unauthorized" response.
+* `user-approval-url`: The URL to which the user will be redirected if for some reason authentication of a request token failed. Default behavior is to just issue a "401: unauthorized" response.
 * `nonce-services-ref`: The reference to the bean that defines the nonce services. Default is to supply an instance of `org.springframework.security.oauth.provider.nonce.ExpiringTimestampNonceServices`
 * `callback-services-ref`: The reference to the bean that defines the callback services. Default is to supply an instance of `org.springframework.security.oauth.provider.callback.InMemoryCallbackServices`
 * `verifier-services-ref`: The reference to the bean that defines the verifier services. Default is to supply an instance of `org.springframework.security.oauth.provider.verifier.RandomValueInMemoryVerifierServices`

--- a/samples/oauth/sparklr/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/samples/oauth/sparklr/src/main/webapp/WEB-INF/applicationContext.xml
@@ -33,7 +33,7 @@
                   token-services-ref="tokenServices"
                   request-token-url="/oauth/request_token"
                   authenticate-token-url="/oauth/authorize"
-                  authentication-failed-url="/oauth/confirm_access"
+                  user-approval-url="/oauth/confirm_access"
                   access-granted-url="/request_token_authorized.jsp"
                   access-token-url="/oauth/access_token"
                   require10a="false"/>

--- a/spring-security-oauth/src/main/java/org/springframework/security/oauth/config/OAuthProviderBeanDefinitionParser.java
+++ b/spring-security-oauth/src/main/java/org/springframework/security/oauth/config/OAuthProviderBeanDefinitionParser.java
@@ -89,12 +89,11 @@ public class OAuthProviderBeanDefinitionParser implements BeanDefinitionParser {
 
     // create a AuthenticationFailureHandler
     BeanDefinitionBuilder failedAuthenticationHandler = BeanDefinitionBuilder.rootBeanDefinition(SimpleUrlAuthenticationFailureHandler.class);
-    String authenticationFailedURL = element.getAttribute("authentication-failed-url");
-    if (StringUtils.hasText(authenticationFailedURL)) {
-      failedAuthenticationHandler.addConstructorArgValue (authenticationFailedURL);
-    }
-    else {
-      failedAuthenticationHandler.addConstructorArgValue ("/");
+    String userApprovalUrl = element.getAttribute("user-approval-url");
+    if (StringUtils.hasText(userApprovalUrl)) {
+      failedAuthenticationHandler.addConstructorArgValue(userApprovalUrl);
+    } else {
+      failedAuthenticationHandler.addConstructorArgValue("/");
     }
 
     String tokenIdParam = element.getAttribute("token-id-param");

--- a/spring-security-oauth/src/main/resources/org/springframework/security/oauth/spring-security-oauth-1.0.xsd
+++ b/spring-security-oauth/src/main/resources/org/springframework/security/oauth/spring-security-oauth-1.0.xsd
@@ -74,7 +74,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="authentication-failed-url" type="xs:string">
+      <xs:attribute name="user-approval-url" type="xs:string">
         <xs:annotation>
           <xs:documentation>
             The URL to which the user will be redirected if for some reason authentication of a request token failed. Default

--- a/spring-security-oauth/src/test/resources/org/springframework/security/oauth/config/TestAuthorizationServerBeanDefinitionParser-context.xml
+++ b/spring-security-oauth/src/test/resources/org/springframework/security/oauth/config/TestAuthorizationServerBeanDefinitionParser-context.xml
@@ -32,7 +32,7 @@
       token-id-param="myOverriddenTokenIdParam"
       request-token-url="/oauth/request_token"
       authenticate-token-url="/oauth/authorize"
-      authentication-failed-url="/oauth/confirm_access"
+      user-approval-url="/oauth/confirm_access"
       access-granted-url="/request_token_authorized.jsp"
       access-token-url="/oauth/access_token"
       require10a="false" />

--- a/spring-security-oauth/src/test/resources/org/springframework/security/oauth/config/TestConsumerServiceBeanDefinitionParser-context.xml
+++ b/spring-security-oauth/src/test/resources/org/springframework/security/oauth/config/TestConsumerServiceBeanDefinitionParser-context.xml
@@ -29,7 +29,7 @@
 	</authentication-manager>
 
 	<oauth:provider consumer-details-service-ref="consumerDetails" token-services-ref="tokenServices"
-		request-token-url="/oauth/request_token" authenticate-token-url="/oauth/authorize" authentication-failed-url="/oauth/confirm_access"
+		request-token-url="/oauth/request_token" authenticate-token-url="/oauth/authorize" user-approval-url="/oauth/confirm_access"
 		access-granted-url="/request_token_authorized.jsp" access-token-url="/oauth/access_token" require10a="false" />
 
 	<oauth:consumer-details-service id="consumerDetails">


### PR DESCRIPTION
Committed in separate branch now, rebased onto upstream/master
