### PR TITLE
Extended the expression methods to allow testing for existing scope by specifying a regex expression

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2ExpressionUtils.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2ExpressionUtils.java
@@ -23,7 +23,8 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 
 /**
  * @author Dave Syer
- *
+ * @author Radek Ostrowski
+ * 
  */
 public abstract class OAuth2ExpressionUtils {
 
@@ -86,7 +87,22 @@ public abstract class OAuth2ExpressionUtils {
 		}
 	
 		return false;
+	}
 
+	public static boolean hasAnyScopeMatching(Authentication authentication, String[] scopesRegex) {
+
+		if (authentication instanceof OAuth2Authentication) {
+			OAuth2Request clientAuthentication = ((OAuth2Authentication) authentication).getOAuth2Request();
+			for (String scope : clientAuthentication.getScope()) {
+				for (String regex : scopesRegex) {
+					if (scope.matches(regex)) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.common.exceptions.InsufficientScopeEx
  * 
  * @author Dave Syer
  * @author Rob Winch
+ * @author Radek Ostrowski
  * 
  */
 public class OAuth2SecurityExpressionMethods {
@@ -104,6 +105,45 @@ public class OAuth2SecurityExpressionMethods {
 		boolean result = OAuth2ExpressionUtils.hasAnyScope(authentication, scopes);
 		if (!result && throwExceptionOnInvalidScope) {
 			missingScopes.addAll(Arrays.asList(scopes));
+			Throwable failure = new InsufficientScopeException("Insufficient scope for this resource", missingScopes);
+			throw new AccessDeniedException(failure.getMessage(), failure);
+		}
+		return result;
+	}
+
+	/**
+	 * Check if the current OAuth2 authentication has one of the scopes matching a specified regex expression.
+	 * 
+	 * <pre>
+	 * access = &quot;#oauth2.hasScopeMatching('.*_admin:manage_scopes')))&quot;
+	 * </pre>
+	 * 
+	 * @param scopeRegex
+	 *            the scope regex to match
+	 * @return true if the OAuth2 authentication has the required scope
+	 */
+	public boolean hasScopeMatching(String scopeRegex) {
+		return hasAnyScopeMatching(scopeRegex);
+	}
+
+	/**
+	 * Check if the current OAuth2 authentication has one of the scopes matching a specified regex expression.
+	 * 
+	 * <pre>
+	 * access = &quot;#oauth2.hasAnyScopeMatching('admin:manage_scopes','.*_admin:manage_scopes','.*_admin:read_scopes')))&quot;
+	 * </pre>
+	 * 
+	 * @param roles
+	 *            the scopes regex to match
+	 * @return true if the OAuth2 token has one of these scopes
+	 * @throws AccessDeniedException
+	 *             if the scope is invalid and we the flag is set to throw the exception
+	 */
+	public boolean hasAnyScopeMatching(String... scopesRegex) {
+
+		boolean result = OAuth2ExpressionUtils.hasAnyScopeMatching(authentication, scopesRegex);
+		if (!result && throwExceptionOnInvalidScope) {
+			missingScopes.addAll(Arrays.asList(scopesRegex));
 			Throwable failure = new InsufficientScopeException("Insufficient scope for this resource", missingScopes);
 			throw new AccessDeniedException(failure.getMessage(), failure);
 		}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2MethodSecurityExpressionHandler.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2MethodSecurityExpressionHandler.java
@@ -25,18 +25,20 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.AuthorizationRequest;
 import org.springframework.security.oauth2.provider.BaseClientDetails;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.security.oauth2.provider.AuthorizationRequest;
-import org.springframework.security.oauth2.provider.RequestTokenFactory;
 import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.RequestTokenFactory;
 import org.springframework.security.util.SimpleMethodInvocation;
 import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Dave Syer
+ * @author Radek Ostrowski
  * 
  */
 public class TestOAuth2MethodSecurityExpressionHandler {
@@ -75,6 +77,36 @@ public class TestOAuth2MethodSecurityExpressionHandler {
 		EvaluationContext context = handler.createEvaluationContext(oAuth2Authentication, invocation);
 		Expression expression = handler.getExpressionParser().parseExpression("#oauth2.hasAnyScope('read','write')");
 		assertTrue((Boolean) expression.getValue(context));
+	}
+
+	@Test
+	public void testScopesRegex() throws Exception {
+
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("ns_admin:read"), null, null, null);
+
+		Authentication userAuthentication = null;
+		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
+		MethodInvocation invocation = new SimpleMethodInvocation(this, ReflectionUtils.findMethod(getClass(),
+			"testOauthClient"));
+		EvaluationContext context = handler.createEvaluationContext(oAuth2Authentication, invocation);
+		Expression expression = handler.getExpressionParser().parseExpression("#oauth2.hasScopeMatching('.*_admin:read')");
+		assertTrue((Boolean) expression.getValue(context));
+		expression = handler.getExpressionParser().parseExpression("#oauth2.hasAnyScopeMatching('.*_admin:write','.*_admin:read')");
+		assertTrue((Boolean) expression.getValue(context));
+	}
+
+	@Test(expected = AccessDeniedException.class)
+	public void testScopesRegexThrowsException() throws Exception {
+
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("ns_admin:read"), null, null, null);
+
+		Authentication userAuthentication = null;
+		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
+		MethodInvocation invocation = new SimpleMethodInvocation(this, ReflectionUtils.findMethod(getClass(),
+			"testOauthClient"));
+		EvaluationContext context = handler.createEvaluationContext(oAuth2Authentication, invocation);
+		Expression expression = handler.getExpressionParser().parseExpression("#oauth2.hasScopeMatching('.*_admin:write')");
+		assertFalse((Boolean) expression.getValue(context));
 	}
 
 	@Test


### PR DESCRIPTION
We found this new functionality a requirement when restricting access to resources which could be managed by admin clients in their own namespaces:

"client1_admin:manage_scopes"
"client2_admin:manage_scopes" 
"client3_admin:manage_scopes" 
...

in this case we could use this expression: #oauth2.hasScopeMatching('.*_admin:manage_scopes')
