### PR TITLE
Always sort scopes before creating the MD5 checksum

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/MapDigester.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/MapDigester.java
@@ -1,0 +1,27 @@
+package org.springframework.security.oauth2.common.util;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+
+public class MapDigester {
+    public String digest(Map values) {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("MD5");
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 algorithm not available.  Fatal (should be in the JDK).");
+        }
+
+        try {
+            byte[] bytes = digest.digest(values.toString().getBytes("UTF-8"));
+            return String.format("%032x", new BigInteger(1, bytes));
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 encoding not available.  Fatal (should be in the JDK).");
+        }
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAuthenticationKeyGenerator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAuthenticationKeyGenerator.java
@@ -12,16 +12,14 @@
  */
 package org.springframework.security.oauth2.provider.token;
 
-import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
+import org.springframework.security.oauth2.common.util.MapDigester;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeSet;
 
 /**
  * Basic key generator taking into account the client id, scope, resource ids and username (principal name) if they
@@ -38,6 +36,8 @@ public class DefaultAuthenticationKeyGenerator implements AuthenticationKeyGener
 
 	private static final String USERNAME = "username";
 
+	private MapDigester mapDigester = new MapDigester();
+
 	public String extractKey(OAuth2Authentication authentication) {
 		Map<String, String> values = new LinkedHashMap<String, String>();
 		OAuth2Request authorizationRequest = authentication.getOAuth2Request();
@@ -46,23 +46,9 @@ public class DefaultAuthenticationKeyGenerator implements AuthenticationKeyGener
 		}
 		values.put(CLIENT_ID, authorizationRequest.getClientId());
 		if (authorizationRequest.getScope() != null) {
-			values.put(SCOPE, OAuth2Utils.formatParameterList(authorizationRequest.getScope()));
+			values.put(SCOPE, OAuth2Utils.formatParameterList(new TreeSet<String>(authorizationRequest.getScope())));
 		}
-		MessageDigest digest;
-		try {
-			digest = MessageDigest.getInstance("MD5");
-		}
-		catch (NoSuchAlgorithmException e) {
-			throw new IllegalStateException("MD5 algorithm not available.  Fatal (should be in the JDK).");
-		}
-
-		try {
-			byte[] bytes = digest.digest(values.toString().getBytes("UTF-8"));
-			return String.format("%032x", new BigInteger(1, bytes));
-		}
-		catch (UnsupportedEncodingException e) {
-			throw new IllegalStateException("UTF-8 encoding not available.  Fatal (should be in the JDK).");
-		}
+		return mapDigester.digest(values);
 	}
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAuthenticationKeyGeneratorTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAuthenticationKeyGeneratorTest.java
@@ -1,0 +1,111 @@
+package org.springframework.security.oauth2.provider.token;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.common.util.MapDigester;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultAuthenticationKeyGeneratorTest {
+    private static final String USERNAME = "name";
+    private static final String CLIENT_ID = "client-id";
+    private static final String CHECKSUM = "checksum";
+    @Mock
+    private OAuth2Authentication auth;
+    @Mock
+    private MapDigester mapDigester;
+    @InjectMocks
+    private DefaultAuthenticationKeyGenerator generator;
+
+    @Before
+    public void setUp() throws Exception {
+        when(auth.getName()).thenReturn(USERNAME);
+        when(mapDigester.digest(anyMap())).thenReturn(CHECKSUM);
+    }
+
+    @Test
+    public void shouldUseTheChecksumGeneratedByTheDigest() {
+        when(auth.getOAuth2Request()).thenReturn(newOauthRequest(CLIENT_ID));
+        when(mapDigester.digest(anyMap())).thenReturn(CHECKSUM);
+
+        assertEquals(CHECKSUM, generator.extractKey(auth));
+    }
+
+    @Test
+    public void shouldOnlyUseTheUsernameAsPartOfTheDigestIfTheAuthIsClientOnly() {
+        when(auth.isClientOnly()).thenReturn(true);
+        when(auth.getOAuth2Request()).thenReturn(newOauthRequest(CLIENT_ID));
+
+        generator.extractKey(auth);
+
+        LinkedHashMap<String, String> expectedValues = new LinkedHashMap<String, String>();
+        expectedValues.put("client_id", CLIENT_ID);
+        expectedValues.put("scope", "");
+        verify(mapDigester).digest(expectedValues);
+    }
+
+    @Test
+    public void shouldNotUseScopesIfNoneAreProvided() {
+        when(auth.getOAuth2Request()).thenReturn(newOauthRequest(CLIENT_ID));
+
+        generator.extractKey(auth);
+
+        LinkedHashMap<String, String> expectedValues = new LinkedHashMap<String, String>();
+        expectedValues.put("username", USERNAME);
+        expectedValues.put("client_id", CLIENT_ID);
+        expectedValues.put("scope", "");
+        verify(mapDigester).digest(expectedValues);
+    }
+
+    @Test
+    public void shouldSortTheScopesBeforeDigesting() {
+        when(auth.getOAuth2Request()).thenReturn(newOauthRequest(CLIENT_ID, "3", "1", "2"));
+
+        generator.extractKey(auth);
+
+        LinkedHashMap<String, String> expectedValues = new LinkedHashMap<String, String>();
+        expectedValues.put("username", USERNAME);
+        expectedValues.put("client_id", CLIENT_ID);
+        expectedValues.put("scope", "1 2 3");
+        verify(mapDigester).digest(expectedValues);
+    }
+
+    private OAuth2Request newOauthRequest(String clientId, String... scopes) {
+        Set<String> scopeSet = new LinkedHashSet<String>(Arrays.asList(scopes));
+        if (scopes.length == 0) {
+            scopeSet = null;
+        }
+
+        return new OAuth2Request(
+                new HashMap<String, String>(),
+                clientId,
+                new ArrayList<GrantedAuthority>(),
+                true,
+                scopeSet,
+                new HashSet<String>(),
+                "redirect-uri",
+                new HashSet<String>(),
+                new HashMap<String, Serializable>()
+        );
+    }
+}


### PR DESCRIPTION
This fixes #874 where authorization ids could be generated differently if there was more then one scope.  This was due to the scopes being stored in a set but not sorted prior to hashing the values.  

For example:
```java
// Given these sets
Set<String> a = new LinkedHashSet<String>(Arrays.asList("a", "c", "b"));
Set<String> b = new LinkedHashSet<String>(Arrays.asList("c", "a", "b"));

// this would be true
Assert.assertEquals(a, b);

// due to order differences 
Assert.assertNotEquals(OAuth2Utils.formatParameterList(a), OAuth2Utils.formatParameterList(b)); 

// now being sorted the string will be equal
Assert.assertEquals(OAuth2Utils.formatParameterList(new TreeSet(a)), OAuth2Utils.formatParameterList(new TreeSet(b))); 

```

If you subclass `DefaultAuthenticationKeyGenerator` and override the method `extractKey(...)` and make it return a debuggable key like below: 
```Java
Map<String, String> values = new LinkedHashMap<String, String>();
OAuth2Request authorizationRequest = authentication.getOAuth2Request();
if (!authentication.isClientOnly()) {
   values.put(USERNAME, authentication.getName());
}
values.put(CLIENT_ID, authorizationRequest.getClientId());
if (authorizationRequest.getScope() != null) {
  values.put(SCOPE, OAuth2Utils.formatParameterList(authorizationRequest.getScope()));
}
return values.toString();
```

You will see the `scopes` are some times out of order so the `authentication_id` will have a different checksum value.


