### PR TITLE
SECOAUTH-409

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilter.java
@@ -127,7 +127,14 @@ public class OAuth2ClientContextFilter implements Filter, InitializingBean {
 		if (legalSpaces) {
 			builder.replaceQuery(queryString.replace("+", "%20"));
 		}
-		UriComponents uri = builder.replaceQueryParam("code").build(true);
+		UriComponents uri = null;
+        try {
+		    uri = builder.replaceQueryParam("code").build(true);
+        } catch (IllegalArgumentException ex) {
+            // ignore failures to parse the url (including query string). does't make sense
+            // for redirection purposes anyway.
+            return null;
+        }
 		String query = uri.getQuery();
 		if (legalSpaces) {
 			query = query.replace("%20", "+");

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/TestOAuth2ClientContextFilter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/TestOAuth2ClientContextFilter.java
@@ -56,4 +56,12 @@ public class TestOAuth2ClientContextFilter {
 		request.setQueryString("foo=bar&code=XXXX");
 		assertEquals("http://localhost?foo=bar", filter.calculateCurrentUri(request));
 	}
+
+	@Test
+	public void testCurrentUriWithInvalidQueryString() throws Exception {
+		OAuth2ClientContextFilter filter = new OAuth2ClientContextFilter();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setQueryString("foo=bar&code=XXXX&parm=%xx");
+		assertEquals(null, filter.calculateCurrentUri(request));
+	}
 }


### PR DESCRIPTION
Prevent IllegalArgument exceptions when invalid requests (including invalid query strings) are encountered.
An implication is that invalid requests cannot be redirected for oauth purposes.
