### PR TITLE
NullPointerException in Approval#hashCode if userId is null in the constructor

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/Approval.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/Approval.java
@@ -62,10 +62,10 @@ public class Approval {
 	}
 
 	public Approval(String userId, String clientId, String scope, Date expiresAt, ApprovalStatus status, Date lastUpdatedAt) {
-		this.userId = userId;
-		this.clientId = clientId;
-		this.scope = scope;
-		this.expiresAt = expiresAt;
+		setUserId(userId);
+		setClientId(clientId);
+		setScope(scope);
+		setExpiresAt(expiresAt);
 		this.status = status;
 		this.lastUpdatedAt = lastUpdatedAt;
 	}


### PR DESCRIPTION
I just updated a project's dependency on spring-security-oauth to the most recent version and was then getting a weird exception in Approval#hashCode in an integration test, which turned out to be because the user authentication I used in the test does not specify a userid. (This did not matter until commit 165600b2f27360707569158f1f9873190386e817).

When a null userid is specified in the setter of `Approval`, then it is replaced by an empty string (so the NPE in hashCode won't happen). However if a null userid is specified in the constructor, the behaviour is different. To me it seems like the setters and the constructor should behave the same. Thus in this PR I replaced the simple assignments of values that get a default value in the setter with a setter call.