### PR TITLE
Add scopes to user approval request for TokenStoreUserApprovalHandler

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
@@ -15,15 +15,6 @@
  */
 package org.springframework.security.oauth2.config.annotation.web.configurers;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.http.HttpMethod;
@@ -75,6 +66,15 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.context.request.WebRequestInterceptor;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Configure the properties and enhanced functionality of the Authorization Server endpoints.
@@ -488,6 +488,7 @@ public final class AuthorizationServerEndpointsConfigurer {
 				userApprovalHandler.setTokenStore(tokenStore());
 				userApprovalHandler.setClientDetailsService(clientDetailsService());
 				userApprovalHandler.setRequestFactory(requestFactory());
+				userApprovalHandler.setApprovalStoreDisabled(approvalStoreDisabled);
 				this.userApprovalHandler = userApprovalHandler;
 			}
 			else {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/TokenStoreUserApprovalHandler.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/approval/TokenStoreUserApprovalHandler.java
@@ -16,10 +16,6 @@
 
 package org.springframework.security.oauth2.provider.approval;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -36,6 +32,11 @@ import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.util.Assert;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * A user approval handler that remembers approval decisions by consulting existing tokens.
  * 
@@ -46,12 +47,16 @@ public class TokenStoreUserApprovalHandler implements UserApprovalHandler, Initi
 
 	private static Log logger = LogFactory.getLog(TokenStoreUserApprovalHandler.class);
 
+	private String scopePrefix = OAuth2Utils.SCOPE_PREFIX;
+
 	private String approvalParameter = OAuth2Utils.USER_OAUTH_APPROVAL;
 	
 	private TokenStore tokenStore;
 	
 	private ClientDetailsService clientDetailsService;
-	
+
+	private boolean approvalStoreDisabled = false;
+
 	/**
 	 * Service to load client details (optional) for auto approval checks.
 	 * 
@@ -80,7 +85,11 @@ public class TokenStoreUserApprovalHandler implements UserApprovalHandler, Initi
 	public void setRequestFactory(OAuth2RequestFactory requestFactory) {
 		this.requestFactory = requestFactory;
 	}
-	
+
+	public void setApprovalStoreDisabled(boolean approvalStoreDisabled) {
+		this.approvalStoreDisabled = approvalStoreDisabled;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		Assert.state(tokenStore != null, "TokenStore must be provided");
@@ -168,8 +177,16 @@ public class TokenStoreUserApprovalHandler implements UserApprovalHandler, Initi
 	public Map<String, Object> getUserApprovalRequest(AuthorizationRequest authorizationRequest,
 			Authentication userAuthentication) {
 		Map<String, Object> model = new HashMap<String, Object>();
-		// In case of a redirect we might want the request parameters to be included
 		model.putAll(authorizationRequest.getRequestParameters());
+
+		if (!approvalStoreDisabled) {
+			Map<String, String> scopes = new LinkedHashMap<String, String>();
+			for (String scope : authorizationRequest.getScope()) {
+				scopes.put(scopePrefix + scope, "false");
+			}
+			model.put("scopes", scopes);
+		}
+
 		return model;
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/AuthorizationServerConfigurationTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/AuthorizationServerConfigurationTests.java
@@ -12,18 +12,6 @@
  */
 package org.springframework.security.oauth2.config.annotation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.sql.DataSource;
-
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -75,6 +63,17 @@ import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dave Syer

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/TokenStoreUserApprovalHandlerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/approval/TokenStoreUserApprovalHandlerTests.java
@@ -12,10 +12,6 @@
  */
 package org.springframework.security.oauth2.provider.approval;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.HashMap;
-
 import org.junit.Test;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
@@ -25,6 +21,13 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.request.DefaultOAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
 import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dave Syer
@@ -73,6 +76,21 @@ public class TokenStoreUserApprovalHandlerTests {
 		tokenServices.createAccessToken(new OAuth2Authentication(storedOAuth2Request, userAuthentication));
 		authorizationRequest = handler.checkForPreApproval(authorizationRequest, userAuthentication);
 		assertTrue(handler.isApproved(authorizationRequest, userAuthentication));
+	}
+
+	@Test
+	public void testScopedApproval() {
+		HashMap<String, String> parameters = new HashMap<String, String>();
+		parameters.put(OAuth2Utils.USER_OAUTH_APPROVAL, "true");
+		Set<String> scopes = new HashSet<String>();
+		scopes.add("read");
+		scopes.add("write");
+		AuthorizationRequest request = new AuthorizationRequest(parameters, null, null, scopes, null, null, false, null, null, null);
+
+		Map<String, Object> approvalRequest = handler.getUserApprovalRequest(request, new TestAuthentication("marissa", true));
+		Map<String, String> approvalRequestScopes = (Map<String, String>) approvalRequest.get("scopes");
+		assertTrue(approvalRequestScopes.containsKey("scope.read"));
+		assertTrue(approvalRequestScopes.containsKey("scope.write"));
 	}
 
 	protected static class TestAuthentication extends AbstractAuthenticationToken {


### PR DESCRIPTION
This pull request addresses the issue #1155 so the Authorization Server can present scopes on user's approval page even when using `JwtTokenStore` to support JWT tokens.
