### PR TITLE
Fix IllegalArgumentException on malformed JOSE header

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtHeaderConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtHeaderConverter.java
@@ -33,6 +33,7 @@ import java.util.Map;
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>
  *
  * @author Joe Grandja
+ * @author Vedran Pavic
  */
 class JwtHeaderConverter implements Converter<String, Map<String, String>> {
 	private final JsonFactory factory = new JsonFactory();
@@ -52,7 +53,15 @@ class JwtHeaderConverter implements Converter<String, Map<String, String>> {
 		if (headerEndIndex == -1) {
 			throw new InvalidTokenException("Invalid JWT. Missing JOSE Header.");
 		}
-		byte[] decodedHeader = Codecs.b64UrlDecode(token.substring(0, headerEndIndex));
+
+		byte[] decodedHeader;
+
+		try {
+			decodedHeader = Codecs.b64UrlDecode(token.substring(0, headerEndIndex));
+		}
+		catch (IllegalArgumentException e) {
+			throw new InvalidTokenException("Invalid JWT. Malformed JOSE Header.");
+		}
 
 		JsonParser parser = null;
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtHeaderConverterTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtHeaderConverterTest.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.security.oauth2.provider.token.store.jwk;
 
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -24,10 +23,14 @@ import org.springframework.security.oauth2.common.exceptions.InvalidTokenExcepti
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.springframework.security.oauth2.provider.token.store.jwk.JwtTestUtil.createDefaultJwtPayload;
 import static org.springframework.security.oauth2.provider.token.store.jwk.JwtTestUtil.createJwt;
 
 /**
+ * Tests for {@link JwtHeaderConverter}.
+ *
  * @author Joe Grandja
+ * @author Vedran Pavic
  */
 public class JwtHeaderConverterTest {
 	private final JwtHeaderConverter converter = new JwtHeaderConverter();
@@ -55,4 +58,12 @@ public class JwtHeaderConverterTest {
 		assertEquals("key-id-1", jwtHeaders.get(JwkAttributes.KEY_ID));
 		assertEquals(JwkDefinition.CryptoAlgorithm.RS256.headerParamValue(), jwtHeaders.get(JwkAttributes.ALGORITHM));
 	}
+
+	@Test
+	public void convertWhenJwtTokenWithMalformedHeaderThenThrowJwkException() throws Exception {
+		this.thrown.expect(InvalidTokenException.class);
+		this.thrown.expectMessage("Invalid JWT. Malformed JOSE Header.");
+		this.converter.convert("f." + new String(createDefaultJwtPayload()));
+	}
+
 }


### PR DESCRIPTION
This PR addresses the `IllegalArgumentException` that's thrown when `JwtHeaderConverter#convert` is invoked with JWT that contains a malformed JOSE header. This exception causes status `500` to be returned to the client instead of the expected `401`.

The PR includes a test that can be used to reproduce the problem.

This affects `master`, `2.1.x` and `2.0.x`.

On a sidenote, `JwtHeaderConverter#convert` javadoc claims that `JwkException` is thrown if the JWT is invalid while in reality it throws an `InvalidTokenException`. Can I use this PR to address that as well?