### PR TITLE
fix for SECOAUTH-351

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/BaseClientDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/BaseClientDetails.java
@@ -277,7 +277,7 @@ public class BaseClientDetails implements ClientDetails {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + accessTokenValiditySeconds;
-		result = prime * result + refreshTokenValiditySeconds;
+		result = prime * result + ((refreshTokenValiditySeconds == null) ? 0 : refreshTokenValiditySeconds);
 		result = prime * result + ((authorities == null) ? 0 : authorities.hashCode());
 		result = prime * result + ((authorizedGrantTypes == null) ? 0 : authorizedGrantTypes.hashCode());
 		result = prime * result + ((clientId == null) ? 0 : clientId.hashCode());


### PR DESCRIPTION
i found an NPE in BaseClientDetails#hashCode related to refreshTokenValiditySeconds which is visible when hashCode() is called by something like a collection such as the map that manages instances of those objects.
