### PR TITLE
SECOAUTH-431: Set content-type in WhitelabelApprovalEndpoint responses.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelApprovalEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelApprovalEndpoint.java
@@ -77,6 +77,7 @@ public class WhitelabelApprovalEndpoint {
 			map.put("path", (Object) request.getContextPath());
 			context.setRootObject(map);
 			String result = helper.replacePlaceholders(template, resolver);
+			response.setContentType(getContentType());
 			response.getWriter().append(result);
 		}
 


### PR DESCRIPTION
The default implementation of the /oauth/confirm_access and /oauth/error as defined in the WhitelabelApprovalEndpoint class do not set the content-type header. This means that these pages are not rendered as HTML, my browser is treating them as plain text.

The pull request contains a trivial change to fix this.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
