### PR TITLE
Fix issue for some OAuth2 client who are still sending refreshToken 

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChain.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChain.java
@@ -35,7 +35,7 @@ import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
  * A chain of OAuth2 access token providers. This implementation will iterate through its
  * chain to find the first provider that supports the resource and use it to obtain the
  * access token. Note that the order of the chain is relevant.
- * 
+ *
  * @author Ryan Heaton
  * @author Dave Syer
  */
@@ -53,7 +53,7 @@ public class AccessTokenProviderChain extends OAuth2AccessTokenSupport
 
 	/**
 	 * Token services for long-term persistence of access tokens.
-	 * 
+	 *
 	 * @param clientTokenServices the clientTokenServices to set
 	 */
 	public void setClientTokenServices(ClientTokenServices clientTokenServices) {
@@ -105,7 +105,7 @@ public class AccessTokenProviderChain extends OAuth2AccessTokenSupport
 						clientTokenServices.removeAccessToken(resource, auth);
 					}
 					OAuth2RefreshToken refreshToken = existingToken.getRefreshToken();
-					if (refreshToken != null) {
+					if (refreshToken != null && !resource.isClientOnly()) {
 						accessToken = refreshAccessToken(resource, refreshToken, request);
 					}
 				}
@@ -157,7 +157,7 @@ public class AccessTokenProviderChain extends OAuth2AccessTokenSupport
 
 	/**
 	 * Obtain a new access token for the specified resource using the refresh token.
-	 * 
+	 *
 	 * @param resource The resource.
 	 * @param refreshToken The refresh token.
 	 * @return The access token, or null if failed.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChainTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChainTests.java
@@ -170,6 +170,22 @@ public class AccessTokenProviderChainTests {
 	}
 
 	@Test
+	public void testSunnyDayWithExpiredTokenAndExpiredRefreshTokenForClientCredentialsResource() {
+		resource = new ClientCredentialsResourceDetails();
+		resource.setId("resource");
+		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
+		accessToken.setExpiration(new Date(System.currentTimeMillis() - 1000));
+		DefaultOAuth2RefreshToken refreshToken = new DefaultExpiringOAuth2RefreshToken("EXP",
+				new Date(System.currentTimeMillis() - 1000));
+		accessToken.setRefreshToken(refreshToken);
+		AccessTokenRequest request = new DefaultAccessTokenRequest();
+		request.setExistingToken(accessToken);
+		SecurityContextHolder.getContext().setAuthentication(user);
+		OAuth2AccessToken token = chain.obtainAccessToken(resource, request);
+		assertNotNull(token);
+	}
+
+	@Test
 	public void testMissingSecurityContext() throws Exception {
 		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
 		AccessTokenRequest request = new DefaultAccessTokenRequest();


### PR DESCRIPTION
Fix issue for some OAuth2 client who are still sending refreshToken even if grant type is settled to ClientCredentials (ex Keycloak). This cause an issue when access token expired.

Regarding to RFC original code was correct but to prevent further issues this PR fix and force bypass usage of refresh token when using client credentials mode.