### PR TITLE
Separate the dynamic client registration API client update from the client password update

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ClientRegistrationService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ClientRegistrationService.java
@@ -28,6 +28,8 @@ public interface ClientRegistrationService {
 
 	void updateClientDetails(ClientDetails clientDetails) throws NoSuchClientException;
 
+	void updateClientSecret(String clientId, String secret) throws NoSuchClientException;
+
 	void removeClientDetails(ClientDetails clientDetails) throws NoSuchClientException;
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestJdbcClientDetailsService.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestJdbcClientDetailsService.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -184,14 +186,34 @@ public class TestJdbcClientDetailsService {
 		clientDetails.setClientId("newClientIdWithNoDetails");
 
 		service.addClientDetails(clientDetails);
-		clientDetails.setClientSecret("foo");
-		service.updateClientDetails(clientDetails);
+		service.updateClientSecret(clientDetails.getClientId(), "foo");
 
 		Map<String, Object> map = jdbcTemplate.queryForMap(SELECT_SQL, "newClientIdWithNoDetails");
 
 		assertEquals("newClientIdWithNoDetails", map.get("client_id"));
 		assertTrue(map.containsKey("client_secret"));
 		assertEquals("foo", map.get("client_secret"));
+	}
+	
+	@Test
+	public void testUpdateClientRedirectURI() {
+
+		BaseClientDetails clientDetails = new BaseClientDetails();
+		clientDetails.setClientId("newClientIdWithNoDetails");
+
+		service.addClientDetails(clientDetails);
+
+		String[] redirectURI = {"http://localhost:8080", "http://localhost:9090"};
+		clientDetails.setRegisteredRedirectUri(
+				new HashSet<String>(Arrays.asList(redirectURI)));
+
+		service.updateClientDetails(clientDetails);
+
+		Map<String, Object> map = jdbcTemplate.queryForMap(SELECT_SQL, "newClientIdWithNoDetails");
+
+		assertEquals("newClientIdWithNoDetails", map.get("client_id"));
+		assertTrue(map.containsKey("web_server_redirect_uri"));
+		assertEquals("http://localhost:8080,http://localhost:9090", map.get("web_server_redirect_uri"));
 	}
 
 	@Test(expected=NoSuchClientException.class)


### PR DESCRIPTION
In an oauth server, we don't normally return the client secret when someone requests the client details. 

If, for example, someone wants to add a redirect URI to the client information on an oauth server, say they fetch the client details, add the redirect URI and update, they will end up setting the client_secret to an empty value. So, in order to update the client information, the server would need to store the secret so that it can retain the same value on subsequent updates.

Having the client secret updated separately from the rest of the client information is therefore required.
