### PR TITLE
AuthorizationRequest.createOAuth2Request mistakenly populated the reques...

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/AuthorizationRequest.java
@@ -103,7 +103,7 @@ public class AuthorizationRequest extends BaseRequest {
 	}
 
 	public OAuth2Request createOAuth2Request() {
-		return new OAuth2Request(getApprovalParameters(), getClientId(), getAuthorities(), isApproved(), getScope(), getResourceIds(), getRedirectUri(), getExtensions());
+		return new OAuth2Request(getRequestParameters(), getClientId(), getAuthorities(), isApproved(), getScope(), getResourceIds(), getRedirectUri(), getExtensions());
 	}
 
 	/**


### PR DESCRIPTION
...tParameters map with the approvalParameters map. Fixed method to use correct map.

JIRA issue here: https://jira.springsource.org/browse/SECOAUTH-417
