### PR TITLE
Fixes issue 511 where refresh token is stored without enhancements 

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -176,7 +176,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 		OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken);
 		tokenStore.storeAccessToken(accessToken, authentication);
 		if (!reuseRefreshToken) {
-			tokenStore.storeRefreshToken(refreshToken, authentication);
+			tokenStore.storeRefreshToken(accessToken.getRefreshToken(), authentication);
 		}
 		return accessToken;
 	}


### PR DESCRIPTION
Enhanced refresh tokens are not persisted to token store correctly during the `refreshAccessToken` routine in `DefaultTokenServices`.

The issue is not noticeable when utilizing a `JwtTokenStore` since it does not perform persistence. However it is evident using any other token store, e.g. the `InMemoryTokenStore`.

Fix was trivial. A test was created as well.

This solves issue #511 