### PR TITLE
ISSUE #362

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2ExpressionParser.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2ExpressionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,27 +31,27 @@ import org.springframework.util.Assert;
  * Note: The implication is that all expressions that are parsed must return a boolean result. This expectation is
  * already true since Spring Security expects the result to be a boolean.
  * </p>
- * 
+ *
  * @author Rob Winch
- * 
+ *
  */
-final class OAuth2ExpressionParser implements ExpressionParser {
-	private final ExpressionParser delegate;
+public final class OAuth2ExpressionParser implements ExpressionParser {
+    private final ExpressionParser delegate;
 
-	public OAuth2ExpressionParser(ExpressionParser delegate) {
-		Assert.notNull(delegate, "delegate cannot be null");
-		this.delegate = delegate;
-	}
+    public OAuth2ExpressionParser(ExpressionParser delegate) {
+        Assert.notNull(delegate, "delegate cannot be null");
+        this.delegate = delegate;
+    }
 
-	public Expression parseExpression(String expressionString) throws ParseException {
-		return delegate.parseExpression(wrapExpression(expressionString));
-	}
+    public Expression parseExpression(String expressionString) throws ParseException {
+        return delegate.parseExpression(wrapExpression(expressionString));
+    }
 
-	public Expression parseExpression(String expressionString, ParserContext context) throws ParseException {
-		return delegate.parseExpression(wrapExpression(expressionString), context);
-	}
+    public Expression parseExpression(String expressionString, ParserContext context) throws ParseException {
+        return delegate.parseExpression(wrapExpression(expressionString), context);
+    }
 
-	private String wrapExpression(String expressionString) {
-		return "#oauth2.throwOnError(" + expressionString + ")";
-	}
+    private String wrapExpression(String expressionString) {
+        return "#oauth2.throwOnError(" + expressionString + ")";
+    }
 }


### PR DESCRIPTION
OAuth2ExpressionParser class should be public to be instantiable

I work on a project with complex dynamic security access rules.
We implemented our own SecurityExpressionHandler where we want to
instantiate OAuth2ExpressionParser but can't because it's package
protected.