### PR TITLE
Fix the sample sparklr2 start error.

### DIFF
--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/WebMvcConfig.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
@@ -97,7 +98,7 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
 
 
 	@Bean
-	public AdminController adminController(TokenStore tokenStore, ConsumerTokenServices tokenServices,
+	public AdminController adminController(TokenStore tokenStore, @Qualifier("consumerTokenServices") ConsumerTokenServices tokenServices,
 			SparklrUserApprovalHandler userApprovalHandler) {
 		AdminController adminController = new AdminController();
 		adminController.setTokenStore(tokenStore);


### PR DESCRIPTION
Add `@Qualifier("consumerTokenServices")` to fix the start error.

``` java
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'adminController' defined in class path resource [org/springframework/security/oauth/examples/sparklr/config/WebMvcConfig.class]: Unsatisfied dependency expressed through constructor argument with index 1 of type [org.springframework.security.oauth2.provider.token.ConsumerTokenServices]: : No qualifying bean of type [org.springframework.security.oauth2.provider.token.ConsumerTokenServices] is defined: expected single matching bean but found 2: consumerTokenServices,defaultAuthorizationServerTokenServices; 
```
