### PR TITLE
Fix for inconsistency in the auto approval of scopes

### DIFF
--- a/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/oauth/SparklrUserApprovalHandler.java
+++ b/samples/oauth2/sparklr/src/main/java/org/springframework/security/oauth/examples/sparklr/oauth/SparklrUserApprovalHandler.java
@@ -77,7 +77,7 @@ public class SparklrUserApprovalHandler extends ApprovalStoreUserApprovalHandler
 					ClientDetails client = clientDetailsService
 							.loadClientByClientId(authorizationRequest.getClientId());
 					for (String scope : requestedScopes) {
-						if (client.isAutoApprove(scope) || client.isAutoApprove("all")) {
+						if (client.isAutoApprove(scope)) {
 							approved = true;
 							break;
 						}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
@@ -112,7 +112,7 @@ public class ApprovalStoreUserApprovalHandler implements UserApprovalHandler, In
 			try {
 				ClientDetails client = clientDetailsService.loadClientByClientId(clientId);
 				for (String scope : requestedScopes) {
-					if (client.isAutoApprove(scope) || client.isAutoApprove("all")) {
+					if (client.isAutoApprove(scope)) {
 						approvedScopes.add(scope);
 					}
 				}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/client/BaseClientDetailsTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/client/BaseClientDetailsTests.java
@@ -82,6 +82,12 @@ public class BaseClientDetailsTests {
 	}
 
 	@Test
+	public void testBaseClientDetailsNullAutoApprove() {
+		BaseClientDetails details = new BaseClientDetails("foo", "", "foo,bar", "authorization_code", "ROLE_USER");
+		assertFalse(details.isAutoApprove("read"));
+	}
+
+	@Test
 	public void testJsonSerialize() throws Exception {
 		BaseClientDetails details = new BaseClientDetails("foo", "", "foo,bar", "authorization_code", "ROLE_USER");
 		details.setClientId("foo");


### PR DESCRIPTION
Made the implementation of ClientDetails - e.g. the BaseClientDetails - solely
responsible for the decision if a scope can be auto approved. Marking a
ClientDetails - when using JdbcClientDetailsService - with 'true' for the
autoapprove value will still cause all scopes to be auto approved. The consent
screen will be skipped in this scenario.

Fixes gh-479