### PR TITLE
Adding /me endpoint to support Spring Social clients

### DIFF
--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/PhotoServiceUser.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/PhotoServiceUser.java
@@ -1,0 +1,45 @@
+package org.springframework.security.oauth.examples.sparklr;
+
+/**
+ * Photo service user information - added to enable user information to be available to Spring Social client
+ *
+ * @author Michael Lavelle
+ */
+public class PhotoServiceUser {
+	
+	private String username;
+	private String name;
+	
+	/**
+	 * Create a new PhotoServiceUser
+	 *
+	 * @param username The unique username for the user
+	 * @param name The name of the user
+	 */
+	public PhotoServiceUser(String username,String name)
+	{
+		this.username = username;
+		this.name = name;
+	}
+
+	/**
+	 * The unique username for the user
+	 *
+	 * @return username of the user
+	 */
+	public String getUsername() {
+		return username;
+	}
+
+	/**
+	 * The name of the user
+	 *
+	 * @return name of the user
+	 */
+	public String getName() {
+		return name;
+	}
+
+	
+
+}

--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/OAuth2ServerConfig.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/OAuth2ServerConfig.java
@@ -56,9 +56,10 @@ public class OAuth2ServerConfig {
 		protected void configure(HttpSecurity http) throws Exception {
 			// @formatter:off
 			http
-				.requestMatchers().antMatchers("/photos/**")
+				.requestMatchers().antMatchers("/photos/**","/me")
 			.and()
 				.authorizeRequests()
+				.antMatchers("/me").access("hasRole('ROLE_USER')")
 				.antMatchers("/photos").access("hasRole('ROLE_USER')")
 				.antMatchers("/photos/trusted/**").access("hasRole('ROLE_USER')")
 				.antMatchers("/photos/user/**").access("hasRole('ROLE_USER')")
@@ -80,9 +81,10 @@ public class OAuth2ServerConfig {
 		public void configure(HttpSecurity http) throws Exception {
 			// @formatter:off
 			http
-				.requestMatchers().antMatchers("/photos/**", "/oauth/users/**", "/oauth/clients/**")
+				.requestMatchers().antMatchers("/photos/**", "/oauth/users/**", "/oauth/clients/**","/me")
 			.and()
 				.authorizeRequests()
+					.antMatchers("/me").access("#oauth2.hasScope('read')")
 					.antMatchers("/photos").access("#oauth2.hasScope('read')")
 					.antMatchers("/photos/trusted/**").access("#oauth2.hasScope('trust')")
 					.antMatchers("/photos/user/**").access("#oauth2.hasScope('trust')")

--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/WebMvcConfig.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/WebMvcConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth.examples.sparklr.impl.PhotoServiceImpl
 import org.springframework.security.oauth.examples.sparklr.mvc.AccessConfirmationController;
 import org.springframework.security.oauth.examples.sparklr.mvc.AdminController;
 import org.springframework.security.oauth.examples.sparklr.mvc.PhotoController;
+import org.springframework.security.oauth.examples.sparklr.mvc.PhotoServiceUserController;
 import org.springframework.security.oauth.examples.sparklr.oauth.SparklrUserApprovalHandler;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 import org.springframework.security.oauth2.provider.approval.ApprovalStore;
@@ -57,6 +58,13 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
         return contentViewResolver;
     }
 
+   
+    @Bean
+    public PhotoServiceUserController photoServiceUserController(PhotoService photoService) {
+   	   PhotoServiceUserController photoServiceUserController = new PhotoServiceUserController();
+       return photoServiceUserController;
+    }
+   
     @Bean
     public PhotoController photoController(PhotoService photoService) {
         PhotoController photoController = new PhotoController();

--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/mvc/PhotoServiceUserController.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/mvc/PhotoServiceUserController.java
@@ -1,0 +1,25 @@
+package org.springframework.security.oauth.examples.sparklr.mvc;
+
+import java.security.Principal;
+
+import org.springframework.security.oauth.examples.sparklr.PhotoServiceUser;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * @author Michael Lavelle
+ * 
+ * Added to provide an endpoint from which Spring Social can obtain authentication details
+ */
+@RequestMapping("/me")
+@Controller
+public class PhotoServiceUserController {
+	
+	@ResponseBody
+	@RequestMapping("")
+	public PhotoServiceUser getPhotoServiceUser(Principal principal)
+	{
+		return new PhotoServiceUser(principal.getName(),principal.getName());
+	}
+}


### PR DESCRIPTION
Changes required to reinstate the support for the /me endpoint - this allows spring-social-sparklr module ( https://github.com/michaellavelle/spring-social-sparklr ) to obtain profile details for currently authenticated user, and therefore permits "login with Sparklr" functionality in Spring Social apps.
