### PR TITLE
Change DefaultUserAuthenticationConverter#getAuthorities to protected method

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
@@ -82,7 +82,7 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 		return null;
 	}
 
-	private Collection<? extends GrantedAuthority> getAuthorities(Map<String, ?> map) {
+	protected Collection<? extends GrantedAuthority> getAuthorities(Map<String, ?> map) {
 		if (!map.containsKey(AUTHORITIES)) {
 			return defaultAuthorities;
 		}


### PR DESCRIPTION
I've changed the `DefaultUserAuthenticationConverter#getAuthorities` to protected method for improve extensibility.
I want to create a class that extend the `DefaultUserAuthenticationConverter`.
