### PR TITLE
Use thread context class loader to load classes during deserialization

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/SerializationUtils.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/SerializationUtils.java
@@ -1,6 +1,12 @@
 package org.springframework.security.oauth2.common.util;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.springframework.core.ConfigurableObjectInputStream;
 
 public class SerializationUtils {
 
@@ -31,7 +37,8 @@ public class SerializationUtils {
 	public static <T> T deserialize(byte[] byteArray) {
 		ObjectInputStream oip = null;
 		try {
-			oip = new ObjectInputStream(new ByteArrayInputStream(byteArray));
+			oip = new ConfigurableObjectInputStream(new ByteArrayInputStream(byteArray),
+					Thread.currentThread().getContextClassLoader());
 			@SuppressWarnings("unchecked")
 			T result = (T) oip.readObject();
 			return result;


### PR DESCRIPTION
Previously, SerializationUtils used a standard ObjectInputStream for deserialization. For this to work, the type being deserialized had to be available to SerializationUtils' ClassLoader. This doesn't hold true in environments where there are multiple ClassLoaders involved such as a servlet container with Spring Security OAuth installed as a shared library, or Spring Boot's DevTools (see spring-projects/spring-boot#5071).

This PR updates SerializationUtils to use Spring Framework's ConfigurableObjectInputStream, configured with the current thread's context class loader.