### PR TITLE
Change visibility of DefaultUserAuthenticationConverter#getAuthorities(Map) to ease extension

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
@@ -82,7 +82,7 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 		return null;
 	}
 
-	private Collection<? extends GrantedAuthority> getAuthorities(Map<String, ?> map) {
+	protected Collection<? extends GrantedAuthority> getAuthorities(Map<String, ?> map) {
 		if (!map.containsKey(AUTHORITIES)) {
 			return defaultAuthorities;
 		}


### PR DESCRIPTION
Change visibility of `DefaultUserAuthenticationConverter#getAuthorities(Map)` to ease extension
: private -> protected.

We wanted to add some custom user details at the authorization server level, so resource servers could access it while using the `/oauth/check_token` endpoint. Since we only added a couple attributes, we found out that extending `DefaultUserAuthenticationConverter` was really convenient, but it would have been even cooler if the `getAuthorities` method was protected instead of having to copy it.
