### PR TITLE
Update UserApprovalHandler updateAfterApproval() documentation.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/UserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/UserApprovalHandler.java
@@ -42,7 +42,7 @@ public interface UserApprovalHandler {
 
 	/**
 	 * <p>
-	 * Provides an opportunity to update the authorization request before it is checked for approval in cases where the
+	 * Provides an opportunity to update the authorization request after it is checked for approval in cases where the
 	 * incoming approval parameters contain richer information than just true/false (e.g. some scopes are approved, and
 	 * others are rejected), implementations may need to be able to modify the {@link AuthorizationRequest} before a
 	 * token is generated from it.


### PR DESCRIPTION
The comment states that updateAfterApproval() is called _before_ the request is checked for approval. I believe that it should say _after_.

If it turns out that it is called before approval perhaps the method should be renamed or someone who is more familiar with the code should review this.
