### PR TITLE
SECOAUTH-358 Jackson 2 support for the oauth2 module

### DIFF
--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -139,11 +139,21 @@
 			<version>1.3</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.2</version>
-		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.1.0</version>
+        </dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/DefaultOAuth2RefreshToken.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/DefaultOAuth2RefreshToken.java
@@ -2,8 +2,8 @@ package org.springframework.security.oauth2.common;
 
 import java.io.Serializable;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * An OAuth 2 refresh token.

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessToken.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessToken.java
@@ -16,8 +16,8 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenDeserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenDeserializer.java
@@ -18,13 +18,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.codehaus.jackson.map.deser.StdDeserializer;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 /**
  * <p>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenSerializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenSerializer.java
@@ -17,11 +17,10 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.ser.SerializerBase;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.springframework.util.Assert;
 
 /**
@@ -32,7 +31,7 @@ import org.springframework.util.Assert;
  * @see OAuth2AccessTokenDeserializer
  */
 @SuppressWarnings("deprecation")
-public final class OAuth2AccessTokenSerializer extends SerializerBase<OAuth2AccessToken> {
+public final class OAuth2AccessTokenSerializer extends StdSerializer<OAuth2AccessToken> {
 
 	public OAuth2AccessTokenSerializer() {
 		super(OAuth2AccessToken.class);

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2RefreshToken.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2RefreshToken.java
@@ -12,7 +12,7 @@
  */
 package org.springframework.security.oauth2.common;
 
-import org.codehaus.jackson.annotate.JsonValue;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2Exception.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2Exception.java
@@ -4,8 +4,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 /**
  * Base exception for OAuth 2 exceptions.

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionDeserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionDeserializer.java
@@ -18,11 +18,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionSerializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionSerializer.java
@@ -15,10 +15,10 @@ package org.springframework.security.oauth2.common.exceptions;
 import java.io.IOException;
 import java.util.Map.Entry;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.SerializerProvider;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/BaseClientDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/BaseClientDetails.java
@@ -12,25 +12,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.annotate.JsonAnyGetter;
-import org.codehaus.jackson.annotate.JsonAnySetter;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
-import org.codehaus.jackson.map.deser.std.StdDeserializer;
-import org.codehaus.jackson.map.type.SimpleType;
-import org.codehaus.jackson.type.JavaType;
-import org.codehaus.jackson.type.TypeReference;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.type.SimpleType;
 
 /**
  * Base implementation of {@link org.springframework.security.oauth2.provider.ClientDetails}.

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/JdbcClientDetailsService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/JdbcClientDetailsService.java
@@ -26,7 +26,6 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -39,6 +38,8 @@ import org.springframework.security.oauth2.common.util.DefaultJdbcListFactory;
 import org.springframework.security.oauth2.common.util.JdbcListFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Basic, JDBC implementation of the client details service.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/TestOAuth2AccessTokenSupport.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/TestOAuth2AccessTokenSupport.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Arrays;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
@@ -41,6 +40,8 @@ import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/TestAuthorizationCodeAccessTokenProviderWithConversion.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/TestAuthorizationCodeAccessTokenProviderWithConversion.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.Rule;
@@ -43,6 +42,8 @@ import org.springframework.security.oauth2.client.token.DefaultAccessTokenReques
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/BaseOAuth2AccessTokenJacksonTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/BaseOAuth2AccessTokenJacksonTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -31,6 +30,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Base class for testing Jackson serialization and deserialization of {@link OAuth2AccessToken}.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/TestJsonSerialization.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/TestJsonSerialization.java
@@ -21,10 +21,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/TestOAuth2AccessTokenDeserializer.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/TestOAuth2AccessTokenDeserializer.java
@@ -19,10 +19,11 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.HashSet;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * Tests deserialization of an {@link OAuth2AccessToken} using jackson.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/TestOAuth2AccessTokenSerializer.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/TestOAuth2AccessTokenSerializer.java
@@ -4,10 +4,11 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * Tests serialization of an {@link OAuth2AccessToken} using jackson.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/TestOAuth2ExceptionDeserializer.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/TestOAuth2ExceptionDeserializer.java
@@ -14,7 +14,6 @@ package org.springframework.security.oauth2.common.exception;
 
 import static org.junit.Assert.assertEquals;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
@@ -27,6 +26,8 @@ import org.springframework.security.oauth2.common.exceptions.RedirectMismatchExc
 import org.springframework.security.oauth2.common.exceptions.UnauthorizedClientException;
 import org.springframework.security.oauth2.common.exceptions.UnsupportedGrantTypeException;
 import org.springframework.security.oauth2.common.exceptions.UserDeniedAuthorizationException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  *

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/TestOAuth2ExceptionSerializer.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/TestOAuth2ExceptionSerializer.java
@@ -14,7 +14,6 @@ package org.springframework.security.oauth2.common.exception;
 
 import static org.junit.Assert.assertEquals;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,6 +27,8 @@ import org.springframework.security.oauth2.common.exceptions.RedirectMismatchExc
 import org.springframework.security.oauth2.common.exceptions.UnauthorizedClientException;
 import org.springframework.security.oauth2.common.exceptions.UnsupportedGrantTypeException;
 import org.springframework.security.oauth2.common.exceptions.UserDeniedAuthorizationException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  *

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestBaseClientDetails.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestBaseClientDetails.java
@@ -21,8 +21,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestOAuth2Authentication.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestOAuth2Authentication.java
@@ -6,10 +6,11 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestOAuth2Authentication {
 

--- a/spring-security-oauth2/template.mf
+++ b/spring-security-oauth2/template.mf
@@ -5,7 +5,7 @@ Bundle-ManifestVersion: 2
 Import-Template: 
  org.apache.commons.logging.*;version="[1.1.1, 2.0.0)",
  org.apache.commons.codec.*;version="[1.3, 2.0.0)",
- org.codehaus.jackson.*;version="[1.9.3, 2.0.0)",
+ com.fasterxml.jackson.*;version="[2.0.6,3.0.0)",
  org.springframework.beans.*;version="${spring.osgi.range}",
  org.springframework.aop.*;version="${spring.osgi.range}",
  org.springframework.core.*;version="${spring.osgi.range}",


### PR DESCRIPTION
This is a patch for the oauth2 module to use jackson2 instead of jackson1. 99% of this patch is simply changing the namespaces, although one serializer has disappeared from the new lib.

I've tested this in my system and everything appears to continue to function correctly.

I've talked to the fasterxml people about a jackson->jackson2 bridge lib but there isn't one at present so you either pick between the libraries, or implement the presentation layer twice (this is the option Spring MVC have gone with).

Hope this helps to get started on the move to Jackson 2.

N.B. I signed the contributor's agreement when I submitted this commit: https://github.com/SpringSource/spring-security-oauth/commit/c0c1b39c1bbd94b466cadea197809d91b88f6329
