### PR TITLE
JdbcTokenStore.java is missing sql setter 

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/JdbcTokenStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/JdbcTokenStore.java
@@ -418,4 +418,12 @@ public class JdbcTokenStore implements TokenStore {
 		this.deleteAccessTokenFromRefreshTokenSql = deleteAccessTokenFromRefreshTokenSql;
 	}
 
+  public void setSelectAccessTokensFromUserNameSql(String selectAccessTokensFromUserNameSql) {
+    this.selectAccessTokensFromUserNameSql = selectAccessTokensFromUserNameSql;
+  }
+
+  public void setSelectAccessTokensFromClientIdSql(String selectAccessTokensFromClientIdSql) {
+    this.selectAccessTokensFromClientIdSql = selectAccessTokensFromClientIdSql;
+  }
+
 }


### PR DESCRIPTION
Without setter for "selectAccessTokensFromUserNameSql" and "selectAccessTokensFromClientIdSql" they cant be overridden conveniently.
