### PR TITLE
Make sure scope parameter in redirect url is encoded

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilter.java
@@ -108,7 +108,7 @@ public class OAuth2ClientContextFilter implements Filter, InitializingBean {
 		}
 
 		this.redirectStrategy.sendRedirect(request, response, builder.build()
-				.toUriString());
+				.encode().toUriString());
 	}
 
 	/**

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilterTests.java
@@ -29,6 +29,15 @@ public class OAuth2ClientContextFilterTests {
 	}
 
 	@Test
+	public void testTwoScopesRedirectUri() throws Exception {
+		String redirect = "http://example.com/authorize";
+		Map<String, String> params = new LinkedHashMap<String, String>();
+		params.put("foo", "bar");
+		params.put("scope", "spam scope2");
+		testRedirectUri(redirect, params, redirect + "?foo=bar&scope=spam%20scope2");
+	}
+
+	@Test
 	public void testRedirectUriWithUrlInParams() throws Exception {
 		String redirect = "http://example.com/authorize";
 		Map<String, String> params = Collections.singletonMap("redirect",


### PR DESCRIPTION
The authorization redirect url in the response location header can include spaces if there are multiple scopes. This is not valid and should be encoded.

This problem is introduced in version 2.0.7.