### PR TITLE
958: RemoteTokenServices should handle active

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -111,6 +111,12 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 			throw new InvalidTokenException(accessToken);
 		}
 
+		Boolean active = (Boolean) map.get("active");
+		if (active != null && active == false) {
+			logger.debug("check_token returned inactive token");
+			throw new InvalidTokenException(accessToken);
+		}
+
 		Assert.state(map.containsKey("client_id"), "Client id must be present in response from auth server");
 		return tokenConverter.extractAuthentication(map);
 	}


### PR DESCRIPTION
PR for issue #958 

RTS should handle active attribute in response
as per rfc7662.

active=false means the token is expired and now
raises a InvalidTokenException.