### PR TITLE
Add handling for expired, locked, disabled accounts in ResourceOwnerPasswordTokenGranter

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/password/ResourceOwnerPasswordTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/password/ResourceOwnerPasswordTokenGranter.java
@@ -19,6 +19,7 @@ package org.springframework.security.oauth2.provider.password;
 
 import java.util.Map;
 
+import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -56,6 +57,10 @@ public class ResourceOwnerPasswordTokenGranter extends AbstractTokenGranter {
 		Authentication userAuth = new UsernamePasswordAuthenticationToken(username, password);
 		try {
 			userAuth = authenticationManager.authenticate(userAuth);
+		}
+		catch (AccountStatusException ase) {
+			//covers expired, locked, disabled cases (mentioned in section 5.2, draft 31)
+			throw new InvalidGrantException(ase.getMessage());
 		}
 		catch (BadCredentialsException e) {
 			// If the username/password are wrong the spec says we should send 400/bad grant

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/password/TestResourceOwnerPasswordTokenGranter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/password/TestResourceOwnerPasswordTokenGranter.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -85,6 +86,16 @@ public class TestResourceOwnerPasswordTokenGranter {
 		ResourceOwnerPasswordTokenGranter granter = new ResourceOwnerPasswordTokenGranter(new AuthenticationManager() {
 			public Authentication authenticate(Authentication authentication) throws AuthenticationException {
 				throw new BadCredentialsException("test");
+			}
+		}, providerTokenServices, clientDetailsService);
+		granter.grant("password", authorizationRequest);
+	}
+	
+	@Test(expected = InvalidGrantException.class)
+	public void testAccountLocked() {
+		ResourceOwnerPasswordTokenGranter granter = new ResourceOwnerPasswordTokenGranter(new AuthenticationManager() {
+			public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+				throw new LockedException("test");
 			}
 		}, providerTokenServices, clientDetailsService);
 		granter.grant("password", authorizationRequest);


### PR DESCRIPTION
For https://jira.springsource.org/browse/SECOAUTH-338

Specifically, when a client app (e.g. Android) tried to login with a locked account, since the AccountStatusException is not translated to an InvalidGrantException, it can propagate out to other exception handlers.
