### PR TITLE
Support for space-delimited scopes in DefaultAccessTokenConverter

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -12,6 +12,7 @@
  */
 package org.springframework.security.oauth2.provider.token;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -151,7 +152,7 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 		if (map.containsKey(SCOPE)) {
 			Object scopeObj = map.get(SCOPE);
 			if (String.class.isInstance(scopeObj)) {
-				scope = Collections.singleton(String.class.cast(scopeObj));
+				scope = new LinkedHashSet<String>(Arrays.asList(String.class.cast(scopeObj).split(" ")));
 			} else if (Collection.class.isAssignableFrom(scopeObj.getClass())) {
 				@SuppressWarnings("unchecked")
 				Collection<String> scopeColl = (Collection<String>) scopeObj;

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.provider.RequestTokenFactory;
 
 
 import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -105,7 +106,7 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scope);
 		OAuth2Authentication authentication = converter.extractAuthentication(tokenAttrs);
-		assertEquals(authentication.getOAuth2Request().getScope(), Collections.singleton(scope));
+		assertEquals(Collections.singleton(scope), authentication.getOAuth2Request().getScope());
 	}
 
 	// gh-745
@@ -115,7 +116,16 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scopes);
 		OAuth2Authentication authentication = converter.extractAuthentication(tokenAttrs);
-		assertEquals(authentication.getOAuth2Request().getScope(), scopes);
+		assertEquals(scopes, authentication.getOAuth2Request().getScope());
+	}
+
+	// gh-836 (passes incidentally per gh-745)
+	@Test
+	public void extractAuthenticationMultiScopeString() {
+		String scopes = "read write read-write";
+		assertEquals(new HashSet<String>(Arrays.asList(scopes.split(" "))),
+						converter.extractAuthentication(singletonMap(AccessTokenConverter.SCOPE,
+										scopes)).getOAuth2Request().getScope());
 	}
 
 	// gh-745
@@ -125,7 +135,7 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scope);
 		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value", tokenAttrs);
-		assertEquals(accessToken.getScope(), Collections.singleton(scope));
+		assertEquals(Collections.singleton(scope), accessToken.getScope());
 	}
 
 	// gh-745
@@ -135,7 +145,16 @@ public class DefaultAccessTokenConverterTests {
 		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
 		tokenAttrs.put(AccessTokenConverter.SCOPE, scopes);
 		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value", tokenAttrs);
-		assertEquals(accessToken.getScope(), scopes);
+		assertEquals(scopes, accessToken.getScope());
+	}
+
+	// gh-836
+	@Test
+	public void extractAccessTokenMultiScopeString() {
+		String scopes = "read write read-write";
+		assertEquals(new HashSet<String>(Arrays.asList(scopes.split(" "))),
+						converter.extractAccessToken("token-value",
+										singletonMap(AccessTokenConverter.SCOPE, scopes)).getScope());
 	}
 
 }


### PR DESCRIPTION
Fixed `DefaultAccessTokenConverter` to correctly handle, in all cases, the extraction of multiple scopes expressed as a space-delimited string rather than a JSON array in resolution to #836.  E.g., the [draft OAuth 2.0 Token Introspection](https://tools.ietf.org/html/draft-ietf-oauth-introspection-11#section-2.2) standard specifies such scopes.  (`DefaultAccessTokenConverter.extractAuthentication()` incidentally works for such scopes due to side effects from the resolution of #745; however, `extractAccessToken()` does not.)
