### PR TITLE
fix: package of InMemoryTokenStore in samples/oauth2/sparklr

### DIFF
--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/OAuth2ServerConfig.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/OAuth2ServerConfig.java
@@ -18,11 +18,7 @@ package org.springframework.security.oauth.examples.sparklr.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.context.annotation.*;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -42,181 +38,180 @@ import org.springframework.security.oauth2.provider.approval.ApprovalStore;
 import org.springframework.security.oauth2.provider.approval.TokenApprovalStore;
 import org.springframework.security.oauth2.provider.approval.UserApprovalHandler;
 import org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestFactory;
+import org.springframework.security.oauth2.provider.token.InMemoryTokenStore;
 import org.springframework.security.oauth2.provider.token.TokenStore;
-import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
 
 /**
  * @author Rob Winch
- * 
  */
 @Configuration
 public class OAuth2ServerConfig {
 
-	private static final String SPARKLR_RESOURCE_ID = "sparklr";
+  private static final String SPARKLR_RESOURCE_ID = "sparklr";
 
-	@Configuration
-	@Order(10)
-	protected static class UiResourceConfiguration extends WebSecurityConfigurerAdapter {
-		@Override
-		protected void configure(HttpSecurity http) throws Exception {
-			// @formatter:off
-			http
-				.requestMatchers().antMatchers("/photos/**","/me")
-			.and()
-				.authorizeRequests()
-				.antMatchers("/me").access("hasRole('ROLE_USER')")
-				.antMatchers("/photos").access("hasRole('ROLE_USER')")
-				.antMatchers("/photos/trusted/**").access("hasRole('ROLE_USER')")
-				.antMatchers("/photos/user/**").access("hasRole('ROLE_USER')")
-				.antMatchers("/photos/**").access("hasRole('ROLE_USER')");
-			// @formatter:on
-		}
-	}
+  @Configuration
+  @Order(10)
+  protected static class UiResourceConfiguration extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      // @formatter:off
+      http
+          .requestMatchers().antMatchers("/photos/**", "/me")
+          .and()
+          .authorizeRequests()
+          .antMatchers("/me").access("hasRole('ROLE_USER')")
+          .antMatchers("/photos").access("hasRole('ROLE_USER')")
+          .antMatchers("/photos/trusted/**").access("hasRole('ROLE_USER')")
+          .antMatchers("/photos/user/**").access("hasRole('ROLE_USER')")
+          .antMatchers("/photos/**").access("hasRole('ROLE_USER')");
+      // @formatter:on
+    }
+  }
 
-	@Configuration
-	@EnableResourceServer
-	protected static class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
+  @Configuration
+  @EnableResourceServer
+  protected static class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
 
-		@Override
-		public void configure(ResourceServerSecurityConfigurer resources) {
-			resources.resourceId(SPARKLR_RESOURCE_ID);
-		}
+    @Override
+    public void configure(ResourceServerSecurityConfigurer resources) {
+      resources.resourceId(SPARKLR_RESOURCE_ID);
+    }
 
-		@Override
-		public void configure(HttpSecurity http) throws Exception {
-			// @formatter:off
-			http
-				.requestMatchers().antMatchers("/photos/**", "/oauth/users/**", "/oauth/clients/**","/me")
-			.and()
-				.authorizeRequests()
-					.antMatchers("/me").access("#oauth2.hasScope('read')")
-					.antMatchers("/photos").access("#oauth2.hasScope('read')")
-					.antMatchers("/photos/trusted/**").access("#oauth2.hasScope('trust')")
-					.antMatchers("/photos/user/**").access("#oauth2.hasScope('trust')")
-					.antMatchers("/photos/**").access("#oauth2.hasScope('read')")
-					.regexMatchers(HttpMethod.DELETE, "/oauth/users/([^/].*?)/tokens/.*")
-						.access("#oauth2.clientHasRole('ROLE_CLIENT') and (hasRole('ROLE_USER') or #oauth2.isClient()) and #oauth2.hasScope('write')")
-					.regexMatchers(HttpMethod.GET, "/oauth/clients/([^/].*?)/users/.*")
-						.access("#oauth2.clientHasRole('ROLE_CLIENT') and (hasRole('ROLE_USER') or #oauth2.isClient()) and #oauth2.hasScope('read')")
-					.regexMatchers(HttpMethod.GET, "/oauth/clients/.*")
-						.access("#oauth2.clientHasRole('ROLE_CLIENT') and #oauth2.isClient() and #oauth2.hasScope('read')");
-			// @formatter:on
-		}
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+      // @formatter:off
+      http
+          .requestMatchers().antMatchers("/photos/**", "/oauth/users/**", "/oauth/clients/**", "/me")
+          .and()
+          .authorizeRequests()
+          .antMatchers("/me").access("#oauth2.hasScope('read')")
+          .antMatchers("/photos").access("#oauth2.hasScope('read')")
+          .antMatchers("/photos/trusted/**").access("#oauth2.hasScope('trust')")
+          .antMatchers("/photos/user/**").access("#oauth2.hasScope('trust')")
+          .antMatchers("/photos/**").access("#oauth2.hasScope('read')")
+          .regexMatchers(HttpMethod.DELETE, "/oauth/users/([^/].*?)/tokens/.*")
+          .access("#oauth2.clientHasRole('ROLE_CLIENT') and (hasRole('ROLE_USER') or #oauth2.isClient()) and #oauth2.hasScope('write')")
+          .regexMatchers(HttpMethod.GET, "/oauth/clients/([^/].*?)/users/.*")
+          .access("#oauth2.clientHasRole('ROLE_CLIENT') and (hasRole('ROLE_USER') or #oauth2.isClient()) and #oauth2.hasScope('read')")
+          .regexMatchers(HttpMethod.GET, "/oauth/clients/.*")
+          .access("#oauth2.clientHasRole('ROLE_CLIENT') and #oauth2.isClient() and #oauth2.hasScope('read')");
+      // @formatter:on
+    }
 
-	}
+  }
 
-	@Configuration
-	@EnableAuthorizationServer
-	protected static class AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
+  @Configuration
+  @EnableAuthorizationServer
+  protected static class AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
 
-		@Autowired
-		private TokenStore tokenStore;
+    @Autowired
+    private TokenStore tokenStore;
 
-		@Autowired
-		private UserApprovalHandler userApprovalHandler;
+    @Autowired
+    private UserApprovalHandler userApprovalHandler;
 
-		@Autowired
-		@Qualifier("authenticationManagerBean")
-		private AuthenticationManager authenticationManager;
+    @Autowired
+    @Qualifier("authenticationManagerBean")
+    private AuthenticationManager authenticationManager;
 
-		@Value("${tonr.redirect:http://localhost:8080/tonr2/sparklr/redirect}")
-		private String tonrRedirectUri;
+    @Value("${tonr.redirect:http://localhost:8080/tonr2/sparklr/redirect}")
+    private String tonrRedirectUri;
 
-		@Override
-		public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
 
-			// @formatter:off
-			clients.inMemory().withClient("tonr")
-			 			.resourceIds(SPARKLR_RESOURCE_ID)
-			 			.authorizedGrantTypes("authorization_code", "implicit")
-			 			.authorities("ROLE_CLIENT")
-			 			.scopes("read", "write")
-			 			.secret("secret")
-			 		.and()
-			 		.withClient("tonr-with-redirect")
-			 			.resourceIds(SPARKLR_RESOURCE_ID)
-			 			.authorizedGrantTypes("authorization_code", "implicit")
-			 			.authorities("ROLE_CLIENT")
-			 			.scopes("read", "write")
-			 			.secret("secret")
-			 			.redirectUris(tonrRedirectUri)
-			 		.and()
-		 		    .withClient("my-client-with-registered-redirect")
-	 			        .resourceIds(SPARKLR_RESOURCE_ID)
-	 			        .authorizedGrantTypes("authorization_code", "client_credentials")
-	 			        .authorities("ROLE_CLIENT")
-	 			        .scopes("read", "trust")
-	 			        .redirectUris("http://anywhere?key=value")
-		 		    .and()
-	 		        .withClient("my-trusted-client")
- 			            .authorizedGrantTypes("password", "authorization_code", "refresh_token", "implicit")
- 			            .authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT")
- 			            .scopes("read", "write", "trust")
- 			            .accessTokenValiditySeconds(60)
-		 		    .and()
-	 		        .withClient("my-trusted-client-with-secret")
- 			            .authorizedGrantTypes("password", "authorization_code", "refresh_token", "implicit")
- 			            .authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT")
- 			            .scopes("read", "write", "trust")
- 			            .secret("somesecret")
-	 		        .and()
- 		            .withClient("my-less-trusted-client")
-			            .authorizedGrantTypes("authorization_code", "implicit")
-			            .authorities("ROLE_CLIENT")
-			            .scopes("read", "write", "trust")
-     		        .and()
-		            .withClient("my-less-trusted-autoapprove-client")
-		                .authorizedGrantTypes("implicit")
-		                .authorities("ROLE_CLIENT")
-		                .scopes("read", "write", "trust")
-		                .autoApprove(true);
-			// @formatter:on
-		}
+      // @formatter:off
+      clients.inMemory().withClient("tonr")
+          .resourceIds(SPARKLR_RESOURCE_ID)
+          .authorizedGrantTypes("authorization_code", "implicit")
+          .authorities("ROLE_CLIENT")
+          .scopes("read", "write")
+          .secret("secret")
+          .and()
+          .withClient("tonr-with-redirect")
+          .resourceIds(SPARKLR_RESOURCE_ID)
+          .authorizedGrantTypes("authorization_code", "implicit")
+          .authorities("ROLE_CLIENT")
+          .scopes("read", "write")
+          .secret("secret")
+          .redirectUris(tonrRedirectUri)
+          .and()
+          .withClient("my-client-with-registered-redirect")
+          .resourceIds(SPARKLR_RESOURCE_ID)
+          .authorizedGrantTypes("authorization_code", "client_credentials")
+          .authorities("ROLE_CLIENT")
+          .scopes("read", "trust")
+          .redirectUris("http://anywhere?key=value")
+          .and()
+          .withClient("my-trusted-client")
+          .authorizedGrantTypes("password", "authorization_code", "refresh_token", "implicit")
+          .authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT")
+          .scopes("read", "write", "trust")
+          .accessTokenValiditySeconds(60)
+          .and()
+          .withClient("my-trusted-client-with-secret")
+          .authorizedGrantTypes("password", "authorization_code", "refresh_token", "implicit")
+          .authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT")
+          .scopes("read", "write", "trust")
+          .secret("somesecret")
+          .and()
+          .withClient("my-less-trusted-client")
+          .authorizedGrantTypes("authorization_code", "implicit")
+          .authorities("ROLE_CLIENT")
+          .scopes("read", "write", "trust")
+          .and()
+          .withClient("my-less-trusted-autoapprove-client")
+          .authorizedGrantTypes("implicit")
+          .authorities("ROLE_CLIENT")
+          .scopes("read", "write", "trust")
+          .autoApprove(true);
+      // @formatter:on
+    }
 
-		@Bean
-		public TokenStore tokenStore() {
-			return new InMemoryTokenStore();
-		}
+    @Bean
+    public TokenStore tokenStore() {
+      return new InMemoryTokenStore();
+    }
 
-		@Override
-		public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
-			endpoints.tokenStore(tokenStore).userApprovalHandler(userApprovalHandler)
-					.authenticationManager(authenticationManager);
-		}
+    @Override
+    public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
+      endpoints.tokenStore(tokenStore).userApprovalHandler(userApprovalHandler)
+          .authenticationManager(authenticationManager);
+    }
 
-		@Override
-		public void configure(AuthorizationServerSecurityConfigurer oauthServer) throws Exception {
-			oauthServer.realm("sparklr2/client");
-		}
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer oauthServer) throws Exception {
+      oauthServer.realm("sparklr2/client");
+    }
 
-	}
-	
-	protected static class Stuff {
-	
-		@Autowired
-		private ClientDetailsService clientDetailsService;
+  }
 
-		@Autowired
-		private TokenStore tokenStore;
+  protected static class Stuff {
 
-		@Bean
-		public ApprovalStore approvalStore() throws Exception {
-			TokenApprovalStore store = new TokenApprovalStore();
-			store.setTokenStore(tokenStore);
-			return store;
-		}
+    @Autowired
+    private ClientDetailsService clientDetailsService;
 
-		@Bean
-		@Lazy
-		@Scope(proxyMode=ScopedProxyMode.TARGET_CLASS)
-		public SparklrUserApprovalHandler userApprovalHandler() throws Exception {
-			SparklrUserApprovalHandler handler = new SparklrUserApprovalHandler();
-			handler.setApprovalStore(approvalStore());
-			handler.setRequestFactory(new DefaultOAuth2RequestFactory(clientDetailsService));
-			handler.setClientDetailsService(clientDetailsService);
-			handler.setUseApprovalStore(true);
-			return handler;
-		}
-	}
+    @Autowired
+    private TokenStore tokenStore;
+
+    @Bean
+    public ApprovalStore approvalStore() throws Exception {
+      TokenApprovalStore store = new TokenApprovalStore();
+      store.setTokenStore(tokenStore);
+      return store;
+    }
+
+    @Bean
+    @Lazy
+    @Scope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+    public SparklrUserApprovalHandler userApprovalHandler() throws Exception {
+      SparklrUserApprovalHandler handler = new SparklrUserApprovalHandler();
+      handler.setApprovalStore(approvalStore());
+      handler.setRequestFactory(new DefaultOAuth2RequestFactory(clientDetailsService));
+      handler.setClientDetailsService(clientDetailsService);
+      handler.setUseApprovalStore(true);
+      return handler;
+    }
+  }
 
 }


### PR DESCRIPTION
The sparklr oauth2 sample compiled failed because the package of InMemoryTokenStore.java has been moved to `org.springframework.security.oauth2.provider.token`. I modified the import statement.
