### PR TITLE
Support curly braces on authorize endpoint

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -426,12 +426,12 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 				if (keys != null && keys.containsKey(key)) {
 					name = keys.get(key);
 				}
-				values.append(name + "={" + key + "}");
+				values.append(name + "=" + (query.get(key) == null ? "" : query.get(key).toString()));
 			}
 			if (values.length() > 0) {
 				template.fragment(values.toString());
 			}
-			UriComponents encoded = template.build().expand(query).encode();
+			UriComponents encoded = template.build().encode();
 			builder.fragment(encoded.getFragment());
 		}
 		else {
@@ -440,10 +440,10 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 				if (keys != null && keys.containsKey(key)) {
 					name = keys.get(key);
 				}
-				template.queryParam(name, "{" + key + "}");
+				template.queryParam(name, query.get(key) == null ? "" : query.get(key).toString());
 			}
 			template.fragment(redirectUri.getFragment());
-			UriComponents encoded = template.build().expand(query).encode();
+			UriComponents encoded = template.build().encode();
 			builder.query(encoded.getQuery());
 		}
 


### PR DESCRIPTION
This proposes a fix to issue https://github.com/spring-projects/spring-security-oauth/issues/892

The problem comes from the `UriComponentsBuilder.expand()` method that can't make the difference between the original curly braces in the URI and the braces that are appended to be replace by the values in the `query` map. I changed this to append directly the values by using Objects.toString to avoid a NullPointerException. 
