### PR TITLE
Creating custom grant types based on existing ones enabled

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/CompositeTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/CompositeTokenGranter.java
@@ -42,5 +42,12 @@ public class CompositeTokenGranter implements TokenGranter {
 		}
 		return null;
 	}
+	
+	public void addTokenGranter(TokenGranter tokenGranter) {
+		if (tokenGranter == null) {
+			throw new IllegalArgumentException("Token granter is null");
+		}
+		tokenGranters.add(tokenGranter);
+	}
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/client/ClientCredentialsTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/client/ClientCredentialsTokenGranter.java
@@ -35,7 +35,12 @@ public class ClientCredentialsTokenGranter extends AbstractTokenGranter {
 
 	public ClientCredentialsTokenGranter(AuthorizationServerTokenServices tokenServices,
 			ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
-		super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+		this(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+	}
+
+	protected ClientCredentialsTokenGranter(AuthorizationServerTokenServices tokenServices,
+			ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory, String grantType) {
+		super(tokenServices, clientDetailsService, requestFactory, grantType);
 	}
 	
 	public void setAllowRefresh(boolean allowRefresh) {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
@@ -48,7 +48,12 @@ public class AuthorizationCodeTokenGranter extends AbstractTokenGranter {
 
 	public AuthorizationCodeTokenGranter(AuthorizationServerTokenServices tokenServices,
 			AuthorizationCodeServices authorizationCodeServices, ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
-		super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+		this(tokenServices, authorizationCodeServices, clientDetailsService, requestFactory, GRANT_TYPE);
+	}
+
+	protected AuthorizationCodeTokenGranter(AuthorizationServerTokenServices tokenServices, AuthorizationCodeServices authorizationCodeServices,
+			ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory, String grantType) {
+		super(tokenServices, clientDetailsService, requestFactory, grantType);
 		this.authorizationCodeServices = authorizationCodeServices;
 	}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/ImplicitTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/implicit/ImplicitTokenGranter.java
@@ -39,7 +39,12 @@ public class ImplicitTokenGranter extends AbstractTokenGranter {
 	private static final String GRANT_TYPE = "implicit";
 
 	public ImplicitTokenGranter(AuthorizationServerTokenServices tokenServices, ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
-		super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+		this(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+	}
+
+	protected ImplicitTokenGranter(AuthorizationServerTokenServices tokenServices, ClientDetailsService clientDetailsService,
+			OAuth2RequestFactory requestFactory, String grantType) {
+		super(tokenServices, clientDetailsService, requestFactory, grantType);
 	}
 
 	@Override

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/password/ResourceOwnerPasswordTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/password/ResourceOwnerPasswordTokenGranter.java
@@ -47,7 +47,12 @@ public class ResourceOwnerPasswordTokenGranter extends AbstractTokenGranter {
 
 	public ResourceOwnerPasswordTokenGranter(AuthenticationManager authenticationManager,
 			AuthorizationServerTokenServices tokenServices, ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
-		super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+		this(authenticationManager, tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+	}
+
+	protected ResourceOwnerPasswordTokenGranter(AuthenticationManager authenticationManager, AuthorizationServerTokenServices tokenServices,
+			ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory, String grantType) {
+		super(tokenServices, clientDetailsService, requestFactory, grantType);
 		this.authenticationManager = authenticationManager;
 	}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/refresh/RefreshTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/refresh/RefreshTokenGranter.java
@@ -33,7 +33,12 @@ public class RefreshTokenGranter extends AbstractTokenGranter {
 	private static final String GRANT_TYPE = "refresh_token";
 
 	public RefreshTokenGranter(AuthorizationServerTokenServices tokenServices, ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
-		super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+		this(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE);
+	}
+
+	protected RefreshTokenGranter(AuthorizationServerTokenServices tokenServices, ClientDetailsService clientDetailsService,
+			OAuth2RequestFactory requestFactory, String grantType) {
+		super(tokenServices, clientDetailsService, requestFactory, grantType);
 	}
 	
 	@Override


### PR DESCRIPTION
I have added additional, protected constructors to all available token granters.
The change will enable creating custom token granters (with custom grant type names) by subclassing existing ones.

I have also added a convenient method to `CompositeTokenGranter` to enable adding more token granters, which will allow to add custom granters to `AuthorizationServerEndpointsConfigurer` with less code.