### PR TITLE
Fix for client_id in req parm and auth header

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/auth/DefaultClientAuthenticationHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/auth/DefaultClientAuthenticationHandler.java
@@ -30,7 +30,6 @@ public class DefaultClientAuthenticationHandler implements ClientAuthenticationH
 				clientSecret = clientSecret == null ? "" : clientSecret;
 				switch (scheme) {
 				case header:
-					form.remove("client_id");
 					form.remove("client_secret");
 					headers.add(
 							"Authorization",


### PR DESCRIPTION
pull request - replaces https://github.com/spring-projects/spring-security-oauth/pull/90.

Fix problem of client_id being sent in basic authorization header and request parameter. See: http://forum.springsource.org/showthread.php?141347-client_id-passed-as-request-parameter-and-in-http-basic-authorization

I didn't notice any errors when i ran the integration-test target.  Let me know if you have problems. 

I have signed the contributor agreement.
