### PR TITLE
SECOAUTH-361

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/ResourceServerBeanDefinitionParser.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/ResourceServerBeanDefinitionParser.java
@@ -36,20 +36,30 @@ public class ResourceServerBeanDefinitionParser extends ProviderBeanDefinitionPa
 
 		String resourceId = element.getAttribute("resource-id");
 		String entryPointRef = element.getAttribute("entry-point-ref");
+		String entryAuthDetailsSource = element.getAttribute("auth-details-source-ref");
 
 		// configure the protected resource filter
 		BeanDefinitionBuilder protectedResourceFilterBean = BeanDefinitionBuilder
 				.rootBeanDefinition(OAuth2AuthenticationProcessingFilter.class);
+
 		BeanDefinitionBuilder authenticationManagerBean = BeanDefinitionBuilder
 				.rootBeanDefinition(OAuth2AuthenticationManager.class);
+
 		authenticationManagerBean.addPropertyReference("tokenServices", tokenServicesRef);
+
 		if (StringUtils.hasText(resourceId)) {
 			authenticationManagerBean.addPropertyValue("resourceId", resourceId);
 		}
+
 		protectedResourceFilterBean.addPropertyValue("authenticationManager",
 				authenticationManagerBean.getBeanDefinition());
+
 		if (StringUtils.hasText(entryPointRef)) {
 			protectedResourceFilterBean.addPropertyReference("authenticationEntryPoint", entryPointRef);
+		}
+
+		if (StringUtils.hasText(entryAuthDetailsSource)) {
+			protectedResourceFilterBean.addPropertyReference("authenticationDetailsSource", entryAuthDetailsSource);
 		}
 
 		return protectedResourceFilterBean.getBeanDefinition();

--- a/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
+++ b/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
@@ -370,6 +370,14 @@
 							</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
+
+					<xs:attribute name="auth-details-source-ref" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>
+								The reference to the bean that defines the AuthenticationDetailsSource.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
 				</xs:extension>
 			</xs:complexContent>
 		</xs:complexType>

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/TestOAuth2ClientContextFilter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/TestOAuth2ClientContextFilter.java
@@ -14,7 +14,7 @@ public class TestOAuth2ClientContextFilter {
 	public void testVanillaCurrentUri() throws Exception {
 		OAuth2ClientContextFilter filter = new OAuth2ClientContextFilter();
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addParameter("foo", "bar");
+		request.setQueryString("foo=bar");
 		assertEquals("http://localhost?foo=bar", filter.calculateCurrentUri(request));
 	}
 
@@ -22,8 +22,7 @@ public class TestOAuth2ClientContextFilter {
 	public void testCurrentUriRemovingCode() throws Exception {
 		OAuth2ClientContextFilter filter = new OAuth2ClientContextFilter();
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addParameter("code", "XXXX");
-		request.addParameter("foo", "bar");
+		request.setQueryString("code=XXXX&foo=bar");
 		assertEquals("http://localhost?foo=bar", filter.calculateCurrentUri(request));
 	}
 
@@ -31,9 +30,7 @@ public class TestOAuth2ClientContextFilter {
 	public void testCurrentUriRemovingCodeInSecond() throws Exception {
 		OAuth2ClientContextFilter filter = new OAuth2ClientContextFilter();
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addParameter("foo", "bar");
-		request.addParameter("code", "XXXX");
+		request.setQueryString("foo=bar&code=XXXX");
 		assertEquals("http://localhost?foo=bar", filter.calculateCurrentUri(request));
 	}
-
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/TestResourceServerBeanDefinitionParser.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/TestResourceServerBeanDefinitionParser.java
@@ -28,6 +28,7 @@ public class TestResourceServerBeanDefinitionParser {
 		GenericXmlApplicationContext context = new GenericXmlApplicationContext(getClass(), getClass().getSimpleName()+"-context.xml");
 		// System.err.println(Arrays.asList(context.getBeanDefinitionNames()));
 		assertTrue(context.containsBeanDefinition("oauth2ProviderFilter"));
+		assertTrue(context.containsBeanDefinition("anotherProviderFilter"));
+		assertTrue(context.containsBeanDefinition("thirdProviderFilter"));
 	}
-
 }

--- a/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/TestResourceServerBeanDefinitionParser-context.xml
+++ b/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/TestResourceServerBeanDefinitionParser-context.xml
@@ -14,17 +14,19 @@
 
 	<oauth:resource-server id="oauth2ProviderFilter" resource-id="${my.resource.ids}" />
 
-	<oauth:resource-server id="anotherProviderFilter" resource-id="another" entry-point-ref="entry"
-		token-services-ref="tokens" />
+	<oauth:resource-server id="anotherProviderFilter" resource-id="another" entry-point-ref="entry" token-services-ref="tokens" />
+
+	<oauth:resource-server id="thirdProviderFilter" resource-id="third" entry-point-ref="entry" token-services-ref="tokens" auth-details-source-ref="authenticationDetailsSource" />
 
 	<bean id="entry" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
 		<constructor-arg value="/login" />
 	</bean>
+
+	<bean id="authenticationDetailsSource" class="org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetailsSource" />
 
 	<bean id="tokens" class="org.springframework.security.oauth2.provider.token.DefaultTokenServices">
 		<property name="tokenStore">
 			<bean class="org.springframework.security.oauth2.provider.token.InMemoryTokenStore" />
 		</property>
 	</bean>
-
 </beans>


### PR DESCRIPTION
Users are now able to inject AuthenticationDetailsSource into the <oauth:resource-server/> element as "auth-details-source-ref" attribute.
