### PR TITLE
Support for PKCE in server as per OAUTH PKCE RFC

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/InvalidCodeVerifierException.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/InvalidCodeVerifierException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2006-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.common.exceptions;
+
+/**
+ * @author Marco Lenzo
+ */
+@SuppressWarnings("serial")
+public class InvalidCodeVerifierException extends ClientAuthenticationException {
+
+	public InvalidCodeVerifierException(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public InvalidCodeVerifierException(String msg) {
+		super(msg);
+	}
+
+	@Override
+	public String getOAuth2ErrorCode() {
+		return "invalid_code_verifier";
+	}
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/CodeChallengeUtils.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/CodeChallengeUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2006-2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.common.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.security.crypto.codec.Utf8;
+
+/**
+ * Utility class used to parse code verifiers into code challenges as per OAuth PKCE.
+ * @author Marco Lenzo
+ *
+ */
+public class CodeChallengeUtils {
+
+	private CodeChallengeUtils() {
+
+	}
+
+	/**
+	 * Generates the code challenge from a given code verifier and code challenge method.
+	 * @param codeVerifier
+	 * @param codeChallengeMethod allowed values are only <code>plain</code> and <code>S256</code>
+	 * @return
+	 */
+	public static String getCodeChallenge(String codeVerifier, String codeChallengeMethod) {
+		if (codeChallengeMethod.equals("plain")) {
+			return codeVerifier;
+		}
+		else if (codeChallengeMethod.equalsIgnoreCase("S256")) {
+			return getS256CodeChallenge(codeVerifier);
+		}
+		else {
+			throw new IllegalArgumentException(codeChallengeMethod + " is not a supported code challenge method.");
+		}
+	}
+
+	private static String getS256CodeChallenge(String codeVerifier) {
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance("SHA-256");
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new IllegalArgumentException("No such algorithm [SHA-256]");
+		}
+		byte[] sha256 = md.digest(Utf8.encode(codeVerifier));
+		String codeChallenge = Base64.encodeBase64URLSafeString(sha256);
+		return codeChallenge;
+	}
+
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/OAuth2Utils.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/OAuth2Utils.java
@@ -29,6 +29,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Ryan Heaton
  * @author Dave Syer
+ * @authos Marco Lenzo
  */
 public abstract class OAuth2Utils {
 
@@ -71,6 +72,21 @@ public abstract class OAuth2Utils {
 	 * Constant to use while parsing and formatting parameter maps for OAuth2 requests
 	 */
 	public static final String GRANT_TYPE = "grant_type";
+
+	/**
+	 * Constant to use while parsing and formatting parameter maps for OAuth2 requests
+	 */
+	public static final String CODE_CHALLENGE = "code_challenge";
+
+	/**
+	 * Constant to use while parsing and formatting parameter maps for OAuth2 requests
+	 */
+	public static final String CODE_CHALLENGE_METHOD = "code_challenge_method";
+
+	/**
+	 * Constant to use while parsing and formatting parameter maps for OAuth2 requests
+	 */
+	public static final String CODE_VERIFIER = "code_verifier";
 
 	/**
 	 * Parses a string parameter value into a set of strings.

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/AuthorizationCodeTokenGranter.java
@@ -98,9 +98,13 @@ public class AuthorizationCodeTokenGranter extends AbstractTokenGranter {
 		String codeChallenge = pendingOAuth2Request.getRequestParameters().get(OAuth2Utils.CODE_CHALLENGE);
 		String codeChallengeMethod = pendingOAuth2Request.getRequestParameters().get(OAuth2Utils.CODE_CHALLENGE_METHOD);
 		String codeVerifier = tokenRequest.getRequestParameters().get(OAuth2Utils.CODE_VERIFIER);
-		if (codeChallenge != null && codeChallengeMethod != null
-				&& !CodeChallengeUtils.getCodeChallenge(codeVerifier, codeChallengeMethod).equals(codeChallenge)) {
-			throw new InvalidCodeVerifierException(codeVerifier + " does not match expected code verifier.");
+		if (codeChallenge != null && codeChallengeMethod != null) {
+			if(codeVerifier == null) {
+				throw new InvalidCodeVerifierException("Code verifier expected.");
+			}
+			else if (!CodeChallengeUtils.getCodeChallenge(codeVerifier, codeChallengeMethod).equals(codeChallenge)) {
+				throw new InvalidCodeVerifierException(codeVerifier + " does not match expected code verifier.");
+			}
 		}
 
 		// Secret is not required in the authorization request, so it won't be available

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/utils/CodeChallengeUtilsTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/utils/CodeChallengeUtilsTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.common.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.security.oauth2.common.util.CodeChallengeUtils;
+
+/**
+ * @author Marco Lenzo
+ */
+public class CodeChallengeUtilsTests {
+
+	@Test
+	public void testPlainCodeChallenge() {
+		String codeVerifier = "plainCodeChallenge";
+		String codeChallenge = CodeChallengeUtils.getCodeChallenge("plainCodeChallenge", "plain");
+		assertEquals(codeChallenge, codeVerifier);
+	}
+
+	@Test
+	public void testS256CodeChallenge() {
+		// As per example RFC7636 Appendix B example:
+		// Code verifier is dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+		// Code challenge is E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+		String codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+		String codeChallenge = CodeChallengeUtils.getCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+				"S256");
+		assertEquals("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", codeChallenge);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testCodeChallengeWithUnsupportedCodeChallengeMethod() {
+		CodeChallengeUtils.getCodeChallenge("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk", "xyz");
+	}
+
+}


### PR DESCRIPTION
I implemented the OAUTH PKCE as per RFC 7636 https://www.rfc-editor.org/rfc/rfc7636.txt

I tried to be as less intrusive as possible on the existent code. I was wondering if I had to add the `code_challenge` and `code_challenge_method` parameters in the `AuthorizationRequest` but I eventually opted not to and to rely on the existent maps.

This should complete implementation for issue #655 
