### PR TITLE
Add support for per client refresh token validity seconds SECOAUTH-248

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/BaseClientDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/BaseClientDetails.java
@@ -50,6 +50,10 @@ public class BaseClientDetails implements ClientDetails {
 	@JsonProperty("access_token_validity")
 	private int accessTokenValiditySeconds = 0;
 
+	@JsonProperty("refresh_token_validity")
+	private int refreshTokenValiditySeconds = 0;
+
+
 	public BaseClientDetails() {
 	}
 
@@ -183,11 +187,21 @@ public class BaseClientDetails implements ClientDetails {
 		this.accessTokenValiditySeconds = accessTokenValiditySeconds;
 	}
 
+	@JsonIgnore
+	public int getRefreshTokenValiditySeconds() {
+		return refreshTokenValiditySeconds;
+	}
+
+	public void setRefreshTokenValiditySeconds(int refreshTokenValiditySeconds) {
+		this.refreshTokenValiditySeconds = refreshTokenValiditySeconds;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + accessTokenValiditySeconds;
+		result = prime * result + refreshTokenValiditySeconds;
 		result = prime * result + ((authorities == null) ? 0 : authorities.hashCode());
 		result = prime * result + ((authorizedGrantTypes == null) ? 0 : authorizedGrantTypes.hashCode());
 		result = prime * result + ((clientId == null) ? 0 : clientId.hashCode());
@@ -209,6 +223,9 @@ public class BaseClientDetails implements ClientDetails {
 		BaseClientDetails other = (BaseClientDetails) obj;
 		if (accessTokenValiditySeconds != other.accessTokenValiditySeconds)
 			return false;
+		if (refreshTokenValiditySeconds != other.refreshTokenValiditySeconds)
+			return false;
+
 		if (authorities == null) {
 			if (other.authorities != null)
 				return false;

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ClientDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ClientDetails.java
@@ -86,4 +86,11 @@ public interface ClientDetails extends Serializable {
 	 * @return the access token validity period
 	 */
 	int getAccessTokenValiditySeconds();
+
+	/**
+	 * The refresh token validity period for this client.  Zero or negative for default value set by token service.
+	 *
+	 * @return the refresh token validity period
+	 */
+	int getRefreshTokenValiditySeconds();
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/JdbcClientDetailsService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/JdbcClientDetailsService.java
@@ -37,13 +37,13 @@ import org.springframework.util.StringUtils;
 public class JdbcClientDetailsService implements ClientDetailsService, ClientRegistrationService {
 
 	private static final String CLIENT_FIELDS = "resource_ids, client_secret, scope, "
-			+ "authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity";
+			+ "authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, refresh_token_validity";
 
 	private static final String DEFAULT_SELECT_STATEMENT = "select client_id, " + CLIENT_FIELDS
 			+ " from oauth_client_details where client_id = ?";
 
 	private static final String DEFAULT_INSERT_STATEMENT = "insert into oauth_client_details (" + CLIENT_FIELDS
-			+ ", client_id) values (?,?,?,?,?,?,?,?)";
+			+ ", client_id) values (?,?,?,?,?,?,?,?,?)";
 
 	private static final String DEFAULT_UPDATE_STATEMENT = "update oauth_client_details "
 			+ "set " + CLIENT_FIELDS.replaceAll(", ", "=?, ")+"=? where client_id = ?";
@@ -84,6 +84,8 @@ public class JdbcClientDetailsService implements ClientDetailsService, ClientReg
 					details.setClientId(rs.getString(1));
 					details.setClientSecret(rs.getString(3));
 					details.setAccessTokenValiditySeconds(rs.getInt(8));
+					details.setRefreshTokenValiditySeconds(rs.getInt(9));
+
 					return details;
 				}
 			}, clientId);
@@ -127,6 +129,7 @@ public class JdbcClientDetailsService implements ClientDetailsService, ClientReg
 			clientDetails.getRegisteredRedirectUri()!=null ? StringUtils.collectionToCommaDelimitedString(clientDetails.getRegisteredRedirectUri()) : null,
 			clientDetails.getAuthorities()!=null ? StringUtils.collectionToCommaDelimitedString(clientDetails.getAuthorities()) : null,
 			clientDetails.getAccessTokenValiditySeconds(),
+			clientDetails.getRefreshTokenValiditySeconds(),
 			clientDetails.getClientId()
 		};
 	}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RandomValueTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RandomValueTokenServices.java
@@ -225,8 +225,9 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 		}
 		ExpiringOAuth2RefreshToken refreshToken;
 		String refreshTokenValue = UUID.randomUUID().toString();
-		refreshToken = createRefreshToken(authentication, refreshTokenValue, new Date(System.currentTimeMillis()
-				+ (refreshTokenValiditySeconds * 1000L)));
+		int validitySeconds = getRefreshTokenValiditySeconds(authentication.getAuthorizationRequest());
+		refreshToken = createRefreshToken(authentication, refreshTokenValue, 
+		    new Date(System.currentTimeMillis() + (validitySeconds* 1000L)));
 		tokenStore.storeRefreshToken(refreshToken, authentication);
 		return refreshToken;
 	}
@@ -266,6 +267,22 @@ public class RandomValueTokenServices implements AuthorizationServerTokenService
 		}
 		return accessTokenValiditySeconds;
 	}
+
+	/**
+	 * The refresh token validity period in seconds
+	 * @param authorizationRequest the current authorization request
+	 * @return the refresh token validity period in seconds
+	 */
+	protected int getRefreshTokenValiditySeconds(AuthorizationRequest authorizationRequest) {
+		if (clientDetailsService != null) {
+			ClientDetails client = clientDetailsService.loadClientByClientId(authorizationRequest.getClientId());
+			if (client.getRefreshTokenValiditySeconds() > 0) {
+				return client.getRefreshTokenValiditySeconds();
+			}
+		}
+		return refreshTokenValiditySeconds;
+	}
+
 
 	/**
 	 * The validity (in seconds) of the unauthenticated request token.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestBaseClientDetails.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestBaseClientDetails.java
@@ -61,10 +61,12 @@ public class TestBaseClientDetails {
 
 	@Test
 	public void testJsonDeserialize() throws Exception {
-		String value = "{\"foo\":\"bar\",\"scope\":[\"bar\",\"foo\"],\"authorized_grant_types\":[\"authorization_code\"],\"access_token_validity\":0,\"authorities\":[\"ROLE_USER\"]}";
+		String value = "{\"foo\":\"bar\",\"scope\":[\"bar\",\"foo\"],\"authorized_grant_types\":[\"authorization_code\"],\"access_token_validity\":0,\"authorities\":[\"ROLE_USER\"],\"refresh_token_validity\":0}";
 		BaseClientDetails details = new ObjectMapper().readValue(value, BaseClientDetails.class);
 		// System.err.println(new ObjectMapper().writeValueAsString(details));
 		BaseClientDetails expected = new BaseClientDetails("", "foo,bar", "authorization_code", "ROLE_USER");
 		assertEquals(expected, details);
+		assertEquals(0, details.getAccessTokenValiditySeconds());
+		assertEquals(0, details.getRefreshTokenValiditySeconds());
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestJdbcClientDetailsService.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestJdbcClientDetailsService.java
@@ -24,9 +24,9 @@ public class TestJdbcClientDetailsService {
 
 	private EmbeddedDatabase db;
 
-	private static final String SELECT_SQL = "select client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity from oauth_client_details where client_id=?";
+	private static final String SELECT_SQL = "select client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, refresh_token_validity from oauth_client_details where client_id=?";
 
-	private static final String INSERT_SQL = "insert into oauth_client_details (client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity) values (?, ?, ?, ?, ?, ?, ?, ?)";
+	private static final String INSERT_SQL = "insert into oauth_client_details (client_id, resource_ids, client_secret, scope, authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, refresh_token_validity) values (?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
 	private static final String CUSTOM_INSERT_SQL = "insert into ClientDetails (appId, resourceIds, appSecret, scope, grantTypes, redirectUrl, authorities) values (?, ?, ?, ?, ?, ?, ?)";
 
@@ -50,7 +50,7 @@ public class TestJdbcClientDetailsService {
 
 	@Test
 	public void testLoadingClientIdWithNoDetails() {
-		jdbcTemplate.update(INSERT_SQL, "clientIdWithNoDetails", null, null, null, null, null, null, null);
+	    jdbcTemplate.update(INSERT_SQL, "clientIdWithNoDetails", null, null, null, null, null, null, null, null);
 
 		ClientDetails clientDetails = service.loadClientByClientId("clientIdWithNoDetails");
 
@@ -68,7 +68,7 @@ public class TestJdbcClientDetailsService {
 	@Test
 	public void testLoadingClientIdWithSingleDetails() {
 		jdbcTemplate.update(INSERT_SQL, "clientIdWithSingleDetails", "myResource", "mySecret", "myScope",
-				"myAuthorizedGrantType", "myRedirectUri", "myAuthority", 100);
+				    "myAuthorizedGrantType", "myRedirectUri", "myAuthority", 100, 200);
 
 		ClientDetails clientDetails = service.loadClientByClientId("clientIdWithSingleDetails");
 
@@ -86,6 +86,7 @@ public class TestJdbcClientDetailsService {
 		assertEquals(1, clientDetails.getAuthorities().size());
 		assertEquals("myAuthority", clientDetails.getAuthorities().iterator().next().getAuthority());
 		assertEquals(100, clientDetails.getAccessTokenValiditySeconds());
+		assertEquals(200, clientDetails.getRefreshTokenValiditySeconds());
 	}
 
 	@Test
@@ -95,7 +96,7 @@ public class TestJdbcClientDetailsService {
 
 		JdbcClientDetailsService customService = new JdbcClientDetailsService(db);
 		customService.setSelectClientDetailsSql("select appId, resourceIds, appSecret, scope, "
-				+ "grantTypes, redirectUrl, authorities, access_token_validity from ClientDetails where appId = ?");
+				+ "grantTypes, redirectUrl, authorities, access_token_validity, refresh_token_validity from ClientDetails where appId = ?");
 
 		ClientDetails clientDetails = customService.loadClientByClientId("clientIdWithSingleDetails");
 
@@ -118,7 +119,7 @@ public class TestJdbcClientDetailsService {
 	public void testLoadingClientIdWithMultipleDetails() {
 		jdbcTemplate.update(INSERT_SQL, "clientIdWithMultipleDetails", "myResource1,myResource2", "mySecret",
 				"myScope1,myScope2", "myAuthorizedGrantType1,myAuthorizedGrantType2", "myRedirectUri1,myRedirectUri2",
-				"myAuthority1,myAuthority2", 100);
+				    "myAuthority1,myAuthority2", 100, 200);
 
 		ClientDetails clientDetails = service.loadClientByClientId("clientIdWithMultipleDetails");
 
@@ -147,6 +148,8 @@ public class TestJdbcClientDetailsService {
 		assertEquals("myAuthority1", authorities.next().getAuthority());
 		assertEquals("myAuthority2", authorities.next().getAuthority());
 		assertEquals(100, clientDetails.getAccessTokenValiditySeconds());
+		assertEquals(200, clientDetails.getRefreshTokenValiditySeconds());
+
 	}
 
 	@Test

--- a/spring-security-oauth2/src/test/resources/schema.sql
+++ b/spring-security-oauth2/src/test/resources/schema.sql
@@ -7,7 +7,8 @@ create table oauth_client_details (
   authorized_grant_types VARCHAR(256),
   web_server_redirect_uri VARCHAR(256),
   authorities VARCHAR(256),
-  access_token_validity INTEGER
+  access_token_validity INTEGER,
+  refresh_token_validity INTEGER
 );
 
 create table oauth_access_token (
@@ -39,5 +40,6 @@ create table ClientDetails (
   grantTypes VARCHAR(256),
   redirectUrl VARCHAR(256),
   authorities VARCHAR(256),
-  access_token_validity INTEGER
+  access_token_validity INTEGER,
+  refresh_token_validity INTEGER
 );


### PR DESCRIPTION
Support for per client refresh token validity seconds with passing tests. This may break reverse compatibility,  for existing jdbc databases.
