### PR TITLE
SECOAUTH-256 Fixed so that the scope set is stored in a sorted TreeSet a...

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
@@ -44,7 +45,13 @@ public class AuthorizationRequest implements Serializable {
 		this(parameters.get(CLIENT_ID), OAuth2Utils.parseParameterList(parameters.get("scope")), null, null, false,
 				parameters.get(STATE), parameters.get(REDIRECT_URI));
 		// This is unapproved by default since only the request parameters are available
-		this.parameters.putAll(parameters);
+		for (String key : parameters.keySet()) {
+			if (key.equals(SCOPE)) {
+				this.parameters.put(SCOPE, OAuth2Utils.formatParameterList(scope));
+			} else {
+				this.parameters.put(key, parameters.get(key));
+			}
+		}
 	}
 
 	public AuthorizationRequest(String clientId, Collection<String> scope, Collection<GrantedAuthority> authorities,
@@ -56,13 +63,19 @@ public class AuthorizationRequest implements Serializable {
 	private AuthorizationRequest(AuthorizationRequest copy, boolean approved) {
 		this(copy.getClientId(), copy.scope, copy.authorities, copy.resourceIds, approved, copy.getState(), copy
 				.getRedirectUri());
-		this.parameters.putAll(copy.parameters);
+		for (String key : parameters.keySet()) {
+			if (key.equals(SCOPE)) {
+				this.parameters.put(SCOPE, OAuth2Utils.formatParameterList(scope));
+			} else {
+				this.parameters.put(key, parameters.get(key));
+			}
+		}
 	}
 
 	private AuthorizationRequest(String clientId, Collection<String> scope, Collection<GrantedAuthority> authorities,
 			Collection<String> resourceIds, boolean approved, String state, String requestedRedirect) {
 		this.resourceIds = resourceIds == null ? null : Collections.unmodifiableSet(new HashSet<String>(resourceIds));
-		this.scope = scope == null ? Collections.<String> emptySet() : Collections.unmodifiableSet(new HashSet<String>(
+		this.scope = scope == null ? Collections.<String> emptySet() : Collections.unmodifiableSet(new TreeSet<String>(
 				scope));
 		this.authorities = authorities == null ? null : new HashSet<GrantedAuthority>(authorities);
 		this.approved = approved;


### PR DESCRIPTION
...lso fixed so that the scope parameter is stored as a sorted scope string

SECOAUTH-256 Added test case that shows problem that the order of the scope set is lost

SECOAUTH-256 Fixed so that the test pass. Changed place of TreeSet and HashSet which had been incorrectly changed
