### PR TITLE
SECOAUTH-279: DefaultTokenServices detect when a refresh token is exp…

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -13,6 +13,7 @@
 
 package org.springframework.security.oauth2.provider.token;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Set;
@@ -94,7 +95,13 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 		// expired.
 		if (refreshToken == null) {
 			refreshToken = createRefreshToken(authentication);
+		} else if(refreshToken instanceof ExpiringOAuth2RefreshToken) {
+                	ExpiringOAuth2RefreshToken rt = (ExpiringOAuth2RefreshToken) refreshToken;
+                	if((Calendar.getInstance().getTimeInMillis()) > (rt.getExpiration().getTime())) {
+                    		refreshToken = createRefreshToken(authentication);
+			}
 		}
+        }
 
 		OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken);
 		tokenStore.storeAccessToken(accessToken, authentication);


### PR DESCRIPTION
...d and replace it.

I think the original fix (https://github.com/SpringSource/spring-security-oauth/commit/00899995f68404ac25e6dfdcc8ed04af3d53f0e8#diff-2) is just a workaround for the sparklr2 case.

Other implementations that use expiring refresh tokens will still suffer from this bug.

A better(?) solution may be to detect an expired refresh token and replace it during the createAccessToken stage of authentication. 
