### PR TITLE
If there is more information, the class will be OAuth2Exception, not the opposite.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/http/OAuth2ErrorHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/http/OAuth2ErrorHandler.java
@@ -155,7 +155,7 @@ public class OAuth2ErrorHandler implements ResponseErrorHandler {
 				throw new AccessTokenRequiredException(resource);
 			}
 			catch (OAuth2Exception ex) {
-				if (!ex.getClass().equals(OAuth2Exception.class)) {
+				if (ex.getClass().equals(OAuth2Exception.class)) {
 					// There is more information here than the caller would get from an HttpClientErrorException so
 					// rethrow
 					throw ex;


### PR DESCRIPTION
If we can get an OAuth2Exception already from the body, it is likely to have more information than the header does, so just re-throw it here.