### PR TITLE
Alter AuthorizationServerSecurityConfigurer to allow custom authentication filters for the TokenEndpoint.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
@@ -74,7 +74,7 @@ public final class AuthorizationServerSecurityConfigurer extends
 	 * Custom authentication filters for the TokenEndpoint. Filters will be set upstream of the default
 	 * BasicAuthenticationFilter.
 	 */
-	private List<Filter> tokenEndpointCustomAuthenticationFilters = new ArrayList<Filter>();
+	private List<Filter> tokenEndpointAuthenticationFilters = new ArrayList<Filter>();
 
 	public AuthorizationServerSecurityConfigurer sslOnly() {
 		this.sslOnly = true;
@@ -184,7 +184,7 @@ public final class AuthorizationServerSecurityConfigurer extends
 			clientCredentialsTokenEndpointFilter(http);
 		}
 
-		for (Filter filter : tokenEndpointCustomAuthenticationFilters) {
+		for (Filter filter : tokenEndpointAuthenticationFilters) {
 			http.addFilterBefore(filter, BasicAuthenticationFilter.class);
 		}
 
@@ -223,8 +223,8 @@ public final class AuthorizationServerSecurityConfigurer extends
 	 * 
 	 * @param filter
 	 */
-	public void addTokenEndpointCustomAuthenticationFilter(Filter filter) {
-		this.tokenEndpointCustomAuthenticationFilters.add(filter);
+	public void addTokenEndpointAuthenticationFilter(Filter filter) {
+		this.tokenEndpointAuthenticationFilters.add(filter);
 	}
 
 	/**
@@ -233,8 +233,8 @@ public final class AuthorizationServerSecurityConfigurer extends
 	 * 
 	 * @param filters The authentication filters to set.
 	 */
-	public void tokenEndpointCustomAuthenticationFilters(List<Filter> filters) {
+	public void tokenEndpointAuthenticationFilters(List<Filter> filters) {
 		Assert.notNull(filters, "Custom authentication filter list must not be null");
-		this.tokenEndpointCustomAuthenticationFilters = new ArrayList<Filter>(filters);
+		this.tokenEndpointAuthenticationFilters = new ArrayList<Filter>(filters);
 	}
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.security.oauth2.config.annotation.web.configurers;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.Filter;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -36,6 +40,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.context.NullSecurityContextRepository;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.accept.ContentNegotiationStrategy;
 import org.springframework.web.accept.HeaderContentNegotiationStrategy;
@@ -64,6 +69,12 @@ public final class AuthorizationServerSecurityConfigurer extends
 	private String checkTokenAccess = "denyAll()";
 
 	private boolean sslOnly = false;
+
+	/**
+	 * Custom authentication filters for the TokenEndpoint. Filters will be set upstream of the default
+	 * BasicAuthenticationFilter.
+	 */
+	private List<Filter> tokenEndpointCustomAuthenticationFilters = new ArrayList<Filter>();
 
 	public AuthorizationServerSecurityConfigurer sslOnly() {
 		this.sslOnly = true;
@@ -172,8 +183,13 @@ public final class AuthorizationServerSecurityConfigurer extends
 		if (allowFormAuthenticationForClients) {
 			clientCredentialsTokenEndpointFilter(http);
 		}
+
+		for (Filter filter : tokenEndpointCustomAuthenticationFilters) {
+			http.addFilterBefore(filter, BasicAuthenticationFilter.class);
+		}
+
 		http.exceptionHandling().accessDeniedHandler(accessDeniedHandler);
-		if (sslOnly ) {
+		if (sslOnly) {
 			http.requiresChannel().anyRequest().requiresSecure();
 		}
 
@@ -201,4 +217,24 @@ public final class AuthorizationServerSecurityConfigurer extends
 		return getBuilder().getSharedObject(FrameworkEndpointHandlerMapping.class);
 	}
 
+	/**
+	 * Adds a new custom authentication filter for the TokenEndpoint. Filters will be set upstream of the default
+	 * BasicAuthenticationFilter.
+	 * 
+	 * @param filter
+	 */
+	public void addTokenEndpointCustomAuthenticationFilter(Filter filter) {
+		this.tokenEndpointCustomAuthenticationFilters.add(filter);
+	}
+
+	/**
+	 * Sets a new list of custom authentication filters for the TokenEndpoint. Filters will be set upstream of the
+	 * default BasicAuthenticationFilter.
+	 * 
+	 * @param filters The authentication filters to set.
+	 */
+	public void tokenEndpointCustomAuthenticationFilters(List<Filter> filters) {
+		Assert.notNull(filters, "Custom authentication filter list must not be null");
+		this.tokenEndpointCustomAuthenticationFilters = new ArrayList<Filter>(filters);
+	}
 }

--- a/tests/annotation/custom-authentication/README.md
+++ b/tests/annotation/custom-authentication/README.md
@@ -1,0 +1,3 @@
+This project tests a basic authorization server configuration, with a custom authentication filter on the `TokenEndpoint`.
+The authentication mechanism only authorizes one fixed client to pass. The client_id is taken from an HTTP parameter.
+

--- a/tests/annotation/custom-authentication/pom.xml
+++ b/tests/annotation/custom-authentication/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>spring-oauth2-tests-custom-authentication</artifactId>
+
+	<name>spring-oauth2-tests-custom-authentication</name>
+	<description>Demo project</description>
+
+	<parent>
+		<groupId>org.demo</groupId>
+		<artifactId>spring-oauth2-tests-parent</artifactId>
+		<version>2.0.8.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security.oauth</groupId>
+			<artifactId>spring-security-oauth2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.demo</groupId>
+			<artifactId>spring-oauth2-tests-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tests/annotation/custom-authentication/src/main/java/demo/Application.java
+++ b/tests/annotation/custom-authentication/src/main/java/demo/Application.java
@@ -69,7 +69,7 @@ public class Application {
 
 		@Override
 		public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
-			security.addTokenEndpointCustomAuthenticationFilter(new HardCodedAuthenticationFilter());
+			security.addTokenEndpointAuthenticationFilter(new HardCodedAuthenticationFilter());
 		}
 	}
 

--- a/tests/annotation/custom-authentication/src/main/java/demo/Application.java
+++ b/tests/annotation/custom-authentication/src/main/java/demo/Application.java
@@ -1,0 +1,76 @@
+package demo;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Configuration
+@EnableAutoConfiguration
+@EnableResourceServer
+@RestController
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+
+	@RequestMapping("/")
+	public String home() {
+		return "Hello World";
+	}
+
+	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public String create(@RequestBody MultiValueMap<String, String> map) {
+		return "OK";
+	}
+
+	@Configuration
+	@EnableAuthorizationServer
+	protected static class OAuth2Config extends AuthorizationServerConfigurerAdapter {
+
+		@Autowired
+		private AuthenticationManager authenticationManager;
+
+		@Override
+		public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
+			endpoints.authenticationManager(authenticationManager);
+		}
+
+		@Override
+		public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+			// @formatter:off
+			clients.inMemory().withClient("my-trusted-client")
+					.authorizedGrantTypes("password", "authorization_code", "refresh_token", "implicit")
+					.authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT").scopes("read", "write", "trust")
+					.resourceIds("oauth2-resource").accessTokenValiditySeconds(600).and()
+					.withClient("my-client-with-registered-redirect").authorizedGrantTypes("authorization_code")
+					.authorities("ROLE_CLIENT").scopes("read", "trust").resourceIds("oauth2-resource")
+					.redirectUris("http://anywhere?key=value").and().withClient("my-client-with-secret")
+					.authorizedGrantTypes("client_credentials", "password").authorities("ROLE_CLIENT").scopes("read")
+					.resourceIds("oauth2-resource").secret("secret");
+			// @formatter:on
+		}
+
+		@Override
+		public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
+			security.addTokenEndpointCustomAuthenticationFilter(new HardCodedAuthenticationFilter());
+		}
+	}
+
+}

--- a/tests/annotation/custom-authentication/src/main/java/demo/HardCodedAuthenticationFilter.java
+++ b/tests/annotation/custom-authentication/src/main/java/demo/HardCodedAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package demo;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
+
+/**
+ * Authentication filter that would only authenticate one client, using the
+ * "client_id" parameter.
+ * 
+ * @author mtecourt
+ *
+ */
+public class HardCodedAuthenticationFilter implements Filter {
+
+    private static final String AUTHORIZED_CLIENT_ID = "my-client-with-secret";
+    private static final List<GrantedAuthority> CLIENT_AUTHORITIES = AuthorityUtils
+            .commaSeparatedStringToAuthorityList("ROLE_CLIENT");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("CustomAuthenticationFilter");
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // NOPE
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+            ServletException {
+
+        String clientId = request.getParameter(OAuth2Utils.CLIENT_ID);
+
+        if (AUTHORIZED_CLIENT_ID.equals(clientId)) {
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    AUTHORIZED_CLIENT_ID, "", CLIENT_AUTHORITIES);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            LOGGER.info("Just authenticated : {}", clientId);
+        } else {
+            LOGGER.info("Did NOT authenticate : {}", clientId);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        // NOPE
+    }
+
+}

--- a/tests/annotation/custom-authentication/src/main/resources/application.yml
+++ b/tests/annotation/custom-authentication/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name: vanilla
+management:
+  context_path: /admin
+security:
+  user:
+    password: password
+logging:
+  level:
+    # org.springframework.security: DEBUG

--- a/tests/annotation/custom-authentication/src/test/java/demo/ApplicationTests.java
+++ b/tests/annotation/custom-authentication/src/test/java/demo/ApplicationTests.java
@@ -1,0 +1,20 @@
+package demo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@WebAppConfiguration
+@IntegrationTest("server.port=0")
+public class ApplicationTests {
+
+	@Test
+	public void contextLoads() {
+	}
+
+}

--- a/tests/annotation/custom-authentication/src/test/java/demo/ClientCredentialsProviderTests.java
+++ b/tests/annotation/custom-authentication/src/test/java/demo/ClientCredentialsProviderTests.java
@@ -1,0 +1,86 @@
+package demo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+import sparklr.common.AbstractClientCredentialsProviderTests;
+
+/**
+ * Integration tests using the {@link HardCodedAuthenticationFilter}.
+ * 
+ * One client should be able to use the token endpoint /oauth/token by only providing its client_id as a parameter.
+ * 
+ * @author michaeltecourt
+ */
+@SpringApplicationConfiguration(classes = Application.class)
+public class ClientCredentialsProviderTests extends AbstractClientCredentialsProviderTests {
+
+	protected URI tokenUri;
+
+	@Before
+	public void setUp() {
+		tokenUri = URI.create(http.getUrl("/oauth/token"));
+	}
+
+	/**
+	 * No Basic authentication provided, only the hard coded client_id.
+	 */
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void testHardCodedAuthenticationFineClient() {
+
+		RestTemplate restTemplate = new RestTemplate();
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<String, String>();
+		params.add("grant_type", "client_credentials");
+		params.add("client_id", "my-client-with-secret");
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		RequestEntity<MultiValueMap<String, String>> req = new RequestEntity<MultiValueMap<String, String>>(params,
+				headers, HttpMethod.POST, tokenUri);
+
+		ResponseEntity<Map> response = restTemplate.exchange(req, Map.class);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		Map<String, String> body = response.getBody();
+		String accessToken = body.get("access_token");
+		assertNotNull(accessToken);
+	}
+
+	@Test
+	public void testHardCodedAuthenticationWrongClient() {
+
+		RestTemplate restTemplate = new RestTemplate();
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<String, String>();
+		params.add("grant_type", "client_credentials");
+		params.add("client_id", "my-trusted-client");
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		RequestEntity<MultiValueMap<String, String>> req = new RequestEntity<MultiValueMap<String, String>>(params,
+				headers, HttpMethod.POST, tokenUri);
+
+		try {
+			restTemplate.exchange(req, Map.class);
+			fail("Expected HTTP 401");
+		}
+		catch (HttpStatusCodeException e) {
+			assertEquals(HttpStatus.UNAUTHORIZED, e.getStatusCode());
+		}
+	}
+}

--- a/tests/annotation/pom.xml
+++ b/tests/annotation/pom.xml
@@ -19,6 +19,7 @@
       <module>multi</module>
       <module>client</module>
       <module>resource</module>
+      <module>custom-authentication</module>
     </modules>
 
 	<name>spring-oauth2-tests</name>


### PR DESCRIPTION
Alter `AuthorizationServerSecurityConfigurer` to allow custom authentication filters for the `TokenEndpoint`.

These filters are added upstream of the traditional `BasicAuthenticationFilter`.

Simple integration test project added, details in README.md.