### PR TITLE
Changed signature of request validator validateScope() method

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultOAuth2RequestValidator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultOAuth2RequestValidator.java
@@ -1,10 +1,8 @@
 package org.springframework.security.oauth2.provider;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
-import org.springframework.security.oauth2.common.util.OAuth2Utils;
 
 /**
  * Default implementation of {@link OAuth2RequestValidator}. 
@@ -15,13 +13,12 @@ import org.springframework.security.oauth2.common.util.OAuth2Utils;
 public class DefaultOAuth2RequestValidator implements OAuth2RequestValidator {
 
 	
-	public void validateScope(Map<String, String> parameters, Set<String> clientScopes) {
-		if (parameters.containsKey("scope")) {
-			if (clientScopes != null && !clientScopes.isEmpty()) {
-				for (String scope : OAuth2Utils.parseParameterList(parameters.get("scope"))) {
-					if (!clientScopes.contains(scope)) {
-						throw new InvalidScopeException("Invalid scope: " + scope, clientScopes);
-					}
+	public void validateScope(Set<String> requestScopes, Set<String> clientScopes) {
+
+		if (clientScopes != null && !clientScopes.isEmpty()) {
+			for (String scope : requestScopes) {
+				if (!clientScopes.contains(scope)) {
+					throw new InvalidScopeException("Invalid scope: " + scope, clientScopes);
 				}
 			}
 		}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2RequestValidator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2RequestValidator.java
@@ -20,6 +20,6 @@ public interface OAuth2RequestValidator {
 	 * @param clientScopes the requesting client's registered, allowed scopes
 	 * @throws InvalidScopeException if a requested scope is invalid
 	 */
-	public void validateScope(Map<String, String> parameters, Set<String> clientScopes) throws InvalidScopeException;
+	public void validateScope(Set<String> requestScopes, Set<String> clientScopes) throws InvalidScopeException;
 	
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -160,8 +160,7 @@ public class AuthorizationEndpoint extends AbstractEndpoint implements Initializ
 
 			// We intentionally only validate the parameters requested by the client (ignoring any data that may have
 			// been added to the request by the manager).
-			oAuth2RequestValidator.validateScope(authorizationRequest.getRequestParameters(),
-					client.getScope());
+			oAuth2RequestValidator.validateScope(authorizationRequest.getScope(), client.getScope());
 
 			//Some systems may allow for approval decisions to be remembered or approved by default. Check for 
 			//such logic here, and set the approved flag on the authorization request accordingly.

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -77,17 +77,18 @@ public class TokenEndpoint extends AbstractEndpoint {
 		
 		String clientId = getClientId(principal);
 		HashMap<String, String> map = new HashMap<String,String>(parameters);
+
+		TokenRequest tokenRequest = getOAuth2RequestFactory().createTokenRequest(map);
+		
 		if (clientId != null) {
 			map.put(OAuth2Utils.CLIENT_ID, clientId);
 			// Only validate the client details if a client authenticated during this
 			// request.
 			ClientDetails client = getClientDetailsService().loadClientByClientId(clientId);
 			if (client != null) {
-				oAuth2RequestValidator.validateScope(map, client.getScope());
+				oAuth2RequestValidator.validateScope(tokenRequest.getScope(), client.getScope());
 			}
 		}
-		TokenRequest tokenRequest = getOAuth2RequestFactory().createTokenRequest(map);
-
 		if (!StringUtils.hasText(tokenRequest.getGrantType())) {
 			throw new InvalidRequestException("Missing grant type");
 		}


### PR DESCRIPTION
The previous method signature of validateScope() took in the full parameter map from the request, and re-parsed the scope out of that. However, in both places this method is called, the resolved Set<String> of scopes is available off of a request object (TokenRequest or AuthorizationRequest). That scope set is more accurate than the set visible in the request.getParameters() map. This patch alters the method signature to take in the request scope Set directly instead of re-parsing it. 

JIRA issue: https://jira.springsource.org/browse/SECOAUTH-421
