### PR TITLE
Restricted token endpoint to HTTP POST by default.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configuration/AuthorizationServerEndpointsConfiguration.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configuration/AuthorizationServerEndpointsConfiguration.java
@@ -15,6 +15,7 @@ package org.springframework.security.oauth2.config.annotation.web.configuration;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
@@ -28,6 +29,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProce
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerEndpointsConfiguration.TokenKeyEndpointRegistrar;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
@@ -99,6 +101,7 @@ public class AuthorizationServerEndpointsConfiguration {
 		tokenEndpoint.setTokenGranter(tokenGranter());
 		tokenEndpoint.setOAuth2RequestFactory(oauth2RequestFactory());
 		tokenEndpoint.setOAuth2RequestValidator(oauth2RequestValidator());
+		tokenEndpoint.setAllowedRequestMethods(allowedTokenEndpointRequestMethods());
 		return tokenEndpoint;
 	}
 
@@ -151,6 +154,10 @@ public class AuthorizationServerEndpointsConfiguration {
 			endpoints.tokenServices(defaultAuthorizationServerTokenServices());
 		}
 		return endpoints;
+	}
+
+	private Set<HttpMethod> allowedTokenEndpointRequestMethods() {
+		return getEndpoints().getAllowedTokenEndpointRequestMethods();
 	}
 
 	private OAuth2RequestFactory oauth2RequestFactory() throws Exception {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
@@ -15,11 +15,9 @@
  */
 package org.springframework.security.oauth2.config.annotation.web.configurers;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 import org.springframework.security.oauth2.provider.CompositeTokenGranter;
@@ -96,6 +94,8 @@ public final class AuthorizationServerEndpointsConfigurer {
 	private String prefix;
 
 	private Map<String, String> patternMap = new HashMap<String, String>();
+
+	private Set<HttpMethod> allowedTokenEndpointRequestMethods = new HashSet<HttpMethod>();
 
 	private FrameworkEndpointHandlerMapping frameworkEndpointHandlerMapping;
 
@@ -243,6 +243,11 @@ public final class AuthorizationServerEndpointsConfigurer {
 		return this;
 	}
 
+	public AuthorizationServerEndpointsConfigurer allowedTokenEndpointRequestMethods(HttpMethod... requestMethods) {
+		Collections.addAll(allowedTokenEndpointRequestMethods, requestMethods);
+		return this;
+	}
+
 	public ConsumerTokenServices getConsumerTokenServices() {
 		return consumerTokenServices();
 	}
@@ -253,6 +258,10 @@ public final class AuthorizationServerEndpointsConfigurer {
 
 	public AuthorizationCodeServices getAuthorizationCodeServices() {
 		return authorizationCodeServices();
+	}
+
+	public Set<HttpMethod> getAllowedTokenEndpointRequestMethods() {
+		return allowedTokenEndpointRequestMethods();
 	}
 
 	public OAuth2RequestValidator getRequestValidator() {
@@ -275,6 +284,14 @@ public final class AuthorizationServerEndpointsConfigurer {
 			resourceTokenServices = createDefaultTokenServices();
 		}
 		return resourceTokenServices;
+	}
+
+	private Set<HttpMethod> allowedTokenEndpointRequestMethods() {
+		// HTTP POST should be the only allowed endpoint request method by default.
+		if (allowedTokenEndpointRequestMethods.isEmpty()) {
+			allowedTokenEndpointRequestMethods.add(HttpMethod.POST);
+		}
+		return allowedTokenEndpointRequestMethods;
 	}
 
 	private ConsumerTokenServices consumerTokenServices() {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -17,10 +17,10 @@
 package org.springframework.security.oauth2.provider.endpoint;
 
 import java.security.Principal;
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -40,9 +40,9 @@ import org.springframework.security.oauth2.provider.OAuth2RequestValidator;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestValidator;
 import org.springframework.util.StringUtils;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -67,9 +67,15 @@ public class TokenEndpoint extends AbstractEndpoint {
 
 	private OAuth2RequestValidator oAuth2RequestValidator = new DefaultOAuth2RequestValidator();
 
-	@RequestMapping(value = "/oauth/token", method = RequestMethod.POST)
+	private Set<HttpMethod> allowedRequestMethods = new HashSet<HttpMethod>(Arrays.asList(HttpMethod.POST));
+
+	@RequestMapping(value = "/oauth/token")
 	public ResponseEntity<OAuth2AccessToken> getAccessToken(Principal principal, @RequestParam
-	Map<String, String> parameters) {
+	Map<String, String> parameters, HttpMethod requestMethod) throws HttpRequestMethodNotSupportedException {
+
+		if (!allowedRequestMethods.contains(requestMethod)) {
+			throw new HttpRequestMethodNotSupportedException(requestMethod.toString());
+		}
 
 		if (!(principal instanceof Authentication)) {
 			throw new InsufficientAuthenticationException(
@@ -170,4 +176,7 @@ public class TokenEndpoint extends AbstractEndpoint {
 		this.oAuth2RequestValidator = oAuth2RequestValidator;
 	}
 
+	public void setAllowedRequestMethods(Set<HttpMethod> allowedRequestMethods) {
+		this.allowedRequestMethods = allowedRequestMethods;
+	}
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -42,6 +42,7 @@ import org.springframework.security.oauth2.provider.request.DefaultOAuth2Request
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -66,7 +67,7 @@ public class TokenEndpoint extends AbstractEndpoint {
 
 	private OAuth2RequestValidator oAuth2RequestValidator = new DefaultOAuth2RequestValidator();
 
-	@RequestMapping(value = "/oauth/token")
+	@RequestMapping(value = "/oauth/token", method = RequestMethod.POST)
 	public ResponseEntity<OAuth2AccessToken> getAccessToken(Principal principal, @RequestParam
 	Map<String, String> parameters) {
 


### PR DESCRIPTION
Restricted the token endpoint to only allow HTTP POST requests by default. Proposed solution to https://github.com/spring-projects/spring-security-oauth/issues/327