### PR TITLE
Pluggable OAuth2RequestValidator

### DIFF
--- a/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
+++ b/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
@@ -243,7 +243,18 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
-
+			
+			<xs:attribute name="request-validator-ref" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						The reference to the bean that defines the
+						OAuth2RequestValidator implementation. Default
+						value is an instance of 
+						"org.springframework.security.oauth2.provider.DefaultOAuth2RequestValidator".
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			
 			<xs:attribute name="token-services-ref" type="xs:string">
 				<xs:annotation>
 					<xs:documentation>

--- a/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/authorization-server-extras.xml
+++ b/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/authorization-server-extras.xml
@@ -8,7 +8,7 @@
 	<oauth:authorization-server client-details-service-ref="clientDetails" token-services-ref="tokens"
 		authorization-endpoint-url="/authorize" token-endpoint-url="/token" approval-parameter-name="approve" error-page="/error"
 		authorization-request-manager-ref="factory" redirect-resolver-ref="resolver" token-granter-ref="granter"
-		implicit-grant-service-ref="implicitService"
+		implicit-grant-service-ref="implicitService" request-validator-ref="requestValidator"
 		user-approval-handler-ref="approvals" user-approval-page="/approve">
 		<oauth:authorization-code />
 	</oauth:authorization-server>
@@ -21,7 +21,7 @@
 		<property name="tokenStore">
 			<bean class="org.springframework.security.oauth2.provider.token.InMemoryTokenStore" />
 		</property>
-	</bean>
+	</bean> 
 
 	<bean id="granter" class="org.springframework.security.oauth2.provider.code.AuthorizationCodeTokenGranter">
 		<constructor-arg ref="tokens" />
@@ -31,6 +31,8 @@
 		<constructor-arg ref="clientDetails" />
 		<constructor-arg ref="factory" />
 	</bean>
+	
+	<bean id="requestValidator" class="org.springframework.security.oauth2.provider.DefaultOAuth2RequestValidator" />
 	
 	<bean id="implicitService" class="org.springframework.security.oauth2.provider.implicit.InMemoryImplicitGrantService" />
 


### PR DESCRIPTION
The OAuth2RequestValidator, which is used in the Authorization and Token endpoints, should be pluggable so that developers can use a custom implementation if needed.

JIRA ticket: https://jira.springsource.org/browse/SECOAUTH-420
