### PR TITLE
SECOAUTH-333: redirect_uri should not be mandatory field when obtaining an OAuth2 access token

### DIFF
--- a/samples/oauth2/sparklr/pom.xml
+++ b/samples/oauth2/sparklr/pom.xml
@@ -31,7 +31,7 @@
 								</goals>
 								<configuration>
 									<skip>${skipTests}</skip>
-									<testFailureIgnore>true</testFailureIgnore>
+									<testFailureIgnore>false</testFailureIgnore>
 								</configuration>
 							</execution>
 						</executions>

--- a/samples/oauth2/tonr/pom.xml
+++ b/samples/oauth2/tonr/pom.xml
@@ -31,7 +31,7 @@
 								</goals>
 								<configuration>
 									<skip>${skipTests}</skip>
-									<testFailureIgnore>true</testFailureIgnore>
+									<testFailureIgnore>false</testFailureIgnore>
 								</configuration>
 							</execution>
 						</executions>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultAuthorizationRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultAuthorizationRequest.java
@@ -34,6 +34,8 @@ public class DefaultAuthorizationRequest implements AuthorizationRequest, Serial
 	private Map<String, String> authorizationParameters = new HashMap<String, String>();
 
 	private Map<String, String> approvalParameters = new HashMap<String, String>();
+	
+	private String resolvedRedirectUri;
 
 	public DefaultAuthorizationRequest(Map<String, String> authorizationParameters) {
 		this(authorizationParameters, Collections.<String, String> emptyMap(), authorizationParameters.get(CLIENT_ID),
@@ -117,7 +119,7 @@ public class DefaultAuthorizationRequest implements AuthorizationRequest, Serial
 	}
 
 	public String getRedirectUri() {
-		return authorizationParameters.get(REDIRECT_URI);
+		return resolvedRedirectUri;
 	}
 
 	public Set<String> getResponseTypes() {
@@ -125,7 +127,7 @@ public class DefaultAuthorizationRequest implements AuthorizationRequest, Serial
 	}
 
 	public void setRedirectUri(String redirectUri) {
-		authorizationParameters.put(REDIRECT_URI, redirectUri);
+		this.resolvedRedirectUri = redirectUri;
 	}
 
 	public void addClientDetails(ClientDetails clientDetails) {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
@@ -54,7 +54,7 @@ public class AuthorizationCodeTokenGranter extends AbstractTokenGranter {
 
 		Map<String, String> parameters = authorizationRequest.getAuthorizationParameters();
 		String authorizationCode = parameters.get("code");
-		String redirectUri = parameters.get("redirect_uri");
+		String redirectUri = parameters.get(AuthorizationRequest.REDIRECT_URI);
 
 		if (authorizationCode == null) {
 			throw new OAuth2Exception("An authorization code must be supplied.");
@@ -66,8 +66,12 @@ public class AuthorizationCodeTokenGranter extends AbstractTokenGranter {
 		}
 
 		AuthorizationRequest pendingAuthorizationRequest = storedAuth.getAuthenticationRequest();
-		if (pendingAuthorizationRequest.getRedirectUri() != null
-				&& !pendingAuthorizationRequest.getRedirectUri().equals(redirectUri)) {
+		//https://jira.springsource.org/browse/SECOAUTH-333
+		//redirectUri may be null, if it was null when the authorization was done without the redirect_uri para
+		String redirectUriApprovalParameter = pendingAuthorizationRequest.getAuthorizationParameters().get(AuthorizationRequest.REDIRECT_URI);
+
+		if ((redirectUri != null || redirectUriApprovalParameter != null) && 
+				!pendingAuthorizationRequest.getRedirectUri().equals(redirectUri)) {
 			throw new RedirectMismatchException("Redirect URI mismatch.");
 		}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/RedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/RedirectResolver.java
@@ -13,7 +13,7 @@ public interface RedirectResolver {
   /**
    * Resolve the redirect for the specified client.
    *
-   * @param requestedRedirect The redirect that was requested (may be null).
+   * @param requestedRedirect The redirect that was requested (may not be null).
    * @param client The client for which we're resolving the redirect.
    * @return The resolved redirect URI.
    * @throws OAuth2Exception If the requested redirect is invalid for the specified client.


### PR DESCRIPTION
Changed the AuthorizationEndpoint and the DefaultAuthorizationRequest to make a distinction between the parametrized redirect_uri from the Client and the resolved redirect_uri (the result of the RedirectResolver#resolveRedirect which may NOT be null) to ensure that the redirect_uri may be null if the client obtains an access_token.
