### PR TITLE
Added responseTypes parameter to OAuth2Request

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
@@ -103,7 +103,7 @@ public class AuthorizationRequest extends BaseRequest {
 	}
 
 	public OAuth2Request createOAuth2Request() {
-		return new OAuth2Request(getApprovalParameters(), getClientId(), getAuthorities(), isApproved(), getScope(), getResourceIds(), getRedirectUri(), getExtensions());
+		return new OAuth2Request(getApprovalParameters(), getClientId(), getAuthorities(), isApproved(), getScope(), getResourceIds(), getRedirectUri(), getResponseTypes(), getExtensions());
 	}
 
 	/**

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2Request.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2Request.java
@@ -62,7 +62,7 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 
 	public OAuth2Request(Map<String, String> requestParameters, String clientId,
 			Collection<? extends GrantedAuthority> authorities, boolean approved, Set<String> scope,
-			Set<String> resourceIds, String redirectUri, Map<String, Serializable> extensionProperties) {
+			Set<String> resourceIds, String redirectUri, Set<String> responseTypes, Map<String, Serializable> extensionProperties) {
 		super.setClientId(clientId);
 		super.setRequestParameters(requestParameters);
 		super.setScope(scope);
@@ -74,6 +74,9 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 		}
 		this.approved = approved;
 		this.resourceIds = resourceIds;
+		if (responseTypes != null) {
+			this.responseTypes = new HashSet<String>(responseTypes);
+		}
 		this.redirectUri = redirectUri;
 		if (extensionProperties != null) {
 			this.extensions = extensionProperties;
@@ -82,7 +85,7 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 
 	protected OAuth2Request(OAuth2Request other) {
 		this(other.getRequestParameters(), other.getClientId(), other.getAuthorities(), other.isApproved(), other
-				.getScope(), other.getResourceIds(), other.getRedirectUri(), other.getExtensions());
+				.getScope(), other.getResourceIds(), other.getRedirectUri(), other.getResponseTypes(), other.getExtensions());
 	}
 
 	protected OAuth2Request(String clientId) {
@@ -146,7 +149,7 @@ public class OAuth2Request extends BaseRequest implements Serializable {
     protected void setRequestParameters(Map<String, String> requestParameters) {
     	throw new IllegalStateException("Can't set request parameters on OAuth2Request");
     }
-
+    
 	/**
 	 * Update the request parameters and return a new object with the same properties except the parameters.
 	 * @param parameters new parameters replacing the existing ones
@@ -154,7 +157,7 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 	 */
 	public OAuth2Request createOAuth2Request(Map<String, String> parameters) {
 		return new OAuth2Request(parameters, getClientId(), authorities, approved, getScope(), resourceIds,
-				redirectUri, extensions);
+				redirectUri, responseTypes, extensions);
 	}
 	
 	//
@@ -178,12 +181,18 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 	@Override
 	public int hashCode() {
 		final int prime = 31;
-		int result = 1;
+		int result = super.hashCode();
 		result = prime * result + (approved ? 1231 : 1237);
-		result = prime * result + ((authorities == null) ? 0 : authorities.hashCode());
-		result = prime * result + ((extensions == null) ? 0 : extensions.hashCode());
-		result = prime * result + ((redirectUri == null) ? 0 : redirectUri.hashCode());
-		result = prime * result + ((resourceIds == null) ? 0 : resourceIds.hashCode());
+		result = prime * result
+				+ ((authorities == null) ? 0 : authorities.hashCode());
+		result = prime * result
+				+ ((extensions == null) ? 0 : extensions.hashCode());
+		result = prime * result
+				+ ((redirectUri == null) ? 0 : redirectUri.hashCode());
+		result = prime * result
+				+ ((resourceIds == null) ? 0 : resourceIds.hashCode());
+		result = prime * result
+				+ ((responseTypes == null) ? 0 : responseTypes.hashCode());
 		return result;
 	}
 
@@ -191,7 +200,7 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
-		if (obj == null)
+		if (!super.equals(obj))
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
@@ -201,26 +210,27 @@ public class OAuth2Request extends BaseRequest implements Serializable {
 		if (authorities == null) {
 			if (other.authorities != null)
 				return false;
-		}
-		else if (!authorities.equals(other.authorities))
+		} else if (!authorities.equals(other.authorities))
 			return false;
 		if (extensions == null) {
 			if (other.extensions != null)
 				return false;
-		}
-		else if (!extensions.equals(other.extensions))
+		} else if (!extensions.equals(other.extensions))
 			return false;
 		if (redirectUri == null) {
 			if (other.redirectUri != null)
 				return false;
-		}
-		else if (!redirectUri.equals(other.redirectUri))
+		} else if (!redirectUri.equals(other.redirectUri))
 			return false;
 		if (resourceIds == null) {
 			if (other.resourceIds != null)
 				return false;
-		}
-		else if (!resourceIds.equals(other.resourceIds))
+		} else if (!resourceIds.equals(other.resourceIds))
+			return false;
+		if (responseTypes == null) {
+			if (other.responseTypes != null)
+				return false;
+		} else if (!responseTypes.equals(other.responseTypes))
 			return false;
 		return true;
 	}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/TokenRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/TokenRequest.java
@@ -77,7 +77,7 @@ public class TokenRequest extends BaseRequest {
 		Map<String,String> requestParameters = getRequestParameters();
 		HashMap<String, String> modifiable = new HashMap<String, String>(requestParameters);
 		modifiable.remove("password");
-		return new OAuth2Request(modifiable, client.getClientId(), client.getAuthorities(), true, this.getScope(), null, null, null);
+		return new OAuth2Request(modifiable, client.getClientId(), client.getAuthorities(), true, this.getScope(), null, null, null, null);
 	}
 	
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/TestOAuth2ClientAuthenticationProcessingFilter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/TestOAuth2ClientAuthenticationProcessingFilter.java
@@ -54,7 +54,7 @@ public class TestOAuth2ClientAuthenticationProcessingFilter {
 		Mockito.when(restTemplate.getAccessToken()).thenReturn(new DefaultOAuth2AccessToken("FOO"));
 		Set<String> scopes = new HashSet<String>();
 		scopes.addAll(Arrays.asList("read", "write"));
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "client", null, false, scopes, null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "client", null, false, scopes, null, null, null, null);
 		this.authentication = new OAuth2Authentication(storedOAuth2Request, null);
 		Mockito.when(tokenServices.loadAuthentication("FOO")).thenReturn(authentication);
 		Authentication authentication = filter.attemptAuthentication(null, null);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/RequestTokenFactory.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/RequestTokenFactory.java
@@ -30,9 +30,9 @@ public class RequestTokenFactory {
 
 	public static OAuth2Request createOAuth2Request(Map<String, String> requestParameters, String clientId,
 			Collection<? extends GrantedAuthority> authorities, boolean approved, Set<String> scope,
-			Set<String> resourceIds, String redirectUri, Map<String, Serializable> extensionProperties) {
+			Set<String> resourceIds, String redirectUri, Set<String> responseTypes, Map<String, Serializable> extensionProperties) {
 		return new OAuth2Request(requestParameters, clientId, authorities, approved, scope, resourceIds, redirectUri,
-				extensionProperties);
+				responseTypes, extensionProperties);
 	}
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestOAuth2Authentication.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/TestOAuth2Authentication.java
@@ -16,7 +16,7 @@ import org.springframework.util.SerializationUtils;
 public class TestOAuth2Authentication {
 
 	private OAuth2Request request = RequestTokenFactory.createOAuth2Request(null, "id", null, false,
-			Collections.singleton("read"), null, null, null);
+			Collections.singleton("read"), null, null, null, null);
 
 	private UsernamePasswordAuthenticationToken userAuthentication = new UsernamePasswordAuthenticationToken("foo",
 			"bar", Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
@@ -25,7 +25,7 @@ public class TestOAuth2Authentication {
 	@Rollback
 	public void testIsAuthenticated() {
 		request = RequestTokenFactory.createOAuth2Request(null, "id", null, true, Collections.singleton("read"), null,
-				null, null);
+				null, null, null);
 		OAuth2Authentication authentication = new OAuth2Authentication(request, userAuthentication);
 		assertTrue(authentication.isAuthenticated());
 	}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/TestOAuth2AuthenticationManager.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/TestOAuth2AuthenticationManager.java
@@ -37,7 +37,7 @@ public class TestOAuth2AuthenticationManager {
 
 	private Authentication userAuthentication = new UsernamePasswordAuthenticationToken("marissa", "koala");
 
-	private OAuth2Authentication authentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "foo", null, false, null, null, null, null), userAuthentication);
+	private OAuth2Authentication authentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "foo", null, false, null, null, null, null, null), userAuthentication);
 	
 	{
 		manager.setTokenServices(tokenServices);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/TestOAuth2AuthenticationProcessingFilter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/TestOAuth2AuthenticationProcessingFilter.java
@@ -43,7 +43,7 @@ public class TestOAuth2AuthenticationProcessingFilter {
 
 	private Authentication userAuthentication = new UsernamePasswordAuthenticationToken("marissa", "koala");
 
-	private OAuth2Authentication authentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "foo", null, false, null, null, null, null), userAuthentication);
+	private OAuth2Authentication authentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "foo", null, false, null, null, null, null, null), userAuthentication);
 
 	private FilterChain chain = Mockito.mock(FilterChain.class);
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/TestAuthorizationCodeServicesBase.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/TestAuthorizationCodeServicesBase.java
@@ -17,7 +17,7 @@ public abstract class TestAuthorizationCodeServicesBase {
 
 	@Test
 	public void testCreateAuthorizationCode() {
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null);
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(
 				storedOAuth2Request, new TestAuthentication(
 						"test2", false)); 
@@ -31,7 +31,7 @@ public abstract class TestAuthorizationCodeServicesBase {
 
 	@Test
 	public void testConsumeRemovesCode() {
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null);
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(
 				storedOAuth2Request, new TestAuthentication(
 						"test2", false));

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/TestAuthorizationCodeTokenGranter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/TestAuthorizationCodeTokenGranter.java
@@ -78,7 +78,7 @@ public class TestAuthorizationCodeTokenGranter {
 		parameters.clear();
 		parameters.put(OAuth2Utils.CLIENT_ID, "foo");
 		parameters.put(OAuth2Utils.SCOPE, "scope");
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, Collections.singleton("scope"), null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, Collections.singleton("scope"), null, null, null, null);
 		
 		String code = authorizationCodeServices.createAuthorizationCode(new OAuth2Authentication(
 				storedOAuth2Request, userAuthentication));
@@ -100,7 +100,7 @@ public class TestAuthorizationCodeTokenGranter {
 		parameters.put("foo", "bar");
 		parameters.put(OAuth2Utils.CLIENT_ID, "foo");
 		parameters.put(OAuth2Utils.SCOPE, "scope");
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, Collections.singleton("scope"), null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, Collections.singleton("scope"), null, null, null, null);
 		
 		Authentication userAuthentication = new UsernamePasswordAuthenticationToken("marissa", "koala",
 				AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER"));
@@ -125,7 +125,7 @@ public class TestAuthorizationCodeTokenGranter {
 		parameters.clear();
 		parameters.put(OAuth2Utils.CLIENT_ID, "foo");
 		parameters.put(OAuth2Utils.SCOPE, "read");
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, Collections.singleton("read"), Collections.singleton("resource"), null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, Collections.singleton("read"), Collections.singleton("resource"), null, null, null);
 		
 		Authentication userAuthentication = new UsernamePasswordAuthenticationToken("marissa", "koala",
 				AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER"));
@@ -151,7 +151,7 @@ public class TestAuthorizationCodeTokenGranter {
 		parameters.clear();
 		parameters.put(OAuth2Utils.CLIENT_ID, "foo");
 		parameters.put(OAuth2Utils.SCOPE, "scope");
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", Collections.<GrantedAuthority> emptySet(), true, Collections.singleton("scope"), null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", Collections.<GrantedAuthority> emptySet(), true, Collections.singleton("scope"), null, null, null, null);
 		
 		Authentication userAuthentication = new UsernamePasswordAuthenticationToken("marissa", "koala",
 				AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER"));
@@ -176,7 +176,7 @@ public class TestAuthorizationCodeTokenGranter {
 		parameters.clear();
 		parameters.put(OAuth2Utils.REDIRECT_URI, "https://redirectMe");
 		parameters.put(OAuth2Utils.CLIENT_ID, "foo");
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, null, null, "https://redirectMe", null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(parameters, "foo", null, true, null, null, "https://redirectMe", null, null);
 		
 		Authentication userAuthentication = new UsernamePasswordAuthenticationToken("marissa", "koala",
 				AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER"));

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2MethodSecurityExpressionHandler.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2MethodSecurityExpressionHandler.java
@@ -52,7 +52,7 @@ public class TestOAuth2MethodSecurityExpressionHandler {
 		Authentication userAuthentication = null;
 		
 		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(request.getRequestParameters(), request.getClientId(), request.getAuthorities(), request.isApproved(), request.getScope(), request.getResourceIds(),
-				request.getRedirectUri(), request.getExtensions());
+				request.getRedirectUri(), request.getResponseTypes(), request.getExtensions());
 		
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		MethodInvocation invocation = new SimpleMethodInvocation(this, ReflectionUtils.findMethod(getClass(),
@@ -66,7 +66,7 @@ public class TestOAuth2MethodSecurityExpressionHandler {
 	@Test
 	public void testScopes() throws Exception {
 		
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -107,7 +107,7 @@ public class TestOAuth2MethodSecurityExpressionHandler {
 		EvaluationContext context = handler.createEvaluationContext(clientAuthentication, invocation);
 		assertFalse((Boolean) expression.getValue(context));
 		
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null, null);
 		
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(storedOAuth2Request, null);
 		EvaluationContext anotherContext = handler.createEvaluationContext(oAuth2Authentication, invocation);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2SecurityExpressionMethods.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2SecurityExpressionMethods.java
@@ -47,7 +47,7 @@ public class TestOAuth2SecurityExpressionMethods {
 		Authentication userAuthentication = null;
 		
 		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(request.getRequestParameters(), request.getClientId(), request.getAuthorities(), request.isApproved(), request.getScope(), request.getResourceIds(),
-				request.getRedirectUri(), request.getExtensions());
+				request.getRedirectUri(), request.getResponseTypes(), request.getExtensions());
 		
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		assertTrue(new OAuth2SecurityExpressionMethods(oAuth2Authentication, true).clientHasAnyRole("ROLE_CLIENT"));
@@ -55,7 +55,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test
 	public void testScopes() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -65,7 +65,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test
 	public void testScopesFalse() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -75,7 +75,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test(expected = AccessDeniedException.class)
 	public void testScopesWithException() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -84,7 +84,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test(expected = AccessDeniedException.class)
 	public void testInsufficientScope() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -94,7 +94,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test
 	public void testSufficientScope() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -104,7 +104,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test
 	public void testSufficientScopeWithNoPreviousScopeDecision() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -120,7 +120,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test
 	public void testClientOnly() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = new UsernamePasswordAuthenticationToken("foo", "bar",
 				Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
@@ -131,7 +131,7 @@ public class TestOAuth2SecurityExpressionMethods {
 
 	@Test
 	public void testOAuthUser() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, true, Collections.singleton("read"), null, null, null, null);
 
 		Authentication userAuthentication = new UsernamePasswordAuthenticationToken("foo", "bar",
 				Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2WebSecurityExpressionHandler.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/expression/TestOAuth2WebSecurityExpressionHandler.java
@@ -46,7 +46,7 @@ public class TestOAuth2WebSecurityExpressionHandler {
 		request.setResourceIdsAndAuthoritiesFromClientDetails(new BaseClientDetails("foo", "", "", "client_credentials", "ROLE_CLIENT"));
 		
 		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(request.getRequestParameters(), request.getClientId(), request.getAuthorities(), request.isApproved(), request.getScope(), request.getResourceIds(),
-				request.getRedirectUri(), request.getExtensions());
+				request.getRedirectUri(), request.getResponseTypes(), request.getExtensions());
 		
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
@@ -57,7 +57,7 @@ public class TestOAuth2WebSecurityExpressionHandler {
 
 	@Test
 	public void testScopes() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		FilterInvocation invocation = new FilterInvocation("/foo", "GET");

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/AbstractTestDefaultTokenServices.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/AbstractTestDefaultTokenServices.java
@@ -171,11 +171,11 @@ public abstract class AbstractTestDefaultTokenServices {
 	@Test
 	public void testOneAccessTokenPerUniqueAuthentication() throws Exception {
 		getTokenServices().createAccessToken(
-				new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null),
+				new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null),
 						new TestAuthentication("test2", false)));
 		assertEquals(1, getAccessTokenCount());
 		getTokenServices().createAccessToken(
-				new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("write"), null, null, null),
+				new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("write"), null, null, null, null),
 						new TestAuthentication("test2", false)));
 		assertEquals(2, getAccessTokenCount());
 	}
@@ -207,7 +207,7 @@ public abstract class AbstractTestDefaultTokenServices {
 
 
 	private OAuth2Authentication createAuthentication() {
-		return new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null), new TestAuthentication("test2", false));
+		return new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null), new TestAuthentication("test2", false));
 	}
 
 	protected abstract int getAccessTokenCount();

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestDefaultTokenServicesWithInMemory.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestDefaultTokenServicesWithInMemory.java
@@ -41,7 +41,7 @@ public class TestDefaultTokenServicesWithInMemory extends AbstractTestDefaultTok
 
 	@Test
 	public void testExpiredToken() throws Exception {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null), new TestAuthentication("test2", false));
 		DefaultOAuth2AccessToken firstAccessToken = (DefaultOAuth2AccessToken) getTokenServices().createAccessToken(
 				expectedAuthentication);
 		// Make it expire (and rely on mutable state in volatile token store)
@@ -53,7 +53,7 @@ public class TestDefaultTokenServicesWithInMemory extends AbstractTestDefaultTok
 
 	@Test
 	public void testExpiredRefreshToken() throws Exception {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null), new TestAuthentication("test2", false));
 		DefaultOAuth2AccessToken firstAccessToken = (DefaultOAuth2AccessToken) getTokenServices().createAccessToken(
 				expectedAuthentication);
 		assertNotNull(firstAccessToken.getRefreshToken());
@@ -69,7 +69,7 @@ public class TestDefaultTokenServicesWithInMemory extends AbstractTestDefaultTok
 
 	@Test
 	public void testExpiredRefreshTokenIsRenewedWithNewAccessToken() throws Exception {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null), new TestAuthentication("test2", false));
 		DefaultOAuth2AccessToken firstAccessToken = (DefaultOAuth2AccessToken) getTokenServices().createAccessToken(
 				expectedAuthentication);
 		assertNotNull(firstAccessToken.getRefreshToken());
@@ -96,7 +96,7 @@ public class TestDefaultTokenServicesWithInMemory extends AbstractTestDefaultTok
 				return client;
 			}
 		});
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null), new TestAuthentication("test2", false));
 		DefaultOAuth2AccessToken firstAccessToken = (DefaultOAuth2AccessToken) getTokenServices().createAccessToken(
 				expectedAuthentication);
 		OAuth2RefreshToken expectedExpiringRefreshToken = firstAccessToken.getRefreshToken();
@@ -127,7 +127,7 @@ public class TestDefaultTokenServicesWithInMemory extends AbstractTestDefaultTok
 				return client;
 			}
 		});
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, Collections.singleton("read"), null, null, null, null), new TestAuthentication("test2", false));
 		DefaultOAuth2AccessToken token = (DefaultOAuth2AccessToken) getTokenServices().createAccessToken(
 				expectedAuthentication);
 		assertNull(token.getRefreshToken());

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestInMemoryTokenStore.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestInMemoryTokenStore.java
@@ -31,7 +31,7 @@ public class TestInMemoryTokenStore extends TestTokenStoreBase {
 	@Test
 	public void testTokenCountConsistency() throws Exception {
 		for (int i = 0; i <= 10; i++) {
-			OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id" + i, null, false, null, null, null, null), new TestAuthentication("test", false));
+			OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id" + i, null, false, null, null, null, null, null), new TestAuthentication("test", false));
 			DefaultOAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken" + i);
 			expectedOAuth2AccessToken.setExpiration(new Date(System.currentTimeMillis() - 1000));
 			if (i > 1) {
@@ -43,7 +43,7 @@ public class TestInMemoryTokenStore extends TestTokenStoreBase {
 
 	@Test
 	public void testTokenCountConsistentWithExpiryQueue() throws Exception {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test", false));
 		DefaultOAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		expectedOAuth2AccessToken.setExpiration(new Date(System.currentTimeMillis()+10000));
 		for (int i = 0; i <= 10; i++) {
@@ -56,7 +56,7 @@ public class TestInMemoryTokenStore extends TestTokenStoreBase {
 	public void testAutoFlush() throws Exception {
 		getTokenStore().setFlushInterval(3);
 		for (int i = 0; i <= 10; i++) {
-			OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id" + i, null, false, null, null, null, null), new TestAuthentication("test", false));
+			OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id" + i, null, false, null, null, null, null, null), new TestAuthentication("test", false));
 			DefaultOAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken" + i);
 			expectedOAuth2AccessToken.setExpiration(new Date(System.currentTimeMillis() - 1000));
 			if (i > 2) {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestTokenStoreBase.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/TestTokenStoreBase.java
@@ -46,7 +46,7 @@ public abstract class TestTokenStoreBase {
 
 	@Test
 	public void testStoreAccessToken() {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test2", false));
 		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
 
@@ -61,13 +61,13 @@ public abstract class TestTokenStoreBase {
 	@Test
 	public void testRetrieveAccessToken() {
 		//Test approved request
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, true, null, null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, true, null, null, null, null, null);
 		OAuth2Authentication authentication = new OAuth2Authentication(storedOAuth2Request, new TestAuthentication("test2", true));
 		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, authentication);
 
 		//Test unapproved request
-		storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null);
+		storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null);
 		authentication = new OAuth2Authentication(storedOAuth2Request, new TestAuthentication("test2", true));
 		OAuth2AccessToken actualOAuth2AccessToken = getTokenStore().getAccessToken(authentication);
 		assertEquals(expectedOAuth2AccessToken, actualOAuth2AccessToken);
@@ -84,7 +84,7 @@ public abstract class TestTokenStoreBase {
 
 	@Test
 	public void testFindAccessTokensByUserName() {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test2", false));
 		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
 
@@ -94,7 +94,7 @@ public abstract class TestTokenStoreBase {
 
 	@Test
 	public void testFindAccessTokensByClientId() {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test2", false));
 		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
 
@@ -109,7 +109,7 @@ public abstract class TestTokenStoreBase {
 
 	@Test
 	public void testRefreshTokenIsNotStoredDuringAccessToken() {
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test2", false));
 		DefaultOAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		expectedOAuth2AccessToken.setRefreshToken(new DefaultOAuth2RefreshToken("refreshToken"));
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
@@ -124,7 +124,7 @@ public abstract class TestTokenStoreBase {
 	public void testStoreRefreshToken() {
 		DefaultOAuth2RefreshToken expectedExpiringRefreshToken = new DefaultExpiringOAuth2RefreshToken("testToken",
 				new Date());
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test2", false));
 		getTokenStore().storeRefreshToken(expectedExpiringRefreshToken, expectedAuthentication);
 
 		OAuth2RefreshToken actualExpiringRefreshToken = getTokenStore().readRefreshToken("testToken");
@@ -143,7 +143,7 @@ public abstract class TestTokenStoreBase {
 	@Test
 	public void testGetAccessTokenForDeletedUser() throws Exception {
 		//Test approved request
-		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, true, null, null, null, null);
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, true, null, null, null, null, null);
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(storedOAuth2Request, new TestAuthentication("test", true));
 		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
@@ -151,7 +151,7 @@ public abstract class TestTokenStoreBase {
 		assertEquals(expectedAuthentication, getTokenStore().readAuthentication(expectedOAuth2AccessToken.getValue()));
 		
 		//Test unapproved request
-		storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null);
+		storedOAuth2Request = RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null);
 		OAuth2Authentication anotherAuthentication = new OAuth2Authentication(storedOAuth2Request, new TestAuthentication("test", true));
 		assertEquals(expectedOAuth2AccessToken, getTokenStore().getAccessToken(anotherAuthentication));
 		// The generated key for the authentication is the same as before, but the two auths are not equal. This could
@@ -166,7 +166,7 @@ public abstract class TestTokenStoreBase {
 	public void testRemoveRefreshToken() {
 		OAuth2RefreshToken expectedExpiringRefreshToken = new DefaultExpiringOAuth2RefreshToken("testToken",
 				new Date());
-		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null), new TestAuthentication("test2", false));
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request(null, "id", null, false, null, null, null, null, null), new TestAuthentication("test2", false));
 		getTokenStore().storeRefreshToken(expectedExpiringRefreshToken, expectedAuthentication);
 		getTokenStore().removeRefreshToken(expectedExpiringRefreshToken);
 		

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/vote/TestScopeVoter.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/vote/TestScopeVoter.java
@@ -51,7 +51,7 @@ public class TestScopeVoter {
 	@Test
 	public void testDenyIfOAuth2AndExplictlyDenied() throws Exception {
 
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		assertEquals(
@@ -62,7 +62,7 @@ public class TestScopeVoter {
 
 	@Test
 	public void testAccessGrantedIfScopesPresent() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		assertEquals(
@@ -74,7 +74,7 @@ public class TestScopeVoter {
 	@Test
 	public void testAccessGrantedIfScopesPresentWithPrefix() throws Exception {
 		voter.setScopePrefix("scope=");
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		assertEquals(
@@ -85,7 +85,7 @@ public class TestScopeVoter {
 
 	@Test
 	public void testAccessDeniedIfWrongScopesPresent() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		voter.setThrowException(false);
@@ -97,7 +97,7 @@ public class TestScopeVoter {
 
 	@Test(expected = AccessDeniedException.class)
 	public void testExceptionThrownIfWrongScopesPresent() throws Exception {
-		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null);
+		OAuth2Request clientAuthentication = RequestTokenFactory.createOAuth2Request(null, "foo", null, false, Collections.singleton("read"), null, null, null, null);
 		Authentication userAuthentication = null;
 		OAuth2Authentication oAuth2Authentication = new OAuth2Authentication(clientAuthentication, userAuthentication);
 		assertEquals(


### PR DESCRIPTION
OAuth2Request did not have a field for responseTypes, which we ended up needing, so I added the field and a getter method.

JIRA issue here: https://jira.springsource.org/browse/SECOAUTH-416
