### PR TITLE
Fix to allow double exp values

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -104,7 +104,13 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 		info.remove(CLIENT_ID);
 		info.remove(SCOPE);
 		if (map.containsKey(EXP)) {
-			token.setExpiration(new Date((Long) map.get(EXP) * 1000L));
+			Object expObject = map.get(EXP);
+			if (expObject instanceof Double) {
+				token.setExpiration(new Date((long) ((Double) expObject * 1000D)));
+			}
+			else if (expObject instanceof Long) {
+				token.setExpiration(new Date((Long) expObject * 1000L));
+			}
 		}
 		if (map.containsKey(JTI)) {
 			info.put(JTI, map.get(JTI));

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
@@ -157,4 +157,25 @@ public class DefaultAccessTokenConverterTests {
 										singletonMap(AccessTokenConverter.SCOPE, scopes)).getScope());
 	}
 
+	@Test
+	public void verifyDoubleExpValuesAllowed() {
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		Date now = new Date();
+		tokenAttrs.put(AccessTokenConverter.EXP, now.getTime() / 1000D);
+		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value",
+				tokenAttrs);
+		assertEquals(now.getTime(), accessToken.getExpiration().getTime());
+	}
+
+	@Test
+	public void verifyLongExpValuesAllowed() {
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		Date now = new Date();
+		Date nowNoMilliSeconds = new Date((now.getTime() / 1000L) * 1000L);
+		tokenAttrs.put(AccessTokenConverter.EXP, nowNoMilliSeconds.getTime() / 1000L);
+		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value",
+				tokenAttrs);
+		assertEquals(nowNoMilliSeconds.getTime(), accessToken.getExpiration().getTime());
+	}
+
 }


### PR DESCRIPTION
A `NumericDate` is described in the [Terminology](https://tools.ietf.org/html/rfc7519#section-2) section of [RFC7519](https://tools.ietf.org/html/rfc7519). Based on that description, it is not mandatory that these values be integral (i.e. they can contain decimal places).