### PR TITLE
WhiteLabelErrorEndpoint XSS vulnerability fix

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpoint.java
@@ -21,7 +21,7 @@ public class WhitelabelErrorEndpoint {
 	private static final String ERROR = "<html><body><h1>OAuth Error</h1><p>${errorSummary}</p></body></html>";
 
 	@RequestMapping("/oauth/error")
-	public ModelAndView handleError(final HttpServletRequest request) {
+	public ModelAndView handleError(HttpServletRequest request) {
 		Map<String, Object> model = new HashMap<String, Object>();
 		Object error = request.getAttribute("error");
 		// The error summary may contain malicious user input,

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpoint.java
@@ -1,33 +1,40 @@
 package org.springframework.security.oauth2.provider.endpoint;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.util.HtmlUtils;
 
 /**
  * Controller for displaying the error page for the authorization server.
- * 
+ *
  * @author Dave Syer
  */
 @FrameworkEndpoint
 public class WhitelabelErrorEndpoint {
 
+	private static final String ERROR = "<html><body><h1>OAuth Error</h1><p>${errorSummary}</p></body></html>";
+
 	@RequestMapping("/oauth/error")
-	public ModelAndView handleError(HttpServletRequest request) {
+	public ModelAndView handleError(final HttpServletRequest request) {
 		Map<String, Object> model = new HashMap<String, Object>();
 		Object error = request.getAttribute("error");
-		if (error==null) {
-			error = Collections.singletonMap("summary", "Unknown error");
+		// The error summary may contain malicious user input,
+		// it needs to be escaped to prevent XSS
+		String errorSummary;
+		if (error instanceof OAuth2Exception) {
+			OAuth2Exception oauthError = (OAuth2Exception) error;
+			errorSummary = HtmlUtils.htmlEscape(oauthError.getSummary());
 		}
-		model.put("error", error);
+		else {
+			errorSummary = "Unknown error";
+		}
+		model.put("errorSummary", errorSummary);
 		return new ModelAndView(new SpelView(ERROR), model);
 	}
-
-	private static String ERROR = "<html><body><h1>OAuth Error</h1><p>${error.summary}</p></body></html>";
-
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpointTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/WhitelabelErrorEndpointTests.java
@@ -14,12 +14,13 @@
 
 package org.springframework.security.oauth2.provider.endpoint;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
+import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
@@ -53,4 +54,12 @@ public class WhitelabelErrorEndpointTests {
 		assertTrue("Wrong content: " + content, content.contains("Unknown"));
 	}
 
+	@Test
+	public void testErrorPageXSS() throws Exception {
+		request.setAttribute("error", new InvalidGrantException("Invalid grant : <script>alert('XSS');</script>"));
+		ModelAndView result = endpoint.handleError(request);
+		result.getView().render(result.getModel(), request, response);
+		String content = response.getContentAsString();
+		assertFalse("Wrong content : " + content, content.contains("<script>"));
+	}
 }


### PR DESCRIPTION
XSS vulnerability revealed during an audit led by an external contractor specialized in security.

`OAuth2Exception`s may contain client input (invalid grant types,
etc), and need to be escaped before getting rendered by the default
error endpoint.

 * Add HTML escaping for OAuth2Exception errors
 * Other type of "error" objects result in a default message (SpEL
${error.summary} was not going to work anyway)
 * Unit test