### PR TITLE
Expire OAuth codes if they are not redeemed

### DIFF
--- a/spring-security-oauth/src/test/resources/schema.sql
+++ b/spring-security-oauth/src/test/resources/schema.sql
@@ -22,5 +22,7 @@ create table oauth_refresh_token (
 );
 
 create table oauth_code (
-  code VARCHAR(256), authentication LONGVARBINARY
+  code VARCHAR(256),
+  authentication LONGVARBINARY,
+  created TIMESTAMP DEFAULT current_timestamp
 );

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/InMemoryAuthorizationCodeServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/InMemoryAuthorizationCodeServices.java
@@ -1,5 +1,6 @@
 package org.springframework.security.oauth2.provider.code;
 
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -11,18 +12,52 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
  * @author Dave Syer
  */
 public class InMemoryAuthorizationCodeServices extends RandomValueAuthorizationCodeServices {
+	/**
+	 *  From RFC6749: A maximum authorization code lifetime of 10 minutes is RECOMMENDED
+	 *
+	 *  @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.2">RFC6749 4.1.2.  Authorization Response</a>
+	 */
+	private static final int DEFAULT_CODE_LIFETIME_SECONDS = 10*60;
 
-	protected final ConcurrentHashMap<String, OAuth2Authentication> authorizationCodeStore = new ConcurrentHashMap<String, OAuth2Authentication>();
+	private int codeLiftetimeSeconds = DEFAULT_CODE_LIFETIME_SECONDS;
+
+	protected final ConcurrentHashMap<String, ExpiringOAuth2Authentication> authorizationCodeStore = new ConcurrentHashMap<String, ExpiringOAuth2Authentication>();
 
 	@Override
 	protected void store(String code, OAuth2Authentication authentication) {
-		this.authorizationCodeStore.put(code, authentication);
+		this.authorizationCodeStore.put(code, new ExpiringOAuth2Authentication(System.currentTimeMillis(),
+			authentication));
 	}
 
 	@Override
 	public OAuth2Authentication remove(String code) {
-		OAuth2Authentication auth = this.authorizationCodeStore.remove(code);
-		return auth;
+		removeExpired();
+		ExpiringOAuth2Authentication expiringOAuth2Authentication = this.authorizationCodeStore.remove(code);
+		return expiringOAuth2Authentication == null ? null : expiringOAuth2Authentication.authentication;
 	}
 
+	private void removeExpired() {
+		synchronized (authorizationCodeStore) {
+			long expirationThreshold = System.currentTimeMillis() - codeLiftetimeSeconds;
+			for (Iterator<ExpiringOAuth2Authentication> iterator = authorizationCodeStore.values().iterator(); iterator.hasNext(); ) {
+				if (iterator.next().createdTimestamp < expirationThreshold) {
+					iterator.remove();
+				}
+			}
+		}
+	}
+
+	private static class ExpiringOAuth2Authentication {
+		private final long createdTimestamp;
+		private final OAuth2Authentication authentication;
+
+		private ExpiringOAuth2Authentication(final long createdTimestamp, final OAuth2Authentication authentication) {
+			this.createdTimestamp = createdTimestamp;
+			this.authentication = authentication;
+		}
+	}
+
+	public void setCodeLiftetimeSeconds(int codeLiftetimeSeconds) {
+		this.codeLiftetimeSeconds = codeLiftetimeSeconds;
+	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeServicesBaseTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeServicesBaseTests.java
@@ -12,18 +12,22 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.RequestTokenFactory;
 
 public abstract class AuthorizationCodeServicesBaseTests {
+	private static final int CODE_LIFETIME_FOREVER = Integer.MAX_VALUE;
+	private static final int CODE_LIFETIME_EXPIRE_ON_CREATE = Integer.MIN_VALUE;
 
-	abstract AuthorizationCodeServices getAuthorizationCodeServices();
+	abstract AuthorizationCodeServices getAuthorizationCodeServices(int codeLiftetimeSeconds);
 
 	@Test
 	public void testCreateAuthorizationCode() {
 		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request("id", false);
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(storedOAuth2Request,
 				new TestAuthentication("test2", false));
-		String code = getAuthorizationCodeServices().createAuthorizationCode(expectedAuthentication);
+		AuthorizationCodeServices authorizationCodeServices = getAuthorizationCodeServices(CODE_LIFETIME_FOREVER);
+
+		String code = authorizationCodeServices.createAuthorizationCode(expectedAuthentication);
 		assertNotNull(code);
 
-		OAuth2Authentication actualAuthentication = getAuthorizationCodeServices().consumeAuthorizationCode(code);
+		OAuth2Authentication actualAuthentication = authorizationCodeServices.consumeAuthorizationCode(code);
 		assertEquals(expectedAuthentication, actualAuthentication);
 	}
 
@@ -32,14 +36,15 @@ public abstract class AuthorizationCodeServicesBaseTests {
 		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request("id", false);
 		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(storedOAuth2Request,
 				new TestAuthentication("test2", false));
-		String code = getAuthorizationCodeServices().createAuthorizationCode(expectedAuthentication);
+		AuthorizationCodeServices authorizationCodeServices = getAuthorizationCodeServices(CODE_LIFETIME_FOREVER);
+		String code = authorizationCodeServices.createAuthorizationCode(expectedAuthentication);
 		assertNotNull(code);
 
-		OAuth2Authentication actualAuthentication = getAuthorizationCodeServices().consumeAuthorizationCode(code);
+		OAuth2Authentication actualAuthentication = authorizationCodeServices.consumeAuthorizationCode(code);
 		assertEquals(expectedAuthentication, actualAuthentication);
 
 		try {
-			getAuthorizationCodeServices().consumeAuthorizationCode(code);
+			authorizationCodeServices.consumeAuthorizationCode(code);
 			fail("Should have thrown exception");
 		}
 		catch (InvalidGrantException e) {
@@ -50,7 +55,26 @@ public abstract class AuthorizationCodeServicesBaseTests {
 	@Test
 	public void testConsumeNonExistingCode() {
 		try {
-			getAuthorizationCodeServices().consumeAuthorizationCode("doesnt exist");
+			getAuthorizationCodeServices(CODE_LIFETIME_FOREVER).consumeAuthorizationCode("doesnt exist");
+			fail("Should have thrown exception");
+		}
+		catch (InvalidGrantException e) {
+			// good we expected this
+		}
+	}
+
+	@Test
+	public void testConsumeExpiredCode() {
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request("id", false);
+		OAuth2Authentication expectedAuthentication = new OAuth2Authentication(storedOAuth2Request,
+			new TestAuthentication("test2", false));
+		AuthorizationCodeServices authorizationCodeServices = getAuthorizationCodeServices(
+			CODE_LIFETIME_EXPIRE_ON_CREATE);
+		String code = authorizationCodeServices.createAuthorizationCode(expectedAuthentication);
+		assertNotNull(code);
+
+		try {
+			authorizationCodeServices.consumeAuthorizationCode(code);
 			fail("Should have thrown exception");
 		}
 		catch (InvalidGrantException e) {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/InMemoryAuthorizationCodeServicesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/InMemoryAuthorizationCodeServicesTests.java
@@ -12,7 +12,8 @@ public class InMemoryAuthorizationCodeServicesTests extends AuthorizationCodeSer
 	}
 
 	@Override
-	AuthorizationCodeServices getAuthorizationCodeServices() {
+	AuthorizationCodeServices getAuthorizationCodeServices(int codeLiftetimeSeconds) {
+		authorizationCodeServices.setCodeLiftetimeSeconds(codeLiftetimeSeconds);
 		return authorizationCodeServices;
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/JdbcAuthorizationCodeServicesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/JdbcAuthorizationCodeServicesTests.java
@@ -23,7 +23,8 @@ public class JdbcAuthorizationCodeServicesTests extends AuthorizationCodeService
 	}
 
 	@Override
-	AuthorizationCodeServices getAuthorizationCodeServices() {
+	AuthorizationCodeServices getAuthorizationCodeServices(int codeLiftetimeSeconds) {
+		authorizationCodeServices.setCodeLiftetimeSeconds(codeLiftetimeSeconds);
 		return authorizationCodeServices;
 	}
 }

--- a/spring-security-oauth2/src/test/resources/schema.sql
+++ b/spring-security-oauth2/src/test/resources/schema.sql
@@ -34,11 +34,13 @@ create table oauth_access_token (
 create table oauth_refresh_token (
   token_id VARCHAR(256),
   token LONGVARBINARY,
-  authentication LONGVARBINARY
+  authentication LONGVARBINARY,
 );
 
 create table oauth_code (
-  code VARCHAR(256), authentication LONGVARBINARY
+  code VARCHAR(256),
+  authentication LONGVARBINARY,
+  created TIMESTAMP DEFAULT current_timestamp
 );
 
 create table oauth_approvals (

--- a/tests/annotation/jdbc/src/main/resources/schema.sql
+++ b/tests/annotation/jdbc/src/main/resources/schema.sql
@@ -48,6 +48,8 @@ create table oauth_refresh_token (
 );
 
 create table oauth_code (
-  code VARCHAR(256), authentication LONGVARBINARY
+  code VARCHAR(256),
+  authentication LONGVARBINARY,
+  created TIMESTAMP DEFAULT current_timestamp
 );
 

--- a/tests/xml/jdbc/src/main/resources/schema.sql
+++ b/tests/xml/jdbc/src/main/resources/schema.sql
@@ -48,7 +48,9 @@ create table oauth_refresh_token (
 );
 
 create table oauth_code (
-  code VARCHAR(256), authentication LONGVARBINARY
+  code VARCHAR(256),
+  authentication LONGVARBINARY,
+  created TIMESTAMP DEFAULT current_timestamp
 );
 
 insert into oauth_client_details (client_id, resource_ids, scope, authorized_grant_types, authorities, access_token_validity) 


### PR DESCRIPTION
RFC6749 [says](https://tools.ietf.org/html/rfc6749#section-4.1.2):

> The authorization code MUST expire shortly after it is issued to mitigate the risk of leaks.  A maximum authorization code lifetime of 10 minutes is RECOMMENDED.

However currently spring-security-oauth does not foresee any means of expiring authorization codes. This may in the long run pose a security risk at worst or a waste of hard disk/memory space at best.

The attached code will expire tokens by default after 10 minutes, but can be configured for any duration.

I have signed the contributor's agreement.
