### PR TITLE
Fix autoapprovals not being added to approval store

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandler.java
@@ -117,6 +117,15 @@ public class ApprovalStoreUserApprovalHandler implements UserApprovalHandler, In
 					}
 				}
 				if (approvedScopes.containsAll(requestedScopes)) {
+					// gh-807 - if all scopes are auto approved, approvals still need to be added to the approval store.
+					Set<Approval> approvals = new HashSet<Approval>();
+					Date expiry = computeExpiry();
+					for (String approvedScope : approvedScopes) {
+						approvals.add(new Approval(userAuthentication.getName(), authorizationRequest.getClientId(),
+								approvedScope, expiry, ApprovalStatus.APPROVED));
+					}
+					approvalStore.addApprovals(approvals);
+
 					authorizationRequest.setApproved(true);
 					return authorizationRequest;
 				}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandlerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/ApprovalStoreUserApprovalHandlerTests.java
@@ -117,6 +117,22 @@ public class ApprovalStoreUserApprovalHandlerTests {
 	}
 
 	@Test
+	public void testApprovalsAddedForAutoapprovedScopes() {
+		handler.setClientDetailsService(clientDetailsService);
+		BaseClientDetails client = new BaseClientDetails("client", null, "read", "authorization_code", null);
+		client.setAutoApproveScopes(new HashSet<String>(Arrays.asList("read")));
+		clientDetailsService.setClientDetailsStore(Collections.singletonMap("client", client));
+		AuthorizationRequest authorizationRequest = new AuthorizationRequest("client", Arrays.asList("read"));
+		AuthorizationRequest result = handler.checkForPreApproval(authorizationRequest, userAuthentication);
+
+		Collection<Approval> approvals = store.getApprovals(userAuthentication.getName(), "client");
+		assertEquals(1, approvals.size());
+
+		Approval approval = approvals.iterator().next();
+		assertEquals("read", approval.getScope());
+	}
+
+	@Test
 	public void testAutoapprovedAllScopes() {
 		handler.setClientDetailsService(clientDetailsService);
 		BaseClientDetails client = new BaseClientDetails("client", null, "read", "authorization_code", null);


### PR DESCRIPTION
#807 was marked as fixed, but there is still an issue if the scopes are autoapproved - the approvals are never actually inserted into the `ApprovalStore` if _all_ scopes are auto approved, which causes the refresh token to result in an `InvalidGrantException` because there are no approvals in the store.