### PR TITLE
Correct OAuth2 deserializers to handle OAuth server returning access denied errors

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson1Deserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson1Deserializer.java
@@ -23,6 +23,7 @@ import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 
 /**
@@ -104,7 +105,7 @@ public class OAuth2ExceptionJackson1Deserializer extends JsonDeserializer<OAuth2
 			ex = new UnsupportedResponseTypeException(errorMessage);
 		}
 		else if ("access_denied".equals(errorCode)) {
-			ex = new UserDeniedAuthorizationException(errorMessage);
+			ex = new OAuth2AccessDeniedException(errorMessage);
 		}
 		else if ("insufficient_scope".equals(errorCode)) {
 			ex = new InsufficientScopeException(errorMessage, OAuth2Utils.parseParameterList((String) errorParams

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson2Deserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson2Deserializer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 
 /**
@@ -113,7 +114,7 @@ public class OAuth2ExceptionJackson2Deserializer extends StdDeserializer<OAuth2E
 					.get("scope")));
 		}
 		else if ("access_denied".equals(errorCode)) {
-			ex = new UserDeniedAuthorizationException(errorMessage);
+			ex = new OAuth2AccessDeniedException(errorMessage);
 		}
 		else {
 			ex = new OAuth2Exception(errorMessage);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/OAuth2ExceptionDeserializerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/OAuth2ExceptionDeserializerTests.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.security.oauth2.common.exceptions.*;
 
 /**
@@ -87,7 +88,7 @@ public class OAuth2ExceptionDeserializerTests {
 	@Test
 	public void readValueAccessDenied() throws Exception {
 		String accessToken = createResponse(OAuth2Exception.ACCESS_DENIED);
-		UserDeniedAuthorizationException result = (UserDeniedAuthorizationException) mapper.readValue(accessToken,
+		OAuth2AccessDeniedException result = (OAuth2AccessDeniedException) mapper.readValue(accessToken,
 				OAuth2Exception.class);
 		assertEquals(DETAILS,result.getMessage());
 		assertEquals(null,result.getAdditionalInformation());

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/OAuth2ExceptionJackson2DeserializerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/exception/OAuth2ExceptionJackson2DeserializerTests.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.security.oauth2.common.exceptions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -88,7 +89,7 @@ public class OAuth2ExceptionJackson2DeserializerTests {
 	@Test
 	public void readValueAccessDenied() throws Exception {
 		String accessToken = createResponse(OAuth2Exception.ACCESS_DENIED);
-		UserDeniedAuthorizationException result = (UserDeniedAuthorizationException) mapper.readValue(accessToken,
+		OAuth2AccessDeniedException result = (OAuth2AccessDeniedException) mapper.readValue(accessToken,
 				OAuth2Exception.class);
 		assertEquals(DETAILS,result.getMessage());
 		assertEquals(null,result.getAdditionalInformation());


### PR DESCRIPTION
Update OAuth2 exception deserializers to deserialize access denied exceptions into the OAuth2AccessDeniedException. By merging this change the OAuth server and OAuth client will agree on HTTP status code 403 when the OAuth client is denied access to perform the requested action.

Fixes gh-810