### PR TITLE
Issue #732: incorrect reference to Sparkl app in Tonr (OAuth 1)

### DIFF
--- a/samples/oauth/tonr/pom.xml
+++ b/samples/oauth/tonr/pom.xml
@@ -33,7 +33,7 @@
 						<addContextWarDependencies>true</addContextWarDependencies>
 						<webapps>
 							<webapp>
-								<contextPath>/sparklr2</contextPath>
+								<contextPath>/sparklr</contextPath>
 								<groupId>${project.groupId}</groupId>
 								<artifactId>sparklr</artifactId>
 								<version>${project.version}</version>


### PR DESCRIPTION
Changing reference to Sparkl OAuth 1 sample app, so that `mvn tomcat7:run` command would work correctly.

Fixing Github issue 732 
(https://github.com/spring-projects/spring-security-oauth/issues/732)