### PR TITLE
Fix for #1129 NPE when JWK optional alg missing

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkVerifyingJwtAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkVerifyingJwtAccessTokenConverter.java
@@ -111,7 +111,7 @@ class JwkVerifyingJwtAccessTokenConverter extends JwtAccessTokenConverter {
 		if (algorithmHeader == null) {
 			throw new InvalidTokenException("Invalid JWT/JWS: " + ALGORITHM + " is a required JOSE Header");
 		}
-		if (!algorithmHeader.equals(jwkDefinition.getAlgorithm().headerParamValue())) {
+		if (jwkDefinition.getAlgorithm() != null && !algorithmHeader.equals(jwkDefinition.getAlgorithm().headerParamValue())) {
 			throw new InvalidTokenException("Invalid JOSE Header " + ALGORITHM + " (" + algorithmHeader + ")" +
 					" does not match algorithm associated to JWK with " + KEY_ID + " (" + keyIdHeader + ")");
 		}


### PR DESCRIPTION
Fix includes unit-test of scenario.  Tested locally against PingFederate's JWT's and JWKS:

Conformant JWKS attached inline:

```
{
keys: [
{
kty: "RSA",
kid: "RSA-Key-1",
use: "sig",
n: "nP4CkMViFhamXHVTCQ4_h7lDIM_CXBR6eGMEyP1zoOC8Yef0YIkcMzIS8d8A7blT-UWkOw2fou7gXbqde-NhaE7YTvFJuda9EqSY7VxMc14ptdQvrCPLTv5GUj-qbIeYmJD7Qsn5OqV4H_blIeLmoibMf8BauWDp3GEv0ZtaEpx31jnsaKa9Y18iwzRnbKyyHd7b_fVvYNFgKGIO5IGrQv8unDqRou3N6d5dVkYhVoVFa5YU8VOiFWj4x07bvARecRn9UAcK-r771kOF-AWFsTy1rV41TOToXsZhSUHCQJW7aZR4T4f_rm7xHdq6IVoeHC4su1k-be8UlV0Y3IK7kw",
e: "AQAB",
x5c: [
"MIIDcDCCAligAwIBAgIGAVydm8NyMA0GCSqGSIb3DQEBCwUAMHkxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDTzEPMA0GA1UEBxMGRGVudmVyMRgwFgYDVQQKEw9hdXRocS5saWppdC5jb20xGDAWBgNVBAsTD2F1dGhxLmxpaml0LmNvbTEYMBYGA1UEAxMPYXV0aHEubGlqaXQuY29tMB4XDTE3MDYxMjE4NDA0OVoXDTE4MDYxMjE4NDA0OVoweTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNPMQ8wDQYDVQQHEwZEZW52ZXIxGDAWBgNVBAoTD2F1dGhxLmxpaml0LmNvbTEYMBYGA1UECxMPYXV0aHEubGlqaXQuY29tMRgwFgYDVQQDEw9hdXRocS5saWppdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCc/gKQxWIWFqZcdVMJDj+HuUMgz8JcFHp4YwTI/XOg4Lxh5/RgiRwzMhLx3wDtuVP5RaQ7DZ+i7uBdup1742FoTthO8Um51r0SpJjtXExzXim11C+sI8tO/kZSP6psh5iYkPtCyfk6pXgf9uUh4uaiJsx/wFq5YOncYS/Rm1oSnHfWOexopr1jXyLDNGdsrLId3tv99W9g0WAoYg7kgatC/y6cOpGi7c3p3l1WRiFWhUVrlhTxU6IVaPjHTtu8BF5xGf1QBwr6vvvWQ4X4BYWxPLWtXjVM5OhexmFJQcJAlbtplHhPh/+ubvEd2rohWh4cLiy7WT5t7xSVXRjcgruTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAI7FR21yqeDcoveee0iso7tBRLO/ZEaqe7u+RfllLDrGznZnE0AWBun340rhavHa+H2xnmJxAKWaeduHE/qndFoH+NNMA1/L+OHo8VescViG3NVQBmvo0REF4dLkxLpwwRyvLhry5SuQytHae7PK104NKSF6PHjLR4xDmPQk7LMQMcsS4ixJrCgbQxBiYQkf8MToint/QQ1kdjFCzcyzzsEu7o5DXBxuEY/kqaJMUKzZpPlVWPEBux2a9/wNvBiMUJ5Ul2YjFRlwcafS71y6Ypw5i9PJBMyS3A2rut0dOH2rsM/QBeuddIS3By5Jhi66LiYgbtvLdVBzFSToX7S7T8w="
],
x5t: "IHEML6mWOcp23jQgR-94JzigYTE"
}
]
}
```