### PR TITLE
Add findTokensByUserName method to JdbcTokenStore

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.java
@@ -49,6 +49,8 @@ public class JdbcTokenStore implements TokenStore {
 
 	private static final String DEFAULT_ACCESS_TOKENS_FROM_USERNAME_AND_CLIENT_SELECT_STATEMENT = "select token_id, token from oauth_access_token where user_name = ? and client_id = ?";
 
+	private static final String DEFAULT_ACCESS_TOKENS_FROM_USERNAME_SELECT_STATEMENT = "select token_id, token from oauth_access_token where user_name = ?";
+
 	private static final String DEFAULT_ACCESS_TOKENS_FROM_CLIENTID_SELECT_STATEMENT = "select token_id, token from oauth_access_token where client_id = ?";
 
 	private static final String DEFAULT_ACCESS_TOKEN_DELETE_STATEMENT = "delete from oauth_access_token where token_id = ?";
@@ -72,6 +74,8 @@ public class JdbcTokenStore implements TokenStore {
 	private String selectAccessTokenFromAuthenticationSql = DEFAULT_ACCESS_TOKEN_FROM_AUTHENTICATION_SELECT_STATEMENT;
 
 	private String selectAccessTokensFromUserNameAndClientIdSql = DEFAULT_ACCESS_TOKENS_FROM_USERNAME_AND_CLIENT_SELECT_STATEMENT;
+
+	private String selectAccessTokensFromUserNameSql = DEFAULT_ACCESS_TOKENS_FROM_USERNAME_SELECT_STATEMENT;
 
 	private String selectAccessTokensFromClientIdSql = DEFAULT_ACCESS_TOKENS_FROM_CLIENTID_SELECT_STATEMENT;
 
@@ -300,6 +304,22 @@ public class JdbcTokenStore implements TokenStore {
 		return accessTokens;
 	}
 
+	public Collection<OAuth2AccessToken> findTokensByUserName(String userName) {
+		List<OAuth2AccessToken> accessTokens = new ArrayList<OAuth2AccessToken>();
+
+		try {
+			accessTokens = jdbcTemplate.query(selectAccessTokensFromUserNameSql, new SafeAccessTokenRowMapper(),
+					userName);
+		}
+		catch (EmptyResultDataAccessException e) {
+			if (LOG.isInfoEnabled())
+				LOG.info("Failed to find access token for userName " + userName);
+		}
+		accessTokens = removeNulls(accessTokens);
+
+		return accessTokens;
+	}
+
 	public Collection<OAuth2AccessToken> findTokensByClientIdAndUserName(String clientId, String userName) {
 		List<OAuth2AccessToken> accessTokens = new ArrayList<OAuth2AccessToken>();
 
@@ -309,7 +329,7 @@ public class JdbcTokenStore implements TokenStore {
 		}
 		catch (EmptyResultDataAccessException e) {
 			if (LOG.isInfoEnabled()) {
-				LOG.info("Failed to find access token for userName " + userName);
+				LOG.info("Failed to find access token for clientId " + clientId + " and userName " + userName);
 			}
 		}
 		accessTokens = removeNulls(accessTokens);
@@ -425,12 +445,16 @@ public class JdbcTokenStore implements TokenStore {
 		this.deleteAccessTokenFromRefreshTokenSql = deleteAccessTokenFromRefreshTokenSql;
 	}
 
-  public void setSelectAccessTokensFromUserNameAndClientIdSql(String selectAccessTokensFromUserNameAndClientIdSql) {
-    this.selectAccessTokensFromUserNameAndClientIdSql = selectAccessTokensFromUserNameAndClientIdSql;
-  }
+	public void setSelectAccessTokensFromUserNameSql(String selectAccessTokensFromUserNameSql) {
+		this.selectAccessTokensFromUserNameSql = selectAccessTokensFromUserNameSql;
+	}
 
-  public void setSelectAccessTokensFromClientIdSql(String selectAccessTokensFromClientIdSql) {
-    this.selectAccessTokensFromClientIdSql = selectAccessTokensFromClientIdSql;
-  }
+	public void setSelectAccessTokensFromUserNameAndClientIdSql(String selectAccessTokensFromUserNameAndClientIdSql) {
+		this.selectAccessTokensFromUserNameAndClientIdSql = selectAccessTokensFromUserNameAndClientIdSql;
+	}
+
+	public void setSelectAccessTokensFromClientIdSql(String selectAccessTokensFromClientIdSql) {
+		this.selectAccessTokensFromClientIdSql = selectAccessTokensFromClientIdSql;
+	}
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStoreTests.java
@@ -1,10 +1,18 @@
 package org.springframework.security.oauth2.provider.token.store;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.RequestTokenFactory;
 
 /**
  * @author Dave Syer
@@ -26,6 +34,16 @@ public class JdbcTokenStoreTests extends TokenStoreBaseTests {
 		// creates a HSQL in-memory db populated from default scripts classpath:schema.sql and classpath:data.sql
 		db = new EmbeddedDatabaseBuilder().addDefaultScripts().build();
 		tokenStore = new JdbcTokenStore(db);
+	}
+
+	@Test
+	public void testFindAccessTokensByUserName() {
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request("id", false), new TestAuthentication("test2", false));
+		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
+		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
+
+		Collection<OAuth2AccessToken> actualOAuth2AccessTokens = getTokenStore().findTokensByUserName("test2");
+		assertEquals(1, actualOAuth2AccessTokens.size());
 	}
 
 	@After

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/TokenStoreBaseTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/TokenStoreBaseTests.java
@@ -100,7 +100,7 @@ public abstract class TokenStoreBaseTests {
 	}
 
 	@Test
-	public void testFindAccessTokensByUserName() {
+	public void testFindAccessTokensByClientIdAndUserName() {
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(RequestTokenFactory.createOAuth2Request("id", false), new TestAuthentication("test2", false));
 		OAuth2AccessToken expectedOAuth2AccessToken = new DefaultOAuth2AccessToken("testToken");
 		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);


### PR DESCRIPTION
This method adds method which was previously available in [TokenStore](https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/TokenStore.java)
and was changed under gh-182 to:

``` java
Collection<OAuth2AccessToken> findTokensByClientIdAndUserName(String clientId, String userName);
```

under this pull request original method was added to [JdbcTokenStore](https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.java) 

See related discussion under [commit comment](https://github.com/spring-projects/spring-security-oauth/commit/c0961fd84bcf895cf00e8e03daf131bd326cd3d7#commitcomment-8410827)
