### PR TITLE
Added approval pass-through for authorization code token granter

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
@@ -93,6 +93,8 @@ public class AuthorizationCodeTokenGranter implements TokenGranter {
 		AuthorizationRequest authorizationRequest = authorizationRequestFactory.createAuthorizationRequest(parameters, unconfirmedAuthorizationRequest.getApprovalParameters(),
 				clientId, grantType, unconfirmedAuthorizationRequest.getScope());
 
+		authorizationRequest = authorizationRequest.approved(unconfirmedAuthorizationRequest.isApproved());
+		
 		Authentication userAuth = storedAuth.getUserAuthentication();
 		return tokenServices.createAccessToken(new OAuth2Authentication(authorizationRequest, userAuth));
 


### PR DESCRIPTION
The AuthorizationCodeTokenGranter's call to the authoriationRequestFactory currently drops the "approved" flag on the AuthorizationRequest object that gets created. If this flag is not set, then the stored approval is no able to authorize a call to the protected resource. This change restores that flag.

Since there's no setter and no field value in the copy contstructor, this change works by simply calling the "approve" method using the isApproved() value of the stored auth.

This has been tested to work.
