### PR TITLE
Fix to OAuth2AuthenticationDetails toString result to be more pretty.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetails.java
@@ -63,19 +63,22 @@ public class OAuth2AuthenticationDetails implements Serializable {
 		if (remoteAddress!=null) {
 			builder.append("remoteAddress=").append(remoteAddress);
 		}
-		if (builder.length()>1) {
-			builder.append(", ");
-		}
 		if (sessionId!=null) {
-			builder.append("sessionId=<SESSION>");
-			if (builder.length()>1) {
+			if (builder.length()>0) {
 				builder.append(", ");
 			}
+			builder.append("sessionId=<SESSION>");
 		}
 		if (tokenType!=null) {
+			if (builder.length()>0) {
+				builder.append(", ");
+			}
 			builder.append("tokenType=").append(this.tokenType);
 		}
 		if (tokenValue!=null) {
+			if (builder.length()>0) {
+				builder.append(", ");
+			}
 			builder.append("tokenValue=<TOKEN>");
 		}
 		this.display = builder.toString();


### PR DESCRIPTION
Fixed the display value of OAuth2AuthenticationDetails to be more pretty with delimiter(,).

```
remoteAddress=127.0.0.1, sessionId=<SESSION>, tokenType=bearertokenValue=<TOKEN>
-> remoteAddress=127.0.0.1, sessionId=<SESSION>, tokenType=bearer, tokenValue=<TOKEN>
```