### PR TITLE
Preserve user authentication details on re-authentication

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -155,8 +155,16 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 		if (this.authenticationManager != null && !authentication.isClientOnly()) {
 			// The client has already been authenticated, but the user authentication might be old now, so give it a
 			// chance to re-authenticate.
-			Authentication user = new PreAuthenticatedAuthenticationToken(authentication.getUserAuthentication(), "", authentication.getAuthorities());
-			user = authenticationManager.authenticate(user);
+			Authentication userAuthentication = authentication.getUserAuthentication();
+			PreAuthenticatedAuthenticationToken preAuthenticatedToken = new PreAuthenticatedAuthenticationToken(
+					userAuthentication,
+					"",
+					authentication.getAuthorities()
+			);
+			if (userAuthentication != null) {
+				preAuthenticatedToken.setDetails(userAuthentication.getDetails());
+			}
+			Authentication user = authenticationManager.authenticate(preAuthenticatedToken);
 			Object details = authentication.getDetails();
 			authentication = new OAuth2Authentication(authentication.getOAuth2Request(), user);
 			authentication.setDetails(details);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesTests.java
@@ -1,11 +1,32 @@
 package org.springframework.security.oauth2.provider.token;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.TokenRequest;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import java.util.Arrays;
 
 public class DefaultTokenServicesTests {
 
@@ -29,5 +50,94 @@ public class DefaultTokenServicesTests {
 				.thenReturn(null);
 		services.loadAuthentication("FOO");
 	}
+	
+	@Test
+	public void testRefreshAccessTokenWithReauthentication() {
+		UserDetails user = createMockUser("joeuser", "PROCESSOR");
+		UserDetailsService userDetailsService = Mockito.mock(UserDetailsService.class);
 
+		Mockito
+				.when(tokenStore.readRefreshToken(Mockito.anyString()))
+				.thenReturn(new DefaultOAuth2RefreshToken("FOO"));
+
+		Mockito
+				.when(tokenStore.readAuthenticationForRefreshToken(Mockito.any(OAuth2RefreshToken.class)))
+				.thenReturn(createMockOAuth2Authentication("myclient", user, "some more details"));
+
+		Mockito
+				.when(userDetailsService.loadUserByUsername(Mockito.anyString()))
+				.thenReturn(user);
+
+		services.setSupportRefreshToken(true);
+		services.setAuthenticationManager(createAuthenticationManager(userDetailsService));
+		
+		OAuth2AccessToken refreshedAccessToken = services.refreshAccessToken("FOO", createMockTokenRequest("myclient"));
+
+		ArgumentCaptor<OAuth2Authentication> refreshedAuthenticationCaptor = ArgumentCaptor.forClass(OAuth2Authentication.class);
+		
+		Mockito.verify(tokenStore).storeAccessToken(Mockito.eq(refreshedAccessToken), refreshedAuthenticationCaptor.capture());
+		
+		OAuth2Authentication refreshedAuthentication = refreshedAuthenticationCaptor.getValue();
+		Authentication authentication = refreshedAuthentication.getUserAuthentication();
+		Assert.assertEquals(user, authentication.getPrincipal());
+		Assert.assertEquals("some more details", authentication.getDetails());
+	}
+
+	@Test
+	public void testRefreshAccessTokenWithoutReauthentication() {
+
+		UserDetails user = createMockUser("joeuser", "PROCESSOR");
+
+		Mockito
+				.when(tokenStore.readRefreshToken(Mockito.anyString()))
+				.thenReturn(new DefaultOAuth2RefreshToken("FOO"));
+
+		Mockito
+				.when(tokenStore.readAuthenticationForRefreshToken(Mockito.any(OAuth2RefreshToken.class)))
+				.thenReturn(createMockOAuth2Authentication("myclient", user, "some more details"));
+
+		services.setSupportRefreshToken(true);
+		services.setAuthenticationManager(null);
+
+		OAuth2AccessToken refreshedAccessToken = services.refreshAccessToken("FOO", createMockTokenRequest("myclient"));
+
+		ArgumentCaptor<OAuth2Authentication> refreshedAuthenticationCaptor = ArgumentCaptor.forClass(OAuth2Authentication.class);
+
+		Mockito.verify(tokenStore).storeAccessToken(Mockito.eq(refreshedAccessToken), refreshedAuthenticationCaptor.capture());
+
+		OAuth2Authentication refreshedAuthentication = refreshedAuthenticationCaptor.getValue();
+		Authentication authentication = refreshedAuthentication.getUserAuthentication();
+		Assert.assertEquals(user, authentication.getPrincipal());
+		Assert.assertEquals("some more details", authentication.getDetails());
+	}
+	
+	private AuthenticationManager createAuthenticationManager(UserDetailsService userDetailsService) {
+		PreAuthenticatedAuthenticationProvider provider = new PreAuthenticatedAuthenticationProvider();
+		provider.setPreAuthenticatedUserDetailsService(
+				new UserDetailsByNameServiceWrapper<PreAuthenticatedAuthenticationToken>(userDetailsService)
+		);
+		return new ProviderManager(Arrays.<AuthenticationProvider> asList(provider));
+	}
+
+	private TokenRequest createMockTokenRequest(String clientId) {
+		return new TokenRequest(null, clientId, null, null);
+	}
+
+	private OAuth2Request createMockOAuth2Request(String clientId) {
+		return new OAuth2Request(null, clientId, null, true, null, null, null, null, null);
+	}
+	
+	private OAuth2Authentication createMockOAuth2Authentication(String clientId, UserDetails user, String extraDetails) {
+		return new OAuth2Authentication(createMockOAuth2Request(clientId), createMockUserAuthentication(user, extraDetails));
+	}
+
+	private UsernamePasswordAuthenticationToken createMockUserAuthentication(UserDetails user, Object extraDetails) {
+		UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
+		token.setDetails(extraDetails);
+		return token;
+	}
+	
+	private UserDetails createMockUser(String username, String ... roles) {
+		return new User(username, "", AuthorityUtils.createAuthorityList(roles));
+	}
 }


### PR DESCRIPTION
During a token refresh in the `DefaultTokenServices` the user
authentication will be re-authenticated if an `AuthenticationManager`
was provided. A `PreAuthenticatedAuthenticationToken` is created
based on the user authentication and then passed to the
`AuthenticationManager`. However, if there were any details on
the user authentication those details are lost because they are
not copied to the `PreAuthenticatedAuthenticationToken`. If the
`AuthenticationManager` is not provided then this logic is skipped
over and the details are correctly preserved.

The fix is simply to set the details on the
`PreAuthenticatedAuthenticationToken` before passing it to the
`AuthenticationManager`.  I've moved the re-authentication code into
a new protected method named `reauthenticateUserAuthentication` so that
it can be overridden if needed.

Finally, I added two new tests to `DefaultTokenServicesTests` to
validate that the user authentication is built correctly on a refresh.
There is one test for the scenario when there is no re-authentication
which passes even before these changes and then the other tests the
re-authentication scenario which requires this change to pass.
