### PR TITLE
#1009 Provide TokenExpiredException to distinguish invalid and expired tokens

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/ExpiredTokenException.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/ExpiredTokenException.java
@@ -1,0 +1,14 @@
+package org.springframework.security.oauth2.common.exceptions;
+
+/**
+ * Exception thrown when a token has been expired.
+ *
+ * @author Evgeny Mironenko
+ */
+@SuppressWarnings("serial")
+public class ExpiredTokenException extends InvalidTokenException {
+
+    public ExpiredTokenException(String msg) {
+        super(msg);
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/CheckTokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/CheckTokenEndpoint.java
@@ -18,6 +18,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.ExpiredTokenException;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -76,7 +77,7 @@ public class CheckTokenEndpoint {
 		}
 
 		if (token.isExpired()) {
-			throw new InvalidTokenException("Token has expired");
+			throw new ExpiredTokenException("Token has expired");
 		}
 
 		OAuth2Authentication authentication = resourceServerTokenServices.loadAuthentication(token.getValue());

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
+import org.springframework.security.oauth2.common.exceptions.ExpiredTokenException;
 import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
@@ -163,7 +164,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 
 		if (isExpired(refreshToken)) {
 			tokenStore.removeRefreshToken(refreshToken);
-			throw new InvalidTokenException("Invalid refresh token (expired): " + refreshToken);
+			throw new ExpiredTokenException("Invalid refresh token (expired): " + refreshToken);
 		}
 
 		authentication = createRefreshedAuthentication(authentication, tokenRequest);
@@ -232,7 +233,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 		}
 		else if (accessToken.isExpired()) {
 			tokenStore.removeAccessToken(accessToken);
-			throw new InvalidTokenException("Access token expired: " + accessTokenValue);
+			throw new ExpiredTokenException("Access token expired: " + accessTokenValue);
 		}
 
 		OAuth2Authentication result = tokenStore.readAuthentication(accessToken);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChainTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChainTests.java
@@ -45,7 +45,7 @@ import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
-import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.common.exceptions.ExpiredTokenException;
 
 /**
  * @author Dave Syer
@@ -155,7 +155,7 @@ public class AccessTokenProviderChainTests {
 		assertNotNull(token);
 	}
 
-	@Test(expected = InvalidTokenException.class)
+	@Test(expected = ExpiredTokenException.class)
 	public void testSunnyDayWIthExpiredTokenAndExpiredRefreshToken() throws Exception {
 		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
 		accessToken.setExpiration(new Date(System.currentTimeMillis() - 1000));
@@ -310,7 +310,7 @@ public class AccessTokenProviderChainTests {
 				if (((ExpiringOAuth2RefreshToken) refreshToken).getExpiration().getTime() < System
 						.currentTimeMillis()) {
 					// this is what a real provider would do (re-throw a remote exception)
-					throw new InvalidTokenException("Expired refresh token");
+					throw new ExpiredTokenException("Expired refresh token");
 				}
 			}
 			return refreshedToken;


### PR DESCRIPTION
In accordance with OAuth2 Specification, response with error code `invalid_token` have to be returned to a client in case if the access token provided is expired, revoked, malformed, invalid for other reasons https://tools.ietf.org/html/rfc6750#section-3.1 So, there is no `expired_token` error code that we may return to a client. However, despite the limitations of the specification, sometimes we have to distinguish invalid and expired tokens to show different pages on the UI. `TokenExpiredException` that I've added, is thrown when a token has been expired. Now user is able to catch this exception, e.g. in a custom `AuthenticationEntryPoint`, and handle it as he wants.