### PR TITLE
fix NPE while recreating token in case of existing non expiring token

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
@@ -139,7 +139,7 @@ public class ApprovalStoreUserApprovalHandler implements UserApprovalHandler, In
 		// Look at the scopes and see if they have expired
 		Date today = new Date();
 		for (Approval approval : userApprovals) {
-			if (approval.getExpiresAt().after(today)) {
+			if (approval.getExpiresAt() == null || approval.getExpiresAt().after(today)) {
 				if (approval.getStatus() == ApprovalStatus.APPROVED) {
 					validUserApprovedScopes.add(approval.getScope());
 					approvedScopes.add(approval.getScope());

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/JdbcApprovalStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/JdbcApprovalStore.java
@@ -190,7 +190,7 @@ public class JdbcApprovalStore implements ApprovalStore {
 		int refreshed = jdbcTemplate.update(sql, new PreparedStatementSetter() {
 			@Override
 			public void setValues(PreparedStatement ps) throws SQLException {
-				ps.setTimestamp(1, new Timestamp(approval.getExpiresAt().getTime()));
+				ps.setTimestamp(1, approval.getExpiresAt() == null ? null : new Timestamp(approval.getExpiresAt().getTime()));
 				ps.setString(2, (approval.getStatus() == null ? APPROVED : approval.getStatus()).toString());
 				ps.setTimestamp(3, new Timestamp(approval.getLastUpdatedAt().getTime()));
 				ps.setString(4, approval.getUserId());

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandlerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandlerTests.java
@@ -1,15 +1,5 @@
 package org.springframework.security.oauth2.provider.approval;
 
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -20,6 +10,10 @@ import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.security.oauth2.provider.client.InMemoryClientDetailsService;
 import org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestFactory;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
 
 public class ApprovalStoreUserApprovalHandlerTests {
 
@@ -136,4 +130,11 @@ public class ApprovalStoreUserApprovalHandlerTests {
 		assertFalse(result.isApproved());
 	}
 
+    @Test
+    public void testApprovalWithNoExpirationDate() throws Exception {
+        store.addApprovals(Arrays.asList(new Approval("user", "client", "read", null, Approval.ApprovalStatus.APPROVED)));
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest("client", Arrays.asList("read"));
+        AuthorizationRequest result = handler.checkForPreApproval(authorizationRequest, userAuthentication);
+        assertTrue(result.isApproved());
+    }
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/JdbcApprovalStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/JdbcApprovalStoreTests.java
@@ -16,12 +16,6 @@
 
 package org.springframework.security.oauth2.provider.approval;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.Date;
-
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -29,8 +23,15 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.security.oauth2.provider.approval.Approval.ApprovalStatus;
 
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Dave Syer
+ * @author Igor Bereza
  * 
  */
 public class JdbcApprovalStoreTests extends AbstractTestApprovalStore {
@@ -70,4 +71,11 @@ public class JdbcApprovalStoreTests extends AbstractTestApprovalStore {
 								Integer.class,
 								new Date(System.currentTimeMillis() + 1000)));
 	}
+
+    @Test
+    public void testWithNonExpiringApprovals() {
+        Approval approval = new Approval("user", "client", "read", null,
+              ApprovalStatus.APPROVED);
+        assertTrue(store.addApprovals(Arrays.<Approval>asList(approval)));
+    }
 }


### PR DESCRIPTION
Hi all!
Thanks for your awesome framework.
I think i've found a bug.
When we have a non-exipiring token and client application wants to re-create token, sending to oauth/autorize path with parameters. Then we will get NPE in method 

```
ApprovalStoreUserApprovalHandler.checkForPreApproval(AuthorizationRequest authorizationRequest,
            Authentication userAuthentication)
```

at this line 

```
if (approval.getExpiresAt().after(today))
```

So the rootcause is :
We configuring clients with ClientDetailsServiceConfigurer setting accessTokenValiditySeconds to 0. (So our token should never be expired)

In this case when the token will be created at method 

```
DefaultTokenServices.createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken)
```

we have a condition 

```
if (validitySeconds > 0) {
            token.setExpiration(new Date(System.currentTimeMillis() + (validitySeconds * 1000L)));
        }
```

And Approval will be created (in method 

```
TokenApprovalStore.getApprovals(String userId, String clientId)
```

) with null expireAt Date.
That's why NPE appears.

I've attached a solution for null checking and tests for all usages, that i've found.
Maybe it has more elegant solution. Please let me know.
Thanks again for your work:)
