### PR TITLE
Updated OAuth2RequestValidator signature change 

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultOAuth2RequestValidator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/DefaultOAuth2RequestValidator.java
@@ -13,8 +13,10 @@ import org.springframework.security.oauth2.common.exceptions.InvalidScopeExcepti
 public class DefaultOAuth2RequestValidator implements OAuth2RequestValidator {
 
 	
-	public void validateScope(Set<String> requestScopes, Set<String> clientScopes) {
+	public void validateScope(Set<String> requestScopes, ClientDetails client) {
 
+		Set<String> clientScopes = client.getScope();
+		
 		if (clientScopes != null && !clientScopes.isEmpty()) {
 			for (String scope : requestScopes) {
 				if (!clientScopes.contains(scope)) {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2RequestValidator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2RequestValidator.java
@@ -1,9 +1,10 @@
 package org.springframework.security.oauth2.provider;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
+import org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint;
+import org.springframework.security.oauth2.provider.endpoint.TokenEndpoint;
 
 /**
  * Validation interface for OAuth2 requests to the {@link AuthorizationEndpoint} and {@link TokenEndpoint}.
@@ -20,6 +21,6 @@ public interface OAuth2RequestValidator {
 	 * @param clientScopes the requesting client's registered, allowed scopes
 	 * @throws InvalidScopeException if a requested scope is invalid
 	 */
-	public void validateScope(Set<String> requestScopes, Set<String> clientScopes) throws InvalidScopeException;
+	public void validateScope(Set<String> requestScopes, ClientDetails client) throws InvalidScopeException;
 	
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -160,7 +160,7 @@ public class AuthorizationEndpoint extends AbstractEndpoint implements Initializ
 
 			// We intentionally only validate the parameters requested by the client (ignoring any data that may have
 			// been added to the request by the manager).
-			oAuth2RequestValidator.validateScope(authorizationRequest.getScope(), client.getScope());
+			oAuth2RequestValidator.validateScope(authorizationRequest.getScope(), client);
 
 			//Some systems may allow for approval decisions to be remembered or approved by default. Check for 
 			//such logic here, and set the approved flag on the authorization request accordingly.

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -86,7 +86,7 @@ public class TokenEndpoint extends AbstractEndpoint {
 			// request.
 			ClientDetails client = getClientDetailsService().loadClientByClientId(clientId);
 			if (client != null) {
-				oAuth2RequestValidator.validateScope(tokenRequest.getScope(), client.getScope());
+				oAuth2RequestValidator.validateScope(tokenRequest.getScope(), client);
 			}
 		}
 		if (!StringUtils.hasText(tokenRequest.getGrantType())) {


### PR DESCRIPTION
Keeps the first parameter to validateScope() as the actual requested scope set (from the OAuth2Request object), changes second parameter to be the full ClientDetails object.
