### PR TITLE
duplicated query parameters cause invalid signature

### DIFF
--- a/spring-security-oauth/src/main/java/org/springframework/security/oauth/consumer/client/OAuthClientHttpRequestFactory.java
+++ b/spring-security-oauth/src/main/java/org/springframework/security/oauth/consumer/client/OAuthClientHttpRequestFactory.java
@@ -52,7 +52,7 @@ public class OAuthClientHttpRequestFactory implements ClientHttpRequestFactory {
     if (!useAuthHeader) {
       String queryString = this.support.getOAuthQueryString(this.resource, accessToken, uri.toURL(), httpMethod.name(), this.additionalOAuthParameters);
       String uriValue = String.valueOf(uri);
-      uri = URI.create(uriValue.contains("?") ? uriValue + "&" + queryString : uriValue + "?" + queryString);
+      uri = URI.create((uriValue.contains("?") ? uriValue.substring(0, uriValue.indexOf('?')) : uriValue) + "?" + queryString);
     }
 
     ClientHttpRequest req = delegate.createRequest(uri, httpMethod);


### PR DESCRIPTION
If RESTful URI contains query string, the query string will be duplicated and break the OAuth signature.