### PR TITLE
Replace Base64 with Java 8 version, build against Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  
 services:
   - redis-server
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <commons-codec.version>1.9</commons-codec.version>
     <spring.version>4.0.9.RELEASE</spring.version>
     <spring.security.version>3.2.10.RELEASE</spring.security.version>
-    <java.version>1.6</java.version>
+    <java.version>1.8</java.version>
   </properties>
 
   <scm>
@@ -196,13 +196,13 @@
                     <configuration>
                         <signature>
                             <groupId>org.codehaus.mojo.signature</groupId>
-                            <artifactId>java16</artifactId>
+                            <artifactId>java18</artifactId>
                             <version>1.0</version>
                         </signature>
                     </configuration>
                     <executions>
                         <execution>
-                            <id>enforce-java-6</id>
+                            <id>enforce-java-8</id>
                             <phase>test</phase>
                             <goals>
                                 <goal>check</goal>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JwtAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JwtAccessTokenConverter.java
@@ -16,6 +16,7 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.security.crypto.codec.Base64;
+
 import org.springframework.security.jwt.Jwt;
 import org.springframework.security.jwt.JwtHelper;
 import org.springframework.security.jwt.crypto.sign.InvalidSignatureException;
@@ -150,7 +151,7 @@ public class JwtAccessTokenConverter implements TokenEnhancer, AccessTokenConver
 		signer = new RsaSigner((RSAPrivateKey) privateKey);
 		RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
 		verifier = new RsaVerifier(publicKey);
-		verifierKey = "-----BEGIN PUBLIC KEY-----\n" + new String(Base64.encode(publicKey.getEncoded()))
+		verifierKey = "-----BEGIN PUBLIC KEY-----\n" + new String(Base64.getEncoder().encode(publicKey.getEncoded()))
 				+ "\n-----END PUBLIC KEY-----";
 	}
 


### PR DESCRIPTION
Spring framework 5.0, Spring Security 5.0, Spring Boot 2.0 are all Java 8 baseline.  Spring Security OAuth should be aligned with Java 8.

The `org.springframework.security.crypto.codec.Base64` does not exist in Spring Security 5.0, which broke my codes when I was using Spring Boot 2.0.0.M2. 

Use Java 8 built-in Base 64 instead.