### PR TITLE
fix logout config

### DIFF
--- a/samples/oauth2/tonr/src/main/java/org/springframework/security/oauth/examples/config/SecurityConfig.java
+++ b/samples/oauth2/tonr/src/main/java/org/springframework/security/oauth/examples/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .logout()
                 .logoutSuccessUrl("/login.jsp")
                 .logoutUrl("/logout.do")
+                //.logoutRequestMatcher(new AntPathRequestMatcher("/logout.do", "GET"))
                 .permitAll()
                 .and()
             .formLogin()
@@ -40,7 +41,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .failureUrl("/login.jsp?authentication_error=true")
                 .usernameParameter("j_username")
                 .passwordParameter("j_password")
-                .permitAll();
+                .permitAll()
+                .and()
+            .csrf().disable();
     	// @formatter:on
 	}
 


### PR DESCRIPTION
spring-security not support calling logout url by "GET" method when CSRF enabled.
we need to choose between to disable CSRF or set logoutRequestMatcher instead of logoutUrl.
otherwise, 404 return, when request "/logout.do"
