### PR TITLE
@WithMockOAuth2Scopes test helpers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <commons-codec.version>1.9</commons-codec.version>
     <spring.version>4.0.9.RELEASE</spring.version>
     <spring.security.version>3.2.8.RELEASE</spring.security.version>
+    <spring.security.test.version>4.0.4.RELEASE</spring.security.test.version>
     <java.version>1.6</java.version>
   </properties>
 
@@ -233,6 +234,12 @@
 			<artifactId>spring-security-core</artifactId>
 			<version>${spring.security.version}</version>
 		</dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring.security.test.version}</version>
+        </dependency>
 
 		<dependency>
 			<groupId>org.springframework.security</groupId>

--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -112,6 +112,11 @@
 
 		<dependency>
 			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-config</artifactId>
 		</dependency>
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2Scopes.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2Scopes.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.test.context.support;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.test.context.support.WithSecurityContext;
+import org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When used with {@link WithSecurityContextTestExecutionListener} this annotation can be
+ * added to a test method to emulate running with a mocked user. In order to work with
+ * {@link MockMvc} The {@link SecurityContext} that is used will have the following
+ * properties:
+ *
+ * <ul>
+ * <li>The {@link SecurityContext} created will be that of
+ * {@link SecurityContextHolder#createEmptyContext()}</li>
+ * <li>It will be populated with an {@link OAuth2Authentication} that uses
+ * the scopes provided in {@link #scopes()}.
+ * </ul>
+ *
+ * @see WithMockOAuth2Scopes
+ *
+ * @author Michael Claassen
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockOAuth2ScopesSecurityContextFactory.class)
+public @interface WithMockOAuth2Scopes {
+    /**
+     * The scopes to be used. The default is no scopes.
+     * @return
+     */
+    String[] scopes() default {};
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2Scopes.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2Scopes.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 /**
  * When used with {@link WithSecurityContextTestExecutionListener} this annotation can be
  * added to a test method to emulate running with a mocked user. In order to work with
- * {@link MockMvc} The {@link SecurityContext} that is used will have the following
+ * MockMvc The {@link SecurityContext} that is used will have the following
  * properties:
  *
  * <ul>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesRule.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesRule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.test.context.support;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * When used with {@link org.junit.Rule} or {@link org.junit.ClassRule}
+ * performs setup to run tests with a {@link SecurityContext} populated
+ * with an {@link OAuth2Authentication} that uses the scopes provided in
+ * the constructor.
+ *
+ * @author Michael Claassen
+ */
+public class WithMockOAuth2ScopesRule implements TestRule {
+
+    private Set<String> scopes;
+
+    public WithMockOAuth2ScopesRule(String[] scopes) {
+        this.scopes = new HashSet<String>();
+
+        for(String scope : scopes) {
+            this.scopes.add(scope);
+        }
+    }
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+                OAuth2Request request = new OAuth2Request(null, null, null, true, scopes, null, null, null, null);
+
+                Authentication auth = new OAuth2Authentication(request, null);
+
+                context.setAuthentication(auth);
+
+                SecurityContextHolder.setContext(context);
+
+                base.evaluate();
+            }
+        };
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesSecurityContextFactory.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesSecurityContextFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.test.context.support;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A {@link WithMockOAuth2ScopesSecurityContextFactory} that works with {@link WithMockOAuth2Scopes}.
+ *
+ * @author Michael Claassen
+ *
+ * @see WithMockOAuth2Scopes
+ */
+public final class WithMockOAuth2ScopesSecurityContextFactory implements WithSecurityContextFactory<WithMockOAuth2Scopes> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockOAuth2Scopes mockOAuth2Scopes) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        Set<String> scopes = new HashSet<String>();
+
+        for(String scope : mockOAuth2Scopes.scopes()) {
+            scopes.add(scope);
+        }
+
+        OAuth2Request request = new OAuth2Request(null, null, null, true, scopes, null, null, null, null);
+
+        Authentication auth = new OAuth2Authentication(request, null);
+
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesRuleTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesRuleTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.test.context.support;
+
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WithMockOAuth2ScopesRuleTests {
+
+    boolean baseWasRun = false;
+
+    @Test
+    public void ruleWorks() throws Throwable {
+        WithMockOAuth2ScopesRule rule = new WithMockOAuth2ScopesRule(new String[] {"A", "B", "C"});
+
+        Statement base = new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                baseWasRun = true;
+            }
+        };
+
+        rule.apply(base, null).evaluate();
+
+        Set<String> scopes = ((OAuth2Authentication)SecurityContextHolder.getContext().getAuthentication()).getOAuth2Request().getScope();
+
+        assertThat(scopes, hasItems("A", "B", "C"));
+        assertThat(baseWasRun, is(true));
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesSecurityContextFactoryTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesSecurityContextFactoryTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.test.context.support;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WithMockOAuth2ScopesSecurityContextFactoryTests {
+
+    @Mock
+    WithMockOAuth2Scopes withMockOAuth2Scopes;
+
+    private WithMockOAuth2ScopesSecurityContextFactory factory;
+
+    @Before
+    public void setup() {
+        factory = new WithMockOAuth2ScopesSecurityContextFactory();
+    }
+
+    @Test
+    public void scopesWork() {
+        when(withMockOAuth2Scopes.scopes()).thenReturn(new String[]{"A", "B", "C"});
+
+        Set<String> scopes = ((OAuth2Authentication)factory.createSecurityContext(withMockOAuth2Scopes).getAuthentication()).getOAuth2Request().getScope();
+
+        assertThat(scopes, hasItems("A", "B", "C"));
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/test/context/support/WithMockOAuth2ScopesTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.test.context.support;
+
+
+import org.junit.Test;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class WithMockOAuth2ScopesTests {
+
+    @Test
+    public void annotationWorks() {
+        WithMockOAuth2Scopes withMockOAuth2Scopes = AnnotationUtils.findAnnotation(Annotated.class, WithMockOAuth2Scopes.class);
+
+        List<String> scopes = new ArrayList<String>();
+
+        for(String scope : withMockOAuth2Scopes.scopes()) {
+            scopes.add(scope);
+        }
+
+        assertThat(scopes, hasItems("A", "B", "C"));
+    }
+
+    @WithMockOAuth2Scopes(scopes = {"A", "B", "C"})
+    class Annotated {
+
+    }
+}


### PR DESCRIPTION
New test helpers similar to the ones here: https://github.com/spring-projects/spring-security/tree/master/test/src/main/java/org/springframework/security/test/context/support but for mocking OAuth2 scopes.