### PR TITLE
Travis build on JDK 6+7+8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+  - openjdk6
+sudo: false
 
 install: mvn -U install --quiet -DskipTests=true -P bootstrap
 script: mvn clean test -P bootstrap
-
-


### PR DESCRIPTION
Configures Travis to build on Oracle JDK 7+8 and OpenJDK 6+7.

Also enables migration to Travis' container-based infrastructure: http://docs.travis-ci.com/user/migrating-from-legacy/
