### PR TITLE
#351: added setter for reuseRefreshToken in AuthorizationServerEndpoints...

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
@@ -157,8 +157,8 @@ public final class AuthorizationServerEndpointsConfigurer {
 		return this;
 	}
 
-	public AuthorizationServerEndpointsConfigurer reuseRefreshTokens() {
-		this.reuseRefreshToken = true;
+	public AuthorizationServerEndpointsConfigurer reuseRefreshTokens(boolean reuseRefreshToken) {
+		this.reuseRefreshToken = reuseRefreshToken;
 		return this;
 	}
 


### PR DESCRIPTION
Added setter to AuthorizationServerEndpointsConfigurer which makes the reuse of the refresh token flexible. Choosen this above renaming the method to doNotReuseRefreshToken or setting the default value of reuseRefreshToken to false which would conflict the default value of DefaultTokenServices.