### PR TITLE
Bugfix/Allow double JWT exp values

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -104,7 +104,13 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 		info.remove(CLIENT_ID);
 		info.remove(SCOPE);
 		if (map.containsKey(EXP)) {
-			token.setExpiration(new Date((Long) map.get(EXP) * 1000L));
+			Object expObject = map.get(EXP);
+			if (expObject instanceof Double) {
+				token.setExpiration(new Date((long) ((Double) expObject * 1000D)));
+			}
+			else if (expObject instanceof Long) {
+				token.setExpiration(new Date((Long) expObject * 1000L));
+			}
 		}
 		if (map.containsKey(JTI)) {
 			info.put(JTI, map.get(JTI));

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -24,7 +24,6 @@ import org.springframework.security.crypto.codec.Base64;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.DefaultResponseErrorHandler;
@@ -111,7 +110,12 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 			throw new InvalidTokenException(accessToken);
 		}
 
-		Assert.state(map.containsKey("client_id"), "Client id must be present in response from auth server");
+		// gh-838
+		if (!Boolean.TRUE.equals(map.get("active"))) {
+			logger.debug("check_token returned active attribute: " + map.get("active"));
+			throw new InvalidTokenException(accessToken);
+		}
+
 		return tokenConverter.extractAuthentication(map);
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
@@ -157,4 +157,25 @@ public class DefaultAccessTokenConverterTests {
 										singletonMap(AccessTokenConverter.SCOPE, scopes)).getScope());
 	}
 
+	@Test
+	public void verifyDoubleExpValuesAllowed() {
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		Date now = new Date();
+		tokenAttrs.put(AccessTokenConverter.EXP, now.getTime() / 1000D);
+		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value",
+				tokenAttrs);
+		assertEquals(now.getTime(), accessToken.getExpiration().getTime());
+	}
+
+	@Test
+	public void verifyLongExpValuesAllowed() {
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		Date now = new Date();
+		Date nowNoMilliSeconds = new Date((now.getTime() / 1000L) * 1000L);
+		tokenAttrs.put(AccessTokenConverter.EXP, nowNoMilliSeconds.getTime() / 1000L);
+		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value",
+				tokenAttrs);
+		assertEquals(nowNoMilliSeconds.getTime(), accessToken.getExpiration().getTime());
+	}
+
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.provider.token;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Joe Grandja
+ */
+public class RemoteTokenServicesTest {
+	private static final String DEFAULT_CLIENT_ID = "client-id-1234";
+	private static final String DEFAULT_CLIENT_SECRET = "client-secret-1234";
+	private static final String DEFAULT_CHECK_TOKEN_ENDPOINT_URI = "/oauth/check_token";
+	private RemoteTokenServices remoteTokenServices;
+
+	@Before
+	public void setUp() {
+		this.remoteTokenServices = new RemoteTokenServices();
+		this.remoteTokenServices.setClientId(DEFAULT_CLIENT_ID);
+		this.remoteTokenServices.setClientSecret(DEFAULT_CLIENT_SECRET);
+		this.remoteTokenServices.setCheckTokenEndpointUrl(DEFAULT_CHECK_TOKEN_ENDPOINT_URI);
+	}
+
+	// gh-838
+	@Test
+	public void loadAuthenticationWhenIntrospectionResponseContainsActiveTrueThenReturnAuthentication() throws Exception {
+		Map responseAttrs = new HashMap();
+		responseAttrs.put("active", true);		// "active" is the only required attribute as per RFC 7662 (https://tools.ietf.org/search/rfc7662#section-2.2)
+		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
+		this.remoteTokenServices.setRestTemplate(restTemplate);
+
+		OAuth2Authentication authentication = this.remoteTokenServices.loadAuthentication("access-token-1234");
+		assertNotNull(authentication);
+	}
+
+	// gh-838
+	@Test(expected = InvalidTokenException.class)
+	public void loadAuthenticationWhenIntrospectionResponseContainsActiveFalseThenThrowInvalidTokenException() throws Exception {
+		Map responseAttrs = new HashMap();
+		responseAttrs.put("active", false);		// "active" is the only required attribute as per RFC 7662 (https://tools.ietf.org/search/rfc7662#section-2.2)
+		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
+		this.remoteTokenServices.setRestTemplate(restTemplate);
+
+		this.remoteTokenServices.loadAuthentication("access-token-1234");
+	}
+
+	// gh-838
+	@Test(expected = InvalidTokenException.class)
+	public void loadAuthenticationWhenIntrospectionResponseMissingActiveAttributeThenThrowInvalidTokenException() throws Exception {
+		Map responseAttrs = new HashMap();
+		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
+		this.remoteTokenServices.setRestTemplate(restTemplate);
+
+		this.remoteTokenServices.loadAuthentication("access-token-1234");
+	}
+}


### PR DESCRIPTION
A `NumericDate` is described in the [Terminology](https://tools.ietf.org/html/rfc7519#section-2) section of [RFC7519](https://tools.ietf.org/html/rfc7519). Based on that description, it is not mandatory that these values be integral (i.e. they can contain decimal places).