### PR TITLE
Fix for losing authentication details on token refresh

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -193,7 +193,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 	 * @return The refreshed authentication.
 	 * @throws InvalidScopeException If the scope requested is invalid or wider than the original scope.
 	 */
-	private OAuth2Authentication createRefreshedAuthentication(OAuth2Authentication authentication, TokenRequest request) {
+	protected OAuth2Authentication createRefreshedAuthentication(OAuth2Authentication authentication, TokenRequest request) {
 		OAuth2Authentication narrowed = authentication;
 		Set<String> scope = request.getScope();
 		OAuth2Request clientAuth = authentication.getOAuth2Request().refresh(request);
@@ -208,6 +208,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 			}
 		}
 		narrowed = new OAuth2Authentication(clientAuth, authentication.getUserAuthentication());
+		narrowed.setDetails(authentication.getDetails());
 		return narrowed;
 	}
 


### PR DESCRIPTION
This fix is for the case when user implements custom
AccessTokenConverter that puts extra information into the token in
convertAccessToken and extracts it into Authentication inside
extractAuthentication.

Those details were lost on the refresh token code path.

The fix makes DefaultTokenServices to preserve the details much
like it is already doing so when user has supplied custom
AuthenticationManager.

The fix also changes createRefreshedAuthentication access level to
protected so that user can modify scope narrowing logic. That is
to conform to the access level of other similar methods, such as
isExpired.
