### PR TITLE
Fix naming, match constructor args to fields

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2Authentication.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/OAuth2Authentication.java
@@ -21,12 +21,12 @@ public class OAuth2Authentication extends AbstractAuthenticationToken {
 	 * Construct an OAuth 2 authentication. Since some grant types don't require user authentication, the user
 	 * authentication may be null.
 	 * 
-	 * @param authorizationRequest The authorization request (must not be null).
+	 * @param storedRequest The authorization request (must not be null).
 	 * @param userAuthentication The user authentication (possibly null).
 	 */
-	public OAuth2Authentication(OAuth2Request clientAuthentication, Authentication userAuthentication) {
-		super(userAuthentication == null ? clientAuthentication.getAuthorities() : userAuthentication.getAuthorities());
-		this.storedRequest = clientAuthentication;
+	public OAuth2Authentication(OAuth2Request storedRequest, Authentication userAuthentication) {
+		super(userAuthentication == null ? storedRequest.getAuthorities() : userAuthentication.getAuthorities());
+		this.storedRequest = storedRequest;
 		this.userAuthentication = userAuthentication;
 	}
 


### PR DESCRIPTION
I'm using spring-data to persist the OAuth2Authentication in a MongoDB. When reading the OAuth2Authentication from MongoDB this excpetion is thrown.

```
org.springframework.data.mapping.model.MappingException: No property clientAuthentication found on entity class org.springframework.security.oauth2.provider.OAuth2Authentication to bind constructor parameter to!
```

( I know it's kind of risky to rely on the automatic mapping for classes that you do not own :smirk: )
