### PR TITLE
Remove Jackson 1 dependency from oauth2 project

### DIFF
--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -13,7 +13,6 @@
 	<description>Module for providing OAuth2 support to Spring Security</description>
 
 	<properties>
-		<jackson1.version>1.9.13</jackson1.version>
 		<jackson2.version>2.3.2</jackson2.version>
 		<spring.security.jwt.version>1.0.2.RELEASE</spring.security.jwt.version>
 	</properties>
@@ -135,12 +134,6 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>${jackson1.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The `jackson-mapper-asl` doesn't seems to be used anywhere... :/ 
