### PR TITLE
Fix IllegalArgumentException when scope is a String instead of a collect...

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
@@ -68,7 +68,7 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 		}
 		Object authorities = map.get(AUTHORITIES);
 		if (authorities instanceof String) {
-			AuthorityUtils.commaSeparatedStringToAuthorityList((String) authorities);
+			return AuthorityUtils.commaSeparatedStringToAuthorityList((String) authorities);
 		}
 		if (authorities instanceof Collection) {
 			return AuthorityUtils.commaSeparatedStringToAuthorityList(StringUtils

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverterTests.java
@@ -1,0 +1,51 @@
+package org.springframework.security.oauth2.provider.token;
+
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: saket
+ * Date: 29/09/2014
+ * Time: 16:25
+ * To change this template use File | Settings | File Templates.
+ */
+
+public class DefaultUserAuthenticationConverterTests {
+    private UserAuthenticationConverter converter = new DefaultUserAuthenticationConverter();
+
+    @Test
+    public void shouldExtractAuthenticationWhenAuthoritiesIsCollection() throws Exception {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put(UserAuthenticationConverter.USERNAME, "test_user");
+        ArrayList<String> lists = new ArrayList<String>();
+        lists.add("a1");
+        lists.add("a2");
+        map.put(UserAuthenticationConverter.AUTHORITIES, lists);
+
+        Authentication authentication = converter.extractAuthentication(map);
+
+        assertNotEquals(authentication.getAuthorities(), null);
+        assertEquals(authentication.getAuthorities().size(), 2);
+    }
+
+    @Test
+    public void shouldExtractAuthenticationWhenAuthoritiesIsString() throws Exception {
+        Map<String, Object> map = new HashMap<String, Object>();
+        map.put(UserAuthenticationConverter.USERNAME, "test_user");
+        map.put(UserAuthenticationConverter.AUTHORITIES, "a1,a2");
+
+        Authentication authentication = converter.extractAuthentication(map);
+
+        assertNotEquals(authentication.getAuthorities(), null);
+        assertEquals(authentication.getAuthorities().size(), 2);
+    }
+}
+


### PR DESCRIPTION
When the value under the scope attribute in the incoming map was a String instead of a Collection it was failing with an IllegalArgumentException even when it is clear from the message that String and Collection are acceptable values. Bug is due to missing return statement which is now fixed.
