### PR TITLE
Parameter 'scopePrefix' is used in all methods.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
@@ -232,12 +232,12 @@ public class ApprovalStoreUserApprovalHandler implements UserApprovalHandler, In
 		model.putAll(authorizationRequest.getRequestParameters());
 		Map<String, String> scopes = new LinkedHashMap<String, String>();
 		for (String scope : authorizationRequest.getScope()) {
-			scopes.put(OAuth2Utils.SCOPE_PREFIX + scope, "false");
+			scopes.put(scopePrefix + scope, "false");
 		}
 		for (Approval approval : approvalStore.getApprovals(userAuthentication.getName(),
 				authorizationRequest.getClientId())) {
 			if (authorizationRequest.getScope().contains(approval.getScope())) {
-				scopes.put(OAuth2Utils.SCOPE_PREFIX + approval.getScope(),
+				scopes.put(scopePrefix + approval.getScope(),
 						approval.getStatus() == ApprovalStatus.APPROVED ? "true" : "false");
 			}
 		}


### PR DESCRIPTION
The parameter "scopePrefix" is only used in one method of the class - in the other the default "OAuth2Utils.SCOPE_PREFIX" is used - which is likely to not be intended here.