### PR TITLE
Use Interface AuthorizationRequest instead of DefaultAuthorizationRequest in TokenEndpoint

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
@@ -1,10 +1,10 @@
 package org.springframework.security.oauth2.provider;
 
+import org.springframework.security.core.GrantedAuthority;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-
-import org.springframework.security.core.GrantedAuthority;
 
 /**
  * Base class representing a request for authorization. There are convenience methods for the well-known properties

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestDefaultAuthorizationRequestManager.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestDefaultAuthorizationRequestManager.java
@@ -14,13 +14,15 @@
 
 package org.springframework.security.oauth2.provider;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.Collections;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Dave Syer
@@ -53,5 +55,34 @@ public class TestDefaultAuthorizationRequestManager {
 		AuthorizationRequest request = factory.createAuthorizationRequest(Collections.singletonMap("client_id", "foo"));
 		assertEquals("[bar]", request.getScope().toString());
 	}
+
+
+  @Test
+  public void testCreateAuthorizationRequesForAuthorizationCode() {
+    Map<String, String> requestParameters = new HashMap<String, String>();
+    requestParameters.put("client_id", "foo");
+    requestParameters.put("grant_type", "authorization_code");
+    requestParameters.put("code", "XXXXXXX");
+    requestParameters.put("scope", "bar2");
+
+    AuthorizationRequest request = factory.createAuthorizationRequest(requestParameters);
+    assertEquals("foo", request.getClientId());
+    //The scope must be empty
+    assertEquals("[]", request.getScope().toString());
+  }
+
+  @Test
+  public void testCreateAuthorizationRequestForRefeshToken() {
+    Map<String, String> requestParameters = new HashMap<String, String>();
+    requestParameters.put("client_id", "foo");
+    requestParameters.put("grant_type", "refresh_token");
+    requestParameters.put("refresh_token", "XXXXXXX");
+    requestParameters.put("scope", "bar2");
+
+    AuthorizationRequest request = factory.createAuthorizationRequest(requestParameters);
+    assertEquals("foo", request.getClientId());
+    //The scope must be equals to scope param
+    assertEquals("[bar2]", request.getScope().toString());
+  }
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/TestTokenEndpoint.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/TestTokenEndpoint.java
@@ -16,15 +16,6 @@
 
 package org.springframework.security.oauth2.provider.endpoint;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -42,6 +33,15 @@ import org.springframework.security.oauth2.provider.AuthorizationRequestManager;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 import org.springframework.security.oauth2.provider.DefaultAuthorizationRequest;
 import org.springframework.security.oauth2.provider.TokenGranter;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Dave Syer
@@ -118,7 +118,6 @@ public class TestTokenEndpoint {
 		OAuth2AccessToken body = response.getBody();
 		assertEquals(body, expectedToken);
 		assertTrue("Wrong body: " + body, body.getTokenType() != null);
-		assertTrue("Scope of token request not cleared", captor.getValue().getScope().isEmpty());
 	}
 
 }


### PR DESCRIPTION
It's the fix for https://jira.springsource.org/browse/SECOAUTH-399.

The specific usage if DefaultAuthorizationRequest in TokenEndpoint instead of the interface AuthorizationRequest doesn't allow us to define new grantType with custom parameters.
