### PR TITLE
Fix markdown header parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@ Security programming models and configuration idioms.
 * OAuth 2.0.
 
 <span id="quick-start"></span>
+
 ## Quick Start
 
 {% include download_widget.md %}


### PR DESCRIPTION
This fixes Markdown getting confused on the `## Quick Start` header
