### PR TITLE
Removed client_id check in RemoteTokenServices

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -111,7 +111,6 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 			throw new InvalidTokenException(accessToken);
 		}
 
-		Assert.state(map.containsKey("client_id"), "Client id must be present in response from auth server");
 		return tokenConverter.extractAuthentication(map);
 	}
 


### PR DESCRIPTION
Fixes #838 by removing the check for `client_id` in `RemoteTokenServices.loadAuthentication()`.  This check is inappropriate as it's the `ResourceServerTokenServices`' responsibility only to load tokens, not to judge them (other than as invalid in the event of an explicit error response). [RFC 6749](https://tools.ietf.org/html/rfc6749#section-7) doesn't specify the contents of such _check token_ endpoint responses while, for example, [RFC 7662](https://tools.ietf.org/html/rfc7662#section-2.2) explicitly makes `client_id` optional for `introspection` endpoints.
