### PR TITLE
Convert client authorities to a set of strings.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -54,7 +55,8 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 			response.putAll(userTokenConverter.convertUserAuthentication(authentication.getUserAuthentication()));
 		} else {
 			if (clientToken.getAuthorities()!=null && !clientToken.getAuthorities().isEmpty()) {
-				response.put(UserAuthenticationConverter.AUTHORITIES, clientToken.getAuthorities());
+				response.put(UserAuthenticationConverter.AUTHORITIES,
+							 AuthorityUtils.authorityListToSet(clientToken.getAuthorities()));
 			}
 		}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
@@ -13,9 +13,9 @@
 
 package org.springframework.security.oauth2.provider.token;
 
+import static java.util.Collections.singleton;
 import static org.junit.Assert.*;
 
-import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
@@ -34,18 +34,21 @@ import org.springframework.security.oauth2.provider.RequestTokenFactory;
  */
 public class DefaultAccessTokenConverterTests {
 
+	private String ROLE_CLIENT = "ROLE_CLIENT";
+	private String ROLE_USER = "ROLE_USER";
+
 	private DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
 
 	private UsernamePasswordAuthenticationToken userAuthentication = new UsernamePasswordAuthenticationToken("foo",
-			"bar", Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
+			"bar", singleton(new SimpleGrantedAuthority(ROLE_USER)));
 
 	private OAuth2Request request;
 
 	@Before
 	public void init() {
 		request = RequestTokenFactory.createOAuth2Request(null, "id",
-				AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_CLIENT"), true, Collections.singleton("read"),
-				Collections.singleton("resource"), null, null, null);
+				AuthorityUtils.commaSeparatedStringToAuthorityList(ROLE_CLIENT), true, singleton("read"),
+				singleton("resource"), null, null, null);
 	}
 
 	@Test
@@ -57,6 +60,7 @@ public class DefaultAccessTokenConverterTests {
 		assertTrue(map.containsKey(AccessTokenConverter.AUD));
 		assertTrue(map.containsKey(AccessTokenConverter.SCOPE));
 		assertTrue(map.containsKey(AccessTokenConverter.AUTHORITIES));
+		assertEquals(singleton(ROLE_USER), map.get(AccessTokenConverter.AUTHORITIES));
 		OAuth2Authentication extracted = converter.extractAuthentication(map);
 		assertTrue(extracted.getOAuth2Request().getResourceIds().contains("resource"));
 	}
@@ -70,6 +74,7 @@ public class DefaultAccessTokenConverterTests {
 		assertTrue(map.containsKey(AccessTokenConverter.AUD));
 		assertTrue(map.containsKey(AccessTokenConverter.SCOPE));
 		assertTrue(map.containsKey(AccessTokenConverter.AUTHORITIES));
+		assertEquals(singleton(ROLE_CLIENT), map.get(AccessTokenConverter.AUTHORITIES));
 		OAuth2Authentication extracted = converter.extractAuthentication(map);
 		assertTrue(extracted.getOAuth2Request().getResourceIds().contains("resource"));
 	}


### PR DESCRIPTION
4ab43f06317a2ac2f93877dbfe2189d479fb840c added client authorities to the response of `/check_token`, but unfortunately using another type as user authorities: Client tokens are a collection of `GrantedAuthority` while user tokens are a set of strings. This results in differing JSON represantations:

```json
{
"authorities": [
    {
      "authority": "ROLE_CLIENT"
    }
  ]
}
```

vs.

```json
{
"authorities": [
    "ROLE_USER"
  ]
}
```

This pull requests changes the client authorities to be also a set of strings.