### PR TITLE
816: Refreshing AT doesn't replace existing RT

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChain.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChain.java
@@ -162,8 +162,11 @@ public class AccessTokenProviderChain extends OAuth2AccessTokenSupport implement
 			if (tokenProvider.supportsRefresh(resource)) {
 				DefaultOAuth2AccessToken refreshedAccessToken = new DefaultOAuth2AccessToken(
 						tokenProvider.refreshAccessToken(resource, refreshToken, request));
-				// Fixes gh-712
-				refreshedAccessToken.setRefreshToken(refreshToken);
+				if (refreshedAccessToken.getRefreshToken() == null 
+						|| refreshedAccessToken.getRefreshToken().getValue() == null) {
+					// Fixes gh-712
+					refreshedAccessToken.setRefreshToken(refreshToken);
+				}
 				return refreshedAccessToken;
 			}
 		}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -12,10 +12,12 @@
  */
 package org.springframework.security.oauth2.provider.token;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -151,7 +153,8 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 		if (map.containsKey(SCOPE)) {
 			Object scopeObj = map.get(SCOPE);
 			if (String.class.isInstance(scopeObj)) {
-				scope = Collections.singleton(String.class.cast(scopeObj));
+				String[] scopeArray = String.class.cast(scopeObj).split(" ");
+				scope = new HashSet<String>(Arrays.asList(scopeArray));
 			} else if (Collection.class.isAssignableFrom(scopeObj.getClass())) {
 				@SuppressWarnings("unchecked")
 				Collection<String> scopeColl = (Collection<String>) scopeObj;


### PR DESCRIPTION
When access token expires on the Application Client, Spring issues an
refresh access token request.

But Spring never replaces the existing refreshToken event if the
Authorization Server returns a new one alongside the new access token.

see https://tools.ietf.org/html/rfc6749#section-6
