### PR TITLE
Adding support for properly handling the HttpMethodNotSupported error

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -156,9 +156,9 @@ public class TokenEndpoint extends AbstractEndpoint {
 	}
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public void handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) throws Exception {
+	public ResponseEntity<OAuth2Exception> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) throws Exception {
 	    logger.info("Handling error: " + e.getClass().getSimpleName() + ", " + e.getMessage());
-	    throw e;
+	    return getExceptionTranslator().translate(e);
 	}
 	
 	@ExceptionHandler(Exception.class)

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/error/DefaultWebResponseExceptionTranslator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/error/DefaultWebResponseExceptionTranslator.java
@@ -63,7 +63,7 @@ public class DefaultWebResponseExceptionTranslator implements WebResponseExcepti
 		ase = (HttpRequestMethodNotSupportedException) throwableAnalyzer
 				.getFirstThrowableOfType(HttpRequestMethodNotSupportedException.class, causeChain);
 		if (ase instanceof HttpRequestMethodNotSupportedException) {
-			return handleOAuth2Exception(new BadRequest(ase.getMessage(), ase));
+			return handleOAuth2Exception(new MethodNotAllowed(ase.getMessage(), ase));
 		}
 
 		return handleOAuth2Exception(new ServerErrorException(e.getMessage(), e));
@@ -143,18 +143,18 @@ public class DefaultWebResponseExceptionTranslator implements WebResponseExcepti
 	}
 
 	@SuppressWarnings("serial")
-	private static class BadRequest extends OAuth2Exception {
+	private static class MethodNotAllowed extends OAuth2Exception {
 
-		public BadRequest(String msg, Throwable t) {
+		public MethodNotAllowed(String msg, Throwable t) {
 			super(msg, t);
 		}
 
 		public String getOAuth2ErrorCode() {
-			return "bad_request";
+			return "method_not_allowed";
 		}
 
 		public int getHttpErrorCode() {
-			return 400;
+			return 405;
 		}
 
 	}


### PR DESCRIPTION
We ran into a weird issue with the latest version of oauth where GET requests to the token endpoint resulted in a plain text (not xml or json) error to the user of "Internal Server Error" instead of a pretty message about GET's not being allowed.

This pull request handles `HttpRequestMethodNotSupportedException` the same as your other exceptions. The current code throws which is not allowed in a `@ExceptionHandler` handler. This change handles it like the other exceptions.

Then in order to not have the exception reveal itself as a 500 Server error I built in support for catching `HttpRequestMethodNotSupportedException` and turning them into a new `BadRequest` `OAuth2Exception`

The unit tests for `TokenEndpoint` aren't changed and there are no tests for `DefaultWebResponseExceptionTranslator` at the moment. I couldn't find the right place to add any type of integration tests (this is my first look into spring-security-oauth2 code) so if there is a proper place to add something please let me know and I'll add it.