### PR TITLE
Support “out of band” callback

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelOutOfBandRedirectEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelOutOfBandRedirectEndpoint.java
@@ -1,0 +1,67 @@
+package org.springframework.security.oauth2.provider.endpoint;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.util.UriUtils;
+
+/**
+ * Controller for displaying authorization code for the authorization server.
+ * 
+ * @author Miyamoto Daisuke
+ */
+@FrameworkEndpoint
+public class WhitelabelOutOfBandRedirectEndpoint {
+	
+	private static final Pattern VALID_PATTERN = Pattern.compile("^[ 0-9A-Za-z%_]*$");
+
+	@RequestMapping("/oauth/oob")
+	public ModelAndView getAuthorizationCodeDisplay(Map<String, Object> model,
+			@RequestParam(value = "code", required= false) String code,
+			@RequestParam(value = "error", required= false) String error,
+			@RequestParam(value = "error_description", required= false) String desc,
+			@RequestParam(value = "state", required= false) String state) throws Exception {
+		
+		String template;
+		if (StringUtils.isEmpty(error)) {
+			template = SUCCESS_TEMPLATE
+					.replace("%code%", sanitize(code))
+					.replace("%codeq%", UriUtils.encodeQueryParam(sanitize(code), "UTF-8"));
+		} else {
+			template = ERROR_TEMPLATE
+					.replace("%error%", sanitize(error))
+					.replace("%errorq%", UriUtils.encodeQueryParam(sanitize(error), "UTF-8"))
+					.replace("%desc%", sanitize(desc))
+					.replace("%descq%", StringUtils.isEmpty(desc) ? "" : "&error_description="
+							+ UriUtils.encodeQueryParam(sanitize(desc), "UTF-8"));
+		}
+		template = template.replace("%stateq%", StringUtils.isEmpty(state) ? "" : "&state="
+				+ UriUtils.encodeQueryParam(sanitize(state), "UTF-8"));
+		return new ModelAndView(new SpelView(template), model);
+	}
+
+	protected String sanitize(String input) {
+		if (VALID_PATTERN.matcher(input).matches()) {
+			return input;
+		}
+		return "invalid";
+	}
+
+	private static String SUCCESS_TEMPLATE = "<html><head>"
+			+ "<title>Success code=%codeq%%stateq%</title>"
+			+ "</head><body><h1>OAuth Authorization Code</h1>"
+			+ "<p>Copy and paste this code to your mobile phones or command-line utilities.</p>"
+			+ "<p>Code: %code%</p>"
+			+ "</body></html>";
+
+	private static String ERROR_TEMPLATE = "<html><head>"
+			+ "<title>Denied error=%errorq%%descq%%stateq%</title>"
+			+ "</head><body><h1>OAuth Authorization Code</h1>"
+			+ "<p>Error: %error%</p>"
+			+ "<p>Description: %desc%</p>"
+			+ "</body></html>";
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelOutOfBandRedirectEndpointTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelOutOfBandRedirectEndpointTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package org.springframework.security.oauth2.provider.endpoint;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * @author Miyamoto Daisuke
+ *
+ */
+public class WhitelabelOutOfBandRedirectEndpointTests {
+	
+	private WhitelabelOutOfBandRedirectEndpoint endpoint = new WhitelabelOutOfBandRedirectEndpoint();
+	private MockHttpServletRequest request = new MockHttpServletRequest();
+	private MockHttpServletResponse response = new MockHttpServletResponse();
+
+	@Test
+	public void testOutOfBandRedirectPage() throws Exception {
+		request.setContextPath("/foo");
+		HashMap<String, Object> model = new HashMap<String, Object>();
+		String code = "thecode";
+		String err = null;
+		String desc = null;
+		String state = "thestate";
+		ModelAndView result = endpoint.getAuthorizationCodeDisplay(model, code, err, desc, state);
+		result.getView().render(result.getModel(), request , response);
+		String content = response.getContentAsString();
+		assertTrue("Wrong content: " + content, content.contains("<title>Success code=thecode&state=thestate</title>"));
+		assertTrue("Wrong content: " + content, content.contains("Authorization Code"));
+		assertTrue("Wrong content: " + content, content.contains(": thecode"));
+		assertTrue("Wrong content: " + content, !content.contains("${"));
+		assertTrue("Wrong content: " + content, !content.contains("%"));
+	}
+
+	@Test
+	public void testOutOfBandRedirectPageWithUnexpectedCode() throws Exception {
+		request.setContextPath("/foo");
+		HashMap<String, Object> model = new HashMap<String, Object>();
+		String code = "<script>alert('hello, hello!');</script>";
+		String err = null;
+		String desc = null;
+		String state = "thestate";
+		ModelAndView result = endpoint.getAuthorizationCodeDisplay(model, code, err, desc, state);
+		result.getView().render(result.getModel(), request , response);
+		String content = response.getContentAsString();
+		assertTrue("Wrong content: " + content, content.contains("Authorization Code"));
+		assertTrue("Wrong content: " + content, content.contains("<title>Success code=invalid&state=thestate</title>"));
+		assertTrue("Wrong content: " + content, content.contains(": invalid"));
+		assertTrue("Wrong content: " + content, !content.contains("<script>alert('hello, hello!');</script>"));
+		assertTrue("Wrong content: " + content, !content.contains("${"));
+		assertTrue("Wrong content: " + content, !content.contains("%"));
+	}
+
+	@Test
+	public void testOutOfBandRedirectPageWithUnexpectedState() throws Exception {
+		request.setContextPath("/foo");
+		String code = "thecode";
+		String err = null;
+		String desc = null;
+		String state = "<script>alert('hello, hello!');</script>";
+		HashMap<String, Object> model = new HashMap<String, Object>();
+		ModelAndView result = endpoint.getAuthorizationCodeDisplay(model, code, err, desc, state);
+		result.getView().render(result.getModel(), request , response);
+		String content = response.getContentAsString();
+		assertTrue("Wrong content: " + content, content.contains("Authorization Code"));
+		assertTrue("Wrong content: " + content, content.contains("<title>Success code=thecode&state=invalid</title>"));
+		assertTrue("Wrong content: " + content, content.contains(": thecode"));
+		assertTrue("Wrong content: " + content, !content.contains("<script>alert('hello, hello!');</script>"));
+		assertTrue("Wrong content: " + content, !content.contains("${"));
+		assertTrue("Wrong content: " + content, !content.contains("%"));
+	}
+
+	@Test
+	public void testOutOfBandRedirectPageWithDeniedError() throws Exception {
+		request.setContextPath("/foo");
+		String code = null;
+		String err = "access_denied";
+		String desc = "User denied access";
+		String state = "thestate";
+		HashMap<String, Object> model = new HashMap<String, Object>();
+		ModelAndView result = endpoint.getAuthorizationCodeDisplay(model, code, err, desc, state);
+		result.getView().render(result.getModel(), request , response);
+		String content = response.getContentAsString();
+		assertTrue("Wrong content: " + content, content.contains("Authorization Code"));
+		assertTrue("Wrong content: " + content, content.contains("<title>Denied error=access_denied&error_description=User%20denied%20access&state=thestate</title>"));
+		assertTrue("Wrong content: " + content, content.contains(": access_denied"));
+		assertTrue("Wrong content: " + content, content.contains(": User denied access"));
+		assertTrue("Wrong content: " + content, !content.contains("${"));
+//		assertTrue("Wrong content: " + content, !content.contains("%")); // contains "%20"
+	}
+}


### PR DESCRIPTION
Redirect urn "urn:ietf:wg:oauth:2.0:oob" is for Out-Of-Band authentication (where the app cannot be reached by the authenticating BROWSER)
With this value, authorization server redirect the user to a special authorization result page that supports two use cases:

First, if your application can detect changes to the title bar of the browser window, the result of authorization request can be retrieved automatically. An authorization server sets the document title and that is typically available in the title bar of the browser window.

If the authorization request was approved, the title will look like this:

```
Success code=xxxxxx&state=yyyyyyyy
```

If the authorization request was denied or failed, the title will look like this:

```
Denied error=access_denied&error_description=User%20denied%20access&state=yyyyyyyy
```

Once your application has detected the change to the document title and successfully retrieved the code, the browser window can be closed automatically if possible.

When using this approach, it is important to limit the state parameter to a reasonable length to reduce the chance of truncation. We suggest no more than 10 characters.

Second, as a fallback solution, the authorization code will also be printed to the screen so that the user can manually copy and paste it into the client application.
