### PR TITLE
Move the "non-null clientId" check from AuthorizationEndpoint to DefaultOAuth2RequestFactory

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -30,7 +30,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.BadClientCredentialsException;
 import org.springframework.security.oauth2.common.exceptions.ClientAuthenticationException;
-import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
 import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.common.exceptions.RedirectMismatchException;
@@ -126,10 +125,6 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 
 		if (!responseTypes.contains("token") && !responseTypes.contains("code")) {
 			throw new UnsupportedResponseTypeException("Unsupported response types: " + responseTypes);
-		}
-
-		if (authorizationRequest.getClientId() == null) {
-			throw new InvalidClientException("A client id must be provided");
 		}
 
 		try {


### PR DESCRIPTION
The clientId check is virtually useless in the `AuthorizationEndpoint`, as
the `OAuth2RequestFactory` will certainly load the client details before. 
Reaching this check would fail all the tests anyway, since integration
tests expect a `BadClientCredentials` exception, not an
`InvalidClientException`.
Since the `DefaultOAuth2RequestFactory` needs the clientId, the non-null
check has been moved there.
