### PR TITLE
Bugfix for handling non-standard comma-separated scopes

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultAuthorizationRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultAuthorizationRequest.java
@@ -149,7 +149,7 @@ public class DefaultAuthorizationRequest implements AuthorizationRequest, Serial
 			 * This is really an error, but it can catch out unsuspecting users and it's easy to fix. It happens when an
 			 * AuthorizationRequest gets bound accidentally from request parameters using @ModelAttribute.
 			 */
-			if (value.contains(" ") || scope.contains(",")) {
+			if (value.contains(" ") || value.contains(",")) {
 				scope = OAuth2Utils.parseParameterList(value);
 			}
 		}


### PR DESCRIPTION
The check is supposed to look for spaces or commas _within the value_ of a singleton set, but the code currently performs the `contains` check for "," on the initial set of scopes (which kind of misses its target).
