### PR TITLE
RemoteTokenServices should not check for client_id

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -111,7 +111,9 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 			throw new InvalidTokenException(accessToken);
 		}
 
-		Assert.state(map.containsKey("client_id"), "Client id must be present in response from auth server");
+		if (!map.containsKey(AccessTokenConverter.CLIENT_ID)) {
+			map.put(AccessTokenConverter.CLIENT_ID, clientId);
+		}
 		return tokenConverter.extractAuthentication(map);
 	}
 


### PR DESCRIPTION
PR for issue #838 

Per RFC 6749 (which doesn't address the topic)
and RFC 7662 (which explicitly permits this),
a valid check token response from the authorization
server might not contain a client_id.

This fix adress that, using the client_id used
for calling the introspect endpoint to avoid
impacting DefaultAccessTokenConverter.