### PR TITLE
DefaultAccessTokenConverter support for space-delimited scopes

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ResourceRequestDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ResourceRequestDetails.java
@@ -1,0 +1,31 @@
+package org.springframework.security.oauth2.provider;
+
+import java.util.Set;
+
+/**
+ * The details of a requested resource.
+ *
+ * @author Michael Kangas
+ */
+public interface ResourceRequestDetails {
+  /**
+   * The scope required for the resource request.
+   *
+   * @return set of scopes required for the resource request; empty if no scope is required
+   */
+  Set<String> getScope();
+
+  /**
+   * The request method.
+   *
+   * @return the request method
+   */
+  String getMethod();
+
+  /**
+   * The resource URI.
+   *
+   * @return the resource URI
+   */
+  String getURI();
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ResourceRequestDetailsService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/ResourceRequestDetailsService.java
@@ -1,0 +1,19 @@
+package org.springframework.security.oauth2.provider;
+
+/**
+ * Service to provide the details of a requested resource.
+ *
+ * @author Michael Kangas
+ */
+public interface ResourceRequestDetailsService {
+
+  /**
+   * Loads the details the requested resource by request method and resource URI.
+   *
+   * @param requestMethod the request method
+   * @param resourceURI the URI of the requested resource
+   * @return the details of the requested resource or {@code null} if none are found
+   */
+  ResourceRequestDetails loadResourceRequestDetails(String requestMethod, String resourceURI);
+
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetails.java
@@ -15,6 +15,7 @@
 package org.springframework.security.oauth2.provider.authentication;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -37,6 +38,10 @@ public class OAuth2AuthenticationDetails implements Serializable {
 
 	private final String sessionId;
 
+	private final String method;
+
+	private final String requestURI;
+
 	private final String tokenValue;
 
 	private final String tokenType;
@@ -56,29 +61,31 @@ public class OAuth2AuthenticationDetails implements Serializable {
 		this.tokenValue = (String) request.getAttribute(ACCESS_TOKEN_VALUE);
 		this.tokenType = (String) request.getAttribute(ACCESS_TOKEN_TYPE);
 		this.remoteAddress = request.getRemoteAddr();
+		this.method = request.getMethod();
+		this.requestURI = request.getRequestURI();
 
 		HttpSession session = request.getSession(false);
 		this.sessionId = (session != null) ? session.getId() : null;
-		StringBuilder builder = new StringBuilder();
+		ArrayList<String> fields = new ArrayList<String>(5);
 		if (remoteAddress!=null) {
-			builder.append("remoteAddress=").append(remoteAddress);
-		}
-		if (builder.length()>1) {
-			builder.append(", ");
+			fields.add("remoteAddress=" + remoteAddress);
 		}
 		if (sessionId!=null) {
-			builder.append("sessionId=<SESSION>");
-			if (builder.length()>1) {
-				builder.append(", ");
-			}
+			fields.add("sessionId=<SESSION>");
 		}
 		if (tokenType!=null) {
-			builder.append("tokenType=").append(this.tokenType);
+			fields.add("tokenType=" + tokenType);
 		}
 		if (tokenValue!=null) {
-			builder.append("tokenValue=<TOKEN>");
+			fields.add("tokenValue=<TOKEN>");
 		}
-		this.display = builder.toString();
+		if (this.method !=null) {
+			fields.add("method=" + method);
+		}
+		if (this.requestURI !=null) {
+			fields.add("requestURI=" + requestURI);
+		}
+		this.display = fields.toString().substring(1, fields.toString().length() - 1);
 	}
 
 	/**
@@ -101,7 +108,7 @@ public class OAuth2AuthenticationDetails implements Serializable {
 
 	/**
 	 * Indicates the TCP/IP address the authentication request was received from.
-	 * 
+	 *
 	 * @return the address
 	 */
 	public String getRemoteAddress() {
@@ -115,6 +122,24 @@ public class OAuth2AuthenticationDetails implements Serializable {
 	 */
 	public String getSessionId() {
 		return sessionId;
+	}
+
+	/**
+	 * Indicates the request method.
+	 *
+	 * @return the request method
+	 */
+	public String getMethod() {
+		return method;
+	}
+
+	/**
+	 * Indicates the request URI.
+	 *
+	 * @return the request URI
+	 */
+	public String getRequestURI() {
+		return requestURI;
 	}
 
 	/**
@@ -149,6 +174,8 @@ public class OAuth2AuthenticationDetails implements Serializable {
 		result = prime * result + ((sessionId == null) ? 0 : sessionId.hashCode());
 		result = prime * result + ((tokenType == null) ? 0 : tokenType.hashCode());
 		result = prime * result + ((tokenValue == null) ? 0 : tokenValue.hashCode());
+		result = prime * result + ((method == null) ? 0 : method.hashCode());
+		result = prime * result + ((requestURI == null) ? 0 : requestURI.hashCode());
 		return result;
 	}
 
@@ -179,9 +206,19 @@ public class OAuth2AuthenticationDetails implements Serializable {
 		}
 		else if (!tokenValue.equals(other.tokenValue))
 			return false;
+		if (method == null) {
+			if (other.method != null)
+				return false;
+		}
+		else if (!method.equals(other.method))
+			return false;
+		if (requestURI == null) {
+			if (other.requestURI != null)
+				return false;
+		}
+		else if (!requestURI.equals(other.requestURI))
+			return false;
 		return true;
 	}
-	
-	
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/request/InMemoryResourceRequestDetailsService.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/request/InMemoryResourceRequestDetailsService.java
@@ -1,0 +1,94 @@
+package org.springframework.security.oauth2.provider.request;
+
+import static java.util.regex.Pattern.matches;
+
+import org.springframework.security.oauth2.provider.ResourceRequestDetails;
+import org.springframework.security.oauth2.provider.ResourceRequestDetailsService;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * In-memory implementation of a resource request details service.  Pattern matching on method (regex) and request
+ * URI ({@link PathMatcher}) facilitates compact representation of method-->resource-->scope mappings.
+ *
+ * @author Michael Kangas
+ */
+public class InMemoryResourceRequestDetailsService implements ResourceRequestDetailsService {
+  private Map<String, Map<String, Set<String>>> requestScopeStore = new HashMap<String, Map<String, Set<String>>>();
+  private PathMatcher pathMatcher = new AntPathMatcher();
+
+  public void setRequestScopeStore(Map<String, Map<String, Set<String>>> requestScopeStore) {
+    this.requestScopeStore = requestScopeStore;
+  }
+
+  public void setPathMatcher(PathMatcher pathMatcher) {
+    this.pathMatcher = pathMatcher;
+  }
+
+  /**
+   * Loads the details of the requested resource whose request method and URI match at least one configured pattern.
+   * The method is regex-matched against the stored patterns, while the request URI is path-matched.
+   *
+   * <p>
+   * All scopes that are found across all successful matches are included in the result.
+   *
+   * @param method     the request method
+   * @param requestURI the request URI
+   * @return the details of the resource request or {@code null} if none are found (i.e., there are no matches)
+   */
+  @Override
+  public ResourceRequestDetails loadResourceRequestDetails(final String method, final String requestURI) {
+    Set<Set<String>> scopes = new HashSet<Set<String>>();
+    for (Map<String, Set<String>> r : filter(requestScopeStore, method).values()) {
+      scopes.addAll(filter(r, requestURI, pathMatcher).values());
+    }
+
+    if (scopes.isEmpty()) {
+      return null;
+    }
+
+    final Set<String> scope = new HashSet<String>();
+    for (Set<String> s : scopes) {
+      scope.addAll(s);
+    }
+
+    return new ResourceRequestDetails() {
+      public Set<String> getScope() {
+        return scope;
+      }
+
+      public String getMethod() {
+        return method;
+      }
+
+      public String getURI() {
+        return requestURI;
+      }
+    };
+  }
+
+  /**
+   * Filters a map whose keys are patterns that match the argument test.  If a {@link PathMatcher} is supplied, it is
+   * used to do the match (i.e., as a path); otherwise, {@link Pattern}{@code .matches()} is used (i.e., as a regex).
+   *
+   * @param map map whose keys represent patterns (path or regex)
+   * @param test string to match for filtering
+   * @param m optional path matcher to use for path matching (all but the first are ignored)
+   * @return sub-map whose keys match {@code test}
+   */
+  private static <V> Map<String, V> filter(Map<String, V> map, String test, PathMatcher... m) {
+    Map<String, V> result = new HashMap<String, V>();
+    for (String k : map.keySet()) {
+      if (m.length > 0 ? m[0].match(k, test) : matches(k, test)) {
+        result.put(k, map.get(k));
+      }
+    }
+    return result;
+  }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -12,6 +12,7 @@
  */
 package org.springframework.security.oauth2.provider.token;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -151,7 +152,7 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 		if (map.containsKey(SCOPE)) {
 			Object scopeObj = map.get(SCOPE);
 			if (String.class.isInstance(scopeObj)) {
-				scope = Collections.singleton(String.class.cast(scopeObj));
+				scope = new LinkedHashSet<String>(Arrays.asList(String.class.cast(scopeObj).split(" ")));
 			} else if (Collection.class.isAssignableFrom(scopeObj.getClass())) {
 				@SuppressWarnings("unchecked")
 				Collection<String> scopeColl = (Collection<String>) scopeObj;

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -111,7 +111,6 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 			throw new InvalidTokenException(accessToken);
 		}
 
-		Assert.state(map.containsKey("client_id"), "Client id must be present in response from auth server");
 		return tokenConverter.extractAuthentication(map);
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetailsTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetailsTests.java
@@ -14,9 +14,12 @@
 package org.springframework.security.oauth2.provider.authentication;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.util.SerializationUtils;
 
 /**
@@ -34,6 +37,65 @@ public class OAuth2AuthenticationDetailsTests {
 		OAuth2AuthenticationDetails other = (OAuth2AuthenticationDetails) SerializationUtils.deserialize(SerializationUtils
 				.serialize(holder));
 		assertEquals(holder, other);
+	}
+
+	@Test
+	public void testToString() {
+		assertEquals("", new OAuth2AuthenticationDetails(mock()).toString());
+		assertEquals("tokenValue=<TOKEN>", new OAuth2AuthenticationDetails(mock(
+						null, null, null, null, "FOO")).toString());
+		assertEquals("tokenType=bearer", new OAuth2AuthenticationDetails(mock(
+						null, null, null, null, null, "bearer")).toString());
+		assertEquals("tokenType=bearer, tokenValue=<TOKEN>", new OAuth2AuthenticationDetails(mock(
+						null, null, null, null, "FOO", "bearer")).toString());
+		assertEquals("remoteAddress=127.0.0.1, sessionId=<SESSION>, tokenType=bearer, tokenValue=<TOKEN>",
+						new OAuth2AuthenticationDetails(mock(
+										null, null, new MockHttpSession(), "127.0.0.1", "FOO", "bearer")).toString());
+		assertEquals("remoteAddress=127.0.0.1, sessionId=<SESSION>, tokenType=bearer, tokenValue=<TOKEN>, "
+						+ "method=GET, requestURI=/foo/bar", new OAuth2AuthenticationDetails(mock("GET", "/foo/bar",
+						new MockHttpSession(), "127.0.0.1", "FOO", "bearer")).toString());
+	}
+
+	@Test
+	public void testHashCode() {
+		assertEquals(31*31*31*31*31, new OAuth2AuthenticationDetails(mock()).hashCode());
+		assertEquals(31*(31*31*31*31 + "GET".hashCode()) + "/foo/bar".hashCode(),
+						new OAuth2AuthenticationDetails(mock("GET", "/foo/bar")).hashCode());
+	}
+
+	@Test
+	public void testEquals() {
+		OAuth2AuthenticationDetails details = new OAuth2AuthenticationDetails(mock("GET", "/foo/bar"));
+		assertEquals(details, new OAuth2AuthenticationDetails(mock("GET", "/foo/bar")));
+		assertNotEquals(details, new OAuth2AuthenticationDetails(mock("GET", "/bar/foo")));
+	}
+
+	@Test
+	public void testGetMethod() {
+		assertNull(new OAuth2AuthenticationDetails(mock()).getMethod());
+		assertEquals("FOO", new OAuth2AuthenticationDetails(mock("FOO")).getMethod());
+	}
+
+	@Test
+	public void testGetRequestURI() {
+		assertNull(new OAuth2AuthenticationDetails(mock()).getRequestURI());
+		assertEquals("/bar", new OAuth2AuthenticationDetails(mock(null, "/bar")).getRequestURI());
+	}
+
+	/**
+	 * Returns a new mock HttpServletRequest for given parameters in given order.  All must be {@code String}s
+	 * (if provided), except the third, which must be a {@code MockHttpSession}.
+	 *
+	 * @param args method, requestURI, session, remoteAddr, token type, token value
+	 */
+	private MockHttpServletRequest mock(Object... args) {
+		MockHttpServletRequest request = new MockHttpServletRequest(args.length < 1 ? null : (String)args[0],
+						args.length < 2 ? null : (String)args[1]);
+		request.setSession(args.length < 3 ? null : (MockHttpSession)args[2]);
+		request.setRemoteAddr(args.length < 4 ? null : (String)args[3]);
+		request.setAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_VALUE, args.length < 5 ? null : (String)args[4]);
+		request.setAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_TYPE, args.length < 6 ? null : (String)args[5]);
+		return request;
 	}
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/request/InMemoryResourceRequestDetailsServiceTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/request/InMemoryResourceRequestDetailsServiceTests.java
@@ -1,0 +1,92 @@
+package org.springframework.security.oauth2.provider.request;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.springframework.security.oauth2.provider.ResourceRequestDetails;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * @author Michael Kangas
+ */
+@RunWith(Parameterized.class)
+public class InMemoryResourceRequestDetailsServiceTests {
+  private static final Map<String, Map<String, Set<String>>> SCOPES = new HashMap<String, Map<String, Set<String>>>() {
+    {
+      for (Object[] row : new Object[][] {
+              { ".*", "/rest/**", emptySet() },
+              { "GET", "/**/objects/**", singleton("READ") },
+              { "PUT", "/**/objects/**", singleton("CREATE") },
+              { "POST", "/**/objects/**", singleton("UPDATE") },
+              { "DELETE", "/**/objects/**", singleton("REMOVE") },
+              { "PUT|POST|DELETE", "/**/administration/**", singleton("ADMINISTRATION") },
+              { ".*", "/**/photos/**", toSet("PHOTOS", "PROFILE") }
+      }) {
+        Map<String, Set<String>> m = get(row[0]);
+        if (m == null) {
+          m = new HashMap<String, Set<String>>();
+          put((String)row[0], m);
+        }
+        m.put((String)row[1], (Set)row[2]);
+      }
+    }
+  };
+
+  @Parameters
+  public static Collection<Object[]> parameters() {
+    return asList(new Object[][] {
+            // wildcard matches:
+            { emptySet(), "GET", "/rest" },  // no scope
+            { emptySet(), "", "/rest/" },  // no scope
+            { emptySet(), "FOO", "/rest/foobar" },  // no scope
+            { null, "GET", "/foobar" },  // unmatched resource
+
+            // typical matches:
+            { singleton("READ"), "GET", "/rest/objects/documents" },
+            { singleton("CREATE"), "PUT", "/rest/objects/documents" },
+
+            // disjoint matches:
+            { singleton("ADMINISTRATION"), "POST", "/administration" },
+            { singleton("ADMINISTRATION"), "PUT", "/administration" },
+
+            // multiple matches:
+            { toSet("PHOTOS", "PROFILE"), "POST", "/photos" },
+            { toSet("PROFILE", "READ", "PHOTOS"), "GET", "/objects/photos" }
+    });
+  }
+
+  @Parameter
+  public Set<String> expected;
+
+  @Parameter(value = 1)
+  public String requestMethod;
+
+  @Parameter(value = 2)
+  public String resourceURI;
+
+  @Test
+  public void testLoadResourceRequestDetails() {
+    InMemoryResourceRequestDetailsService service = new InMemoryResourceRequestDetailsService();
+    service.setRequestScopeStore(SCOPES);
+    ResourceRequestDetails details = service.loadResourceRequestDetails(requestMethod, resourceURI);
+
+    assertEquals(expected, details != null ? details.getScope() : null);
+  }
+
+  private static <E> Set<E> toSet(E... e) {
+    return new HashSet<E>(asList(e));
+  }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.provider.RequestTokenFactory;
 
 
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -105,7 +106,7 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scope);
 		OAuth2Authentication authentication = converter.extractAuthentication(tokenAttrs);
-		assertEquals(authentication.getOAuth2Request().getScope(), Collections.singleton(scope));
+		assertEquals(Collections.singleton(scope), authentication.getOAuth2Request().getScope());
 	}
 
 	// gh-745
@@ -115,7 +116,16 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scopes);
 		OAuth2Authentication authentication = converter.extractAuthentication(tokenAttrs);
-		assertEquals(authentication.getOAuth2Request().getScope(), scopes);
+		assertEquals(scopes, authentication.getOAuth2Request().getScope());
+	}
+
+	// gh-836 (passes incidentally per gh-745)
+	@Test
+	public void extractAuthenticationMultiScopeString() {
+		String scopes = "read write read-write";
+		assertEquals(new HashSet<String>(Arrays.asList(scopes.split(" "))),
+						converter.extractAuthentication(singletonMap(AccessTokenConverter.SCOPE,
+										scopes)).getOAuth2Request().getScope());
 	}
 
 	// gh-745
@@ -125,7 +135,7 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scope);
 		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value", tokenAttrs);
-		assertEquals(accessToken.getScope(), Collections.singleton(scope));
+		assertEquals(Collections.singleton(scope), accessToken.getScope());
 	}
 
 	// gh-745
@@ -135,7 +145,16 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scopes);
 		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value", tokenAttrs);
-		assertEquals(accessToken.getScope(), scopes);
+		assertEquals(scopes, accessToken.getScope());
+	}
+
+	// gh-836
+	@Test
+	public void extractAccessTokenMultiScopeString() {
+		String scopes = "read write read-write";
+		assertEquals(new HashSet<String>(Arrays.asList(scopes.split(" "))),
+						converter.extractAccessToken("token-value",
+										singletonMap(AccessTokenConverter.SCOPE, scopes)).getScope());
 	}
 
 }


### PR DESCRIPTION
Added support to `DefaultAccessTokenConverter` for multiple scopes expressed in a space-delimited string rather than a JSON array in resolution to #836.  (`extractAuthentication` incidentally works for such scopes due to side-effects from the resolution of #745; however, `extractAccessToken` does not.)
