### PR TITLE
Added ImplicitGrantService, whicn mimics the AuthorizationCodeService pa...

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/ImplicitGrantService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/ImplicitGrantService.java
@@ -1,0 +1,33 @@
+package org.springframework.security.oauth2.provider.implicit;
+
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.TokenRequest;
+
+/**
+ * Service to associate & store an incoming AuthorizationRequest with the TokenRequest that is passed
+ * to the ImplicitTokenGranter during the Implicit flow. This mimics the AuthorizationCodeServices
+ * functionality from the Authorization Code flow, allowing the ImplicitTokenGranter to reference the original 
+ * AuthorizationRequest, while still allowing the ImplicitTokenGranter to adhere to the TokenGranter interface. 
+ * 
+ * @author Amanda Anganes
+ *
+ */
+public interface ImplicitGrantService {
+
+	/**
+	 * Save an association between an OAuth2Request and a TokenRequest.
+	 * 
+	 * @param originalRequest
+	 * @param tokenRequest
+	 */
+	public void store(OAuth2Request originalRequest, TokenRequest tokenRequest);
+	
+	/**
+	 * Look up and return the OAuth2Request associated with the given TokenRequest.
+	 * 
+	 * @param tokenRequest
+	 * @return
+	 */
+	public OAuth2Request remove(TokenRequest tokenRequest);
+	
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/ImplicitTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/ImplicitTokenGranter.java
@@ -23,8 +23,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.token.AbstractTokenGranter;
 import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
@@ -37,6 +37,8 @@ public class ImplicitTokenGranter extends AbstractTokenGranter {
 
 	private static final String GRANT_TYPE = "implicit";
 
+	private ImplicitGrantService service;
+	
 	public ImplicitTokenGranter(AuthorizationServerTokenServices tokenServices, ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
 		super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
 	}
@@ -48,11 +50,15 @@ public class ImplicitTokenGranter extends AbstractTokenGranter {
 		if (userAuth==null || !userAuth.isAuthenticated()) {
 			throw new InsufficientAuthenticationException("There is no currently logged in user");
 		}
-
-		OAuth2Request storedOAuth2Request = getRequestFactory().createOAuth2Request(client, clientToken);
 		
-		return new OAuth2Authentication(storedOAuth2Request, userAuth);
+		OAuth2Request requestForStorage = service.remove(clientToken);
+		
+		return new OAuth2Authentication(requestForStorage, userAuth);
 
+	}
+	
+	public void setImplicitGrantService(ImplicitGrantService service) {
+		this.service = service;
 	}
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/InMemoryImplicitGrantService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/InMemoryImplicitGrantService.java
@@ -1,0 +1,27 @@
+package org.springframework.security.oauth2.provider.implicit;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.TokenRequest;
+
+/**
+ * In-memory implementation of the ImplicitGrantService.
+ * 
+ * @author Amanda Anganes
+ *
+ */
+public class InMemoryImplicitGrantService implements ImplicitGrantService {
+
+	protected final ConcurrentHashMap<TokenRequest, OAuth2Request> requestStore = new ConcurrentHashMap<TokenRequest, OAuth2Request>();
+	
+	public void store(OAuth2Request originalRequest, TokenRequest tokenRequest) {
+		this.requestStore.put(tokenRequest, originalRequest);
+	}
+
+	public OAuth2Request remove(TokenRequest tokenRequest) {
+		OAuth2Request request = this.requestStore.remove(tokenRequest);
+		return request;
+	}
+
+}

--- a/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
+++ b/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
@@ -235,6 +235,15 @@
 				</xs:annotation>
 			</xs:attribute>
 
+			<xs:attribute name="implicit-grant-service-ref" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						The reference to the bean that defines the
+						implicit grant service.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+
 			<xs:attribute name="token-services-ref" type="xs:string">
 				<xs:annotation>
 					<xs:documentation>

--- a/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/authorization-server-extras.xml
+++ b/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/authorization-server-extras.xml
@@ -8,6 +8,7 @@
 	<oauth:authorization-server client-details-service-ref="clientDetails" token-services-ref="tokens"
 		authorization-endpoint-url="/authorize" token-endpoint-url="/token" approval-parameter-name="approve" error-page="/error"
 		authorization-request-manager-ref="factory" redirect-resolver-ref="resolver" token-granter-ref="granter"
+		implicit-grant-service-ref="implicitService"
 		user-approval-handler-ref="approvals" user-approval-page="/approve">
 		<oauth:authorization-code />
 	</oauth:authorization-server>
@@ -30,6 +31,8 @@
 		<constructor-arg ref="clientDetails" />
 		<constructor-arg ref="factory" />
 	</bean>
+	
+	<bean id="implicitService" class="org.springframework.security.oauth2.provider.implicit.InMemoryImplicitGrantService" />
 
 	<bean id="approvals" class="org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler" />
 


### PR DESCRIPTION
...ttern used by the code flow. This allows the ImplicitTokenGranter to retrieve the original AuthorizationRequest, using the incoming TokenRequest as a key.

Without this service, the ImplicitTokenGranter has no reference to the original AuthorizationRequest. The AR may contain additional information not present in the TR, such as items in the extensions map. The additional information can be stored in an OAuth2Request, but because the ImplicitTokenGranter must adhere to the TokenGranter interface, there was no way to pass anything other than a TR to the granter. This new service saves the original AR (converted into an OAuth2Request for storage) alongside the newly created TR, in the AuthorizationEndpoint. This is similar to how the AuthorizationCodeFlow works. On the other side, the ImplicitTokenGranter removes the stored OA2R from the service, using the incoming TR as a key. It can then pass back an OAuth2Authentication object which contains a full copy of the original AR in its OA2R. 

JIRA ticket here: https://jira.springsource.org/browse/SECOAUTH-418
