### PR TITLE
Made the redis client dependencies optional

### DIFF
--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -148,12 +148,14 @@
         	<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
 			<version>1.5.0.RELEASE</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
 			<version>2.6.3</version>
+			<optional>true</optional>
 		</dependency>
 
         <dependency>


### PR DESCRIPTION
I've made the redis dependencies optional, fallowing issue: https://github.com/spring-projects/spring-security-oauth/issues/561