### PR TITLE
Allow XML configuration for allowed TokenEndpoint HTTP methods

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/xml/AuthorizationServerBeanDefinitionParser.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/xml/AuthorizationServerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2009 Web Cohesion
+ * Copyright 2008-2016 Web Cohesion
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,7 +13,10 @@
 
 package org.springframework.security.oauth2.config.xml;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.springframework.beans.BeanMetadataElement;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -23,6 +26,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.BeanIds;
 import org.springframework.security.oauth2.provider.CompositeTokenGranter;
 import org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler;
@@ -48,6 +52,7 @@ import org.w3c.dom.Element;
  * 
  * @author Ryan Heaton
  * @author Dave Syer
+ * @author Michael J. Simons
  */
 public class AuthorizationServerBeanDefinitionParser
 		extends ProviderBeanDefinitionParser {
@@ -60,6 +65,7 @@ public class AuthorizationServerBeanDefinitionParser
 		String oAuth2RequestFactoryRef = element
 				.getAttribute("authorization-request-manager-ref");
 		String tokenEndpointUrl = element.getAttribute("token-endpoint-url");
+		String tokenEndpointAllowedRequestMethods = element.getAttribute("token-endpoint-allowed-request-methods");
 		String checkTokenUrl = element.getAttribute("check-token-endpoint-url");
 		String enableCheckToken = element.getAttribute("check-token-enabled");
 		String authorizationEndpointUrl = element
@@ -237,7 +243,7 @@ public class AuthorizationServerBeanDefinitionParser
 							.getAttribute("token-granter-ref");
 					tokenGranters.add(new RuntimeBeanReference(customGranterRef));
 				}
-			}
+			}			
 		}
 
 		if (registerAuthorizationEndpoint) {
@@ -297,6 +303,15 @@ public class AuthorizationServerBeanDefinitionParser
 		if (StringUtils.hasText(oAuth2RequestValidatorRef)) {
 			tokenEndpointBean.addPropertyReference("oAuth2RequestValidator",
 					oAuth2RequestValidatorRef);
+		}
+		if (StringUtils.hasText(tokenEndpointAllowedRequestMethods)) {
+		    final Set<HttpMethod> allowedRequestMethods = new HashSet<HttpMethod>();
+		    for (String allowedRequestMethod : tokenEndpointAllowedRequestMethods.split(",")) {
+			allowedRequestMethods.add(HttpMethod.valueOf(allowedRequestMethod.trim().toUpperCase(Locale.ENGLISH)));
+		    }
+		    if(allowedRequestMethods.size() != 0) {
+			tokenEndpointBean.addPropertyValue("allowedRequestMethods", allowedRequestMethods);
+		    }
 		}
 
 		if (StringUtils.hasText(enableCheckToken) && enableCheckToken.equals("true")) {

--- a/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-2.0.xsd
+++ b/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-2.0.xsd
@@ -195,7 +195,7 @@
 							</xs:annotation>
 						</xs:attribute>
 					</xs:complexType>
-				</xs:element>
+				</xs:element>				
 			</xs:sequence>
 			<xs:attribute name="client-details-service-ref" type="xs:string">
 				<xs:annotation>
@@ -214,6 +214,19 @@
 					</xs:documentation>
 				</xs:annotation>
 			</xs:attribute>
+			<xs:attribute name="token-endpoint-allowed-request-methods" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						A comma separated list of request methods that
+						are allowed on the token endpoint.
+						According to the oauth spec, only POST should
+						be allowed on the endpoint, which is the default.
+						Values must be in the form of 
+						org.springframework.http.HttpMethod values.
+						Default value: "POST"
+					</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>			
 			<xs:attribute name="authorization-endpoint-url" type="xs:string">
 				<xs:annotation>
 					<xs:documentation>

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/AuthorizationServerBeanDefinitionParserTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/AuthorizationServerBeanDefinitionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2011 the original author or authors.
+ * Copyright 2006-2016 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,6 +29,7 @@ import org.springframework.context.support.GenericXmlApplicationContext;
 
 /**
  * @author Dave Syer
+ * @author Michael J. Simons
  * 
  */
 @RunWith(Parameterized.class)
@@ -45,7 +46,8 @@ public class AuthorizationServerBeanDefinitionParserTests {
 				new Object[] { "authorization-server-extras" },
 				new Object[] { "authorization-server-types" },
 				new Object[] { "authorization-server-check-token" },
-				new Object[] { "authorization-server-disable" });
+				new Object[] { "authorization-server-disable" },
+				new Object[] { "authorization-server-allowed-request-methods" });
 	}
 
 	public AuthorizationServerBeanDefinitionParserTests(String resource) {

--- a/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/xml/authorization-server-allowed-request-methods.xml
+++ b/spring-security-oauth2/src/test/resources/org/springframework/security/oauth2/config/xml/authorization-server-allowed-request-methods.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:oauth="http://www.springframework.org/schema/security/oauth2"
+	xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2-2.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+	<oauth:authorization-server client-details-service-ref="clientDetails" token-services-ref="tokens"
+		authorization-endpoint-url="/authorize" token-endpoint-url="/token" approval-parameter-name="approve" error-page="/error"
+		authorization-request-manager-ref="factory" redirect-resolver-ref="resolver" token-granter-ref="granter"
+		implicit-grant-service-ref="implicitService" request-validator-ref="requestValidator"
+		user-approval-handler-ref="approvals" user-approval-page="/approve"
+		token-endpoint-allowed-request-methods="GET, POST">
+		<oauth:authorization-code />		
+	</oauth:authorization-server>
+
+	<oauth:client-details-service id="clientDetails">
+		<oauth:client client-id="foo" authorized-grant-types="password" />
+	</oauth:client-details-service>
+
+	<bean id="tokens" class="org.springframework.security.oauth2.provider.token.DefaultTokenServices">
+		<property name="tokenStore">
+			<bean class="org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore" />
+		</property>
+	</bean> 
+
+	<bean id="granter" class="org.springframework.security.oauth2.provider.code.AuthorizationCodeTokenGranter">
+		<constructor-arg ref="tokens" />
+		<constructor-arg>
+			<bean class="org.springframework.security.oauth2.provider.code.InMemoryAuthorizationCodeServices" />
+		</constructor-arg>
+		<constructor-arg ref="clientDetails" />
+		<constructor-arg ref="factory" />
+	</bean>
+	
+	<bean id="requestValidator" class="org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestValidator" />
+	
+	<bean id="implicitService" class="org.springframework.security.oauth2.provider.implicit.InMemoryImplicitGrantService" />
+
+	<bean id="approvals" class="org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler" />
+
+	<bean id="resolver" class="org.springframework.security.oauth2.provider.endpoint.DefaultRedirectResolver" />
+	
+	<bean id="factory" class="org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestFactory">
+		<constructor-arg ref="clientDetails"/>
+	</bean>
+
+</beans>


### PR DESCRIPTION
This is a response to #334. With this pull request, XML configuration can be used to configure the allowed request methods on the `TokenEndpoint` the same way it is possible with `AuthorizationServerConfigurerAdapter` without having to resort to a `BeanPostProcessor`:

```
<oauth:authorization-server token-endpoint-url="/token" token-endpoint-allowed-request-methods="GET, POST">
	<oauth:authorization-code />		
</oauth:authorization-server>
```

I'd really appreciate a merge, as it allows to keep an existing (and tested, working) XML configuration, especially when upgrading from 1.x to 2.x. Thanks!

I have signed and agree to the terms of the Spring Individual Contributor
License Agreement.