### PR TITLE
Fix for duplicated access tokens

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -173,11 +173,14 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 			refreshToken = createRefreshToken(authentication);
 		}
 
-		OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken);
-		tokenStore.storeAccessToken(accessToken, authentication);
+		DefaultOAuth2AccessToken accessToken = new DefaultOAuth2AccessToken(
+				createAccessToken(authentication, refreshToken));
 		if (!reuseRefreshToken) {
 			tokenStore.storeRefreshToken(accessToken.getRefreshToken(), authentication);
+		} else {
+			accessToken.setRefreshToken(refreshToken);
 		}
+		tokenStore.storeAccessToken(accessToken, authentication);
 		return accessToken;
 	}
 


### PR DESCRIPTION
There is an attempt to create duplicated access tokens in oauth_access_token database table (attempt to insert rows with same token_id). This is related to the following [question](https://github.com/spring-projects/spring-security-oauth/issues/853).

[Preconditions]
1. JdbcTokenStore is used to persist the tokens.
2. JwtAccessTokenConverter is used to enhance the tokens.
3. oauth_access_token and oauth_refresh_token are empty.

[Steps]
1. Request access token by login/password pair.
```
curl -X POST -vu app123:TBe6G9W1e8Uv http://localhost:8090/oauth/token -H "Accept: application/json" -d "password=qwerty&username=max&grant_type=password&scope=read%20write&client_secret=TBe6G9W1t7Uv&client_id=app123"
```
Authorization service returns access token with refresh token.
```
{"access_token":"eyJasdD...SsdDss","token_type":"bearer","refresh_token":"eysdSJ...bnSDsc","expires_in":59,"scope":"read write","jti":"486f14dd-eaea3-422e-9f50-852072ba8b7e"}
```
2. Refresh access token by previously received refresh token.
```
curl -X POST -vu app123:TBe6G9W1t7Uv http://localhost:8090/oauth/token -H "Accept: application/json" -d "refresh_token=eysdSJ...bnSDsc&grant_type=refresh_token&scope=read%20write&client_secret=TBe6G9W1t7Uv&client_id=app123"
```
The existing access token is removed. In DefaultTokenServices.refreshAccessToken when creating new access token the given refresh token is overwritten with a new one (when enhancing it) here:
[JwtAccessTokenConverter.java](https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JwtAccessTokenConverter.java#L15)
```
line 236: DefaultOAuth2RefreshToken token = new DefaultOAuth2RefreshToken(encode(
					encodedRefreshToken, authentication)); 
```
Then this is saved into oauth_access_token table. So oauth_access_token and oauth_refresh_token become out of sync (oauth_refresh_token has the previous refresh token and oauth_access_token (refresh_token column) has the new generated one).
3. Refresh access token once again by the same refresh token received in step 1.
Because we can't find the access token by the given refresh token, a duplicated access token is inserted into oauth_access_token table (with same token_id).