### PR TITLE
SECOAUTH-56: Fixed the issue that oauth parameters are not URL encoded

### DIFF
--- a/spring-security-oauth/src/main/java/org/springframework/security/oauth/consumer/client/CoreOAuthConsumerSupport.java
+++ b/spring-security-oauth/src/main/java/org/springframework/security/oauth/consumer/client/CoreOAuthConsumerSupport.java
@@ -377,7 +377,7 @@ public class CoreOAuthConsumerSupport implements OAuthConsumerSupport, Initializ
         while (valuesIt.hasNext()) {
           CharSequence parameterValue = valuesIt.next();
           if (parameterValue != null) {
-            queryString.append('=').append(parameterValue);
+            queryString.append('=').append(urlEncode(parameterValue.toString()));
           }
           if (valuesIt.hasNext()) {
             queryString.append('&').append(parameter);

--- a/spring-security-oauth/src/test/java/org/springframework/security/oauth/consumer/client/TestCoreOAuthConsumerSupport.java
+++ b/spring-security-oauth/src/test/java/org/springframework/security/oauth/consumer/client/TestCoreOAuthConsumerSupport.java
@@ -341,7 +341,7 @@ public class TestCoreOAuthConsumerSupport {
 		when(details.isAcceptsAuthorizationHeader()).thenReturn(false);
 		params.put("with", Collections.singleton((CharSequence) "some"));
 		String encoded_space = URLEncoder.encode(" ", "utf-8");
-		params.put("query", Collections.singleton((CharSequence) ("params" + encoded_space + "spaced")));
+		params.put("query", Collections.singleton((CharSequence) ("params spaced")));
 		params.put("too", null);
 		params.put(OAuthConsumerParameter.oauth_consumer_key.toString(), Collections.singleton((CharSequence) "mykey"));
 		params.put(OAuthConsumerParameter.oauth_nonce.toString(), Collections.singleton((CharSequence) "mynonce"));


### PR DESCRIPTION
when not using authorization header, the oauth parameters are passed as the request parameters and should be URL encoded. Otherwise, any special characters will changed or lost. E.g. the signature may contain + and it will be decoded as SPACE in the provider side, thus fail the request.
