### PR TITLE
Added extra parameter to RedirectView constructor calls; set exposeModelAttributes = false

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -226,7 +226,7 @@ public class AuthorizationEndpoint extends AbstractEndpoint implements Initializ
 			
 			if (!authorizationRequest.isApproved()) {
 				return new RedirectView(getUnsuccessfulRedirect(authorizationRequest, new UserDeniedAuthorizationException(
-						"User denied access"), responseTypes.contains("token")), false);
+						"User denied access"), responseTypes.contains("token")), false, true, false);
 			}
 
 			if (responseTypes.contains("token")) {
@@ -260,20 +260,20 @@ public class AuthorizationEndpoint extends AbstractEndpoint implements Initializ
 			if (accessToken == null) {
 				throw new UnsupportedResponseTypeException("Unsupported response type: token");
 			}
-			return new ModelAndView(new RedirectView(appendAccessToken(authorizationRequest, accessToken), false));
+			return new ModelAndView(new RedirectView(appendAccessToken(authorizationRequest, accessToken), false, true, false));
 		}
 		catch (OAuth2Exception e) {
-			return new ModelAndView(new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, true), false));
+			return new ModelAndView(new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, true), false, true, false));
 		}
 	}
 
 	private View getAuthorizationCodeResponse(AuthorizationRequest authorizationRequest, Authentication authUser) {
 		try {
 			return new RedirectView(getSuccessfulRedirect(authorizationRequest,
-					generateCode(authorizationRequest, authUser)), false);
+					generateCode(authorizationRequest, authUser)), false, true, false);
 		}
 		catch (OAuth2Exception e) {
-			return new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, false), false);
+			return new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, false), false, true, false);
 		}
 	}
    
@@ -495,7 +495,7 @@ public class AuthorizationEndpoint extends AbstractEndpoint implements Initializ
 			authorizationRequest.setRedirectUri(requestedRedirect);
 			String redirect = getUnsuccessfulRedirect(authorizationRequest, translate.getBody(), authorizationRequest
 					.getResponseTypes().contains("token"));
-			return new ModelAndView(new RedirectView(redirect, false));
+			return new ModelAndView(new RedirectView(redirect, false, true, false));
 		}
 		catch (OAuth2Exception ex) {
 			// If an AuthorizationRequest cannot be created from the incoming parameters it must be


### PR DESCRIPTION
The way the RedirectView constructors were being called in the AuthorizationEndpoint did not set the  exposeModelAttributes parameter to false. This meant that if a user denied an OAuth2 request, the returned redirect URI contained many model attributes which should not be visible to the user. This patch adds parameters to the RedirectView constructor calls to set that parameter to false.

Note that redirects can also be triggered by returning a path starting with "redirect:". In this case Spring builds the RedirectView behind the scenes, and decides how to set this flag based on flags in the SecurityContext. We haven't analyzed the whole codebase to see if that pattern is being used anywhere, but if it is this issue might crop up in other spots. 

JIRA issue: https://jira.springsource.org/browse/SECOAUTH-422
