### PR TITLE
Add support for scopes as JSON array

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson2Deserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson2Deserializer.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 
@@ -81,8 +82,7 @@ public final class OAuth2AccessTokenJackson2Deserializer extends StdDeserializer
 				}
 			}
 			else if (OAuth2AccessToken.SCOPE.equals(name)) {
-				String text = jp.getText();
-				scope = OAuth2Utils.parseParameterList(text);
+				scope = parseScope(jp);
 			} else {
 				additionalInformation.put(name, jp.readValueAs(Object.class));
 			}
@@ -102,5 +102,19 @@ public final class OAuth2AccessTokenJackson2Deserializer extends StdDeserializer
 		accessToken.setAdditionalInformation(additionalInformation);
 
 		return accessToken;
+	}
+
+	private Set<String> parseScope(JsonParser jp) throws JsonParseException, IOException {
+		Set<String> scope;
+		if (jp.getCurrentToken() == JsonToken.START_ARRAY) {
+			scope = new TreeSet<String>();
+			while (jp.nextToken() != JsonToken.END_ARRAY) {
+				scope.add(jp.getValueAsString());
+			}
+		} else {
+			String text = jp.getText();
+			scope = OAuth2Utils.parseParameterList(text);
+		}
+		return scope;
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/BaseOAuth2AccessTokenJacksonTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/BaseOAuth2AccessTokenJacksonTest.java
@@ -45,6 +45,8 @@ abstract class BaseOAuth2AccessTokenJacksonTest {
 
 	protected static final String ACCESS_TOKEN_MULTISCOPE = "{\"access_token\":\"token-value\",\"token_type\":\"bearer\",\"refresh_token\":\"refresh-value\",\"expires_in\":10,\"scope\":\"read write\"}";
 
+	protected static final String ACCESS_TOKEN_ARRAYSCOPE = "{\"access_token\":\"token-value\",\"token_type\":\"bearer\",\"refresh_token\":\"refresh-value\",\"expires_in\":10,\"scope\":[\"read\",\"write\"]}";
+
 	protected static final String ACCESS_TOKEN_NOSCOPE = "{\"access_token\":\"token-value\",\"token_type\":\"bearer\",\"refresh_token\":\"refresh-value\",\"expires_in\":10}";
 
 	protected static final String ACCESS_TOKEN_NOREFRESH = "{\"access_token\":\"token-value\",\"token_type\":\"bearer\",\"expires_in\":10}";

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson2DeserializerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson2DeserializerTests.java
@@ -84,6 +84,12 @@ public class OAuth2AccessTokenJackson2DeserializerTests extends BaseOAuth2Access
 	}
 
 	@Test
+	public void readValueWithArrayScopes() throws Exception {
+		OAuth2AccessToken actual = mapper.readValue(ACCESS_TOKEN_ARRAYSCOPE, OAuth2AccessToken.class);
+		assertTokenEquals(accessToken, actual);
+	}
+
+	@Test
 	public void readValueWithMac() throws Exception {
 		accessToken.setTokenType("mac");
 		String encodedToken = ACCESS_TOKEN_MULTISCOPE.replace("bearer", accessToken.getTokenType());


### PR DESCRIPTION
Normally the scope is a space separated list, but at least one endpoint uses
a JSON array instead.  This change adds support for parsing a JSON array in
addition to a space separated list.

Fixes gh-722