### PR TITLE
Add Elliptic Curve verification support for spring-security-jwt

### DIFF
--- a/spring-security-jwt/src/main/java/org/springframework/security/jwt/crypto/sign/EllipticCurveKeyHelper.java
+++ b/spring-security-jwt/src/main/java/org/springframework/security/jwt/crypto/sign/EllipticCurveKeyHelper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.jwt.crypto.sign;
+
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.bouncycastle.jce.spec.ECNamedCurveSpec;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+
+/**
+ * @author Michael Duergner
+ */
+class EllipticCurveKeyHelper {
+
+    static ECPublicKey createPublicKey(final BigInteger x, final BigInteger y, final String curve) {
+        try {
+            ECNamedCurveParameterSpec curveParameterSpec = ECNamedCurveTable.getParameterSpec(curve);
+            ECParameterSpec parameterSpec = new ECNamedCurveSpec(
+                    curveParameterSpec.getName(),
+                    curveParameterSpec.getCurve(),
+                    curveParameterSpec.getG(),
+                    curveParameterSpec.getN());
+            ECPublicKeySpec publicKeySpec = new ECPublicKeySpec(new ECPoint(x, y), parameterSpec);
+
+            return (ECPublicKey) KeyFactory.getInstance("EC").generatePublic(publicKeySpec);
+        }
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/spring-security-jwt/src/main/java/org/springframework/security/jwt/crypto/sign/EllipticCurveVerifier.java
+++ b/spring-security-jwt/src/main/java/org/springframework/security/jwt/crypto/sign/EllipticCurveVerifier.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.jwt.crypto.sign;
+
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.Signature;
+import java.security.interfaces.ECPublicKey;
+
+/**
+ * @author Michael Duergner
+ */
+public class EllipticCurveVerifier implements SignatureVerifier {
+
+    private final ECPublicKey key;
+
+    private final String algorithm;
+
+    public EllipticCurveVerifier(final BigInteger x, final BigInteger y, final String curve, final String algorithm) {
+        this(EllipticCurveKeyHelper.createPublicKey(x, y, curve), algorithm);
+    }
+
+    public EllipticCurveVerifier(final ECPublicKey key, final String algorithm) {
+        this.key = key;
+        this.algorithm = algorithm;
+    }
+
+    @Override
+    public String algorithm() {
+        return algorithm;
+    }
+
+    @Override
+    public void verify(byte[] content, byte[] sig) {
+        try {
+            Signature signature = Signature.getInstance(algorithm);
+            signature.initVerify(key);
+            signature.update(content);
+
+            if (!signature.verify(transcodeSignatureToDER(sig))) {
+                throw new InvalidSignatureException("EC Signature did not match content");
+            }
+        }
+        catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private byte[] transcodeSignatureToDER(byte[] jwsSignature) throws GeneralSecurityException {
+
+        // Adapted from org.apache.xml.security.algorithms.implementations.SignatureECDSA
+
+        int rawLen = jwsSignature.length / 2;
+
+        int i;
+
+        for (i = rawLen; (i > 0) && (jwsSignature[rawLen - i] == 0); i--) {
+            // do nothing
+        }
+
+        int j = i;
+
+        if (jwsSignature[rawLen - i] < 0) {
+            j += 1;
+        }
+
+        int k;
+
+        for (k = rawLen; (k > 0) && (jwsSignature[2 * rawLen - k] == 0); k--) {
+            // do nothing
+        }
+
+        int l = k;
+
+        if (jwsSignature[2 * rawLen - k] < 0) {
+            l += 1;
+        }
+
+        int len = 2 + j + 2 + l;
+
+        if (len > 255) {
+            throw new GeneralSecurityException("Invalid ECDSA signature format");
+        }
+
+        int offset;
+
+        final byte derSignature[];
+
+        if (len < 128) {
+            derSignature = new byte[2 + 2 + j + 2 + l];
+            offset = 1;
+        } else {
+            derSignature = new byte[3 + 2 + j + 2 + l];
+            derSignature[1] = (byte) 0x81;
+            offset = 2;
+        }
+
+        derSignature[0] = 48;
+        derSignature[offset++] = (byte) len;
+        derSignature[offset++] = 2;
+        derSignature[offset++] = (byte) j;
+
+        System.arraycopy(jwsSignature, rawLen - i, derSignature, (offset + j) - i, i);
+
+        offset += j;
+
+        derSignature[offset++] = 2;
+        derSignature[offset++] = (byte) l;
+
+        System.arraycopy(jwsSignature, 2 * rawLen - k, derSignature, (offset + l) - k, k);
+
+        return derSignature;
+    }
+}

--- a/spring-security-jwt/src/test/java/org/springframework/security/jwt/crypto/sign/EllipticCurveVerifierTests.java
+++ b/spring-security-jwt/src/test/java/org/springframework/security/jwt/crypto/sign/EllipticCurveVerifierTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.jwt.crypto.sign;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.springframework.security.jwt.codec.Codecs;
+
+import java.math.BigInteger;
+
+/**
+ * @author Michael Duergner
+ */
+public class EllipticCurveVerifierTests {
+
+  private static final byte[] xBytes = Codecs.b64UrlDecode("IsxeG33-QlL2u-O38QKwAbw5tJTZ-jtMVSlzjNXhvys");
+  private static final byte[] yBytes = Codecs.b64UrlDecode("FPTFJF1M0sNRlOVZIH4e1DoZ_hdg1OvF6BlP2QHmSCg");
+
+  private final static BigInteger X = new BigInteger(1, xBytes);
+
+  private final static BigInteger Y = new BigInteger(1, yBytes);
+
+  private final static String CRV = "P-256";
+
+  private final static String ALG = "SHA256withECDSA";
+
+  @Test(expected = IllegalArgumentException.class)
+  public void ellipticCurveVerifierRejectsUnknownCurve() {
+    EllipticCurveVerifier verifier = new EllipticCurveVerifier(
+        BigInteger.ONE,
+        BigInteger.ONE,
+        "xxx",
+        null);
+    assertNotNull(verifier);
+  }
+
+  @Test
+  public void ellipticCurveVerifierValidWithEmptyAlgorithm() {
+    EllipticCurveVerifier verifier = new EllipticCurveVerifier(
+        EllipticCurveVerifierTests.X,
+        EllipticCurveVerifierTests.Y,
+        EllipticCurveVerifierTests.CRV,
+        null);
+    assertNotNull(verifier);
+  }
+
+  @Test
+  public void keyFromCurveParametersIsCorrect() {
+    byte[] sig = Codecs.b64UrlDecode(
+        "gR2_00D_famhmT9h_7cQ7Sfi3J13nFUOH1PsC3WwgVdMV5yI6CXHHcybZKa266yckCGHS1MGKgp3pBsUv93P1Q");
+    byte[] content = Codecs.utf8Encode("eyJhbGciOiJFUzI1NiJ9.eyJrZXkiOiJ2YWx1ZSJ9");
+
+    EllipticCurveVerifier verifier = new EllipticCurveVerifier(
+        EllipticCurveVerifierTests.X,
+        EllipticCurveVerifierTests.Y,
+        EllipticCurveVerifierTests.CRV,
+        EllipticCurveVerifierTests.ALG);
+    verifier.verify(content, sig);
+  }
+
+  @Test(expected = InvalidSignatureException.class)
+  public void signatureIsNotValidForDifferentAlgorithm() {
+    byte[] sig = Codecs.b64UrlDecode(
+            "gR2_00D_famhmT9h_7cQ7Sfi3J13nFUOH1PsC3WwgVdMV5yI6CXHHcybZKa266yckCGHS1MGKgp3pBsUv93P1Q");
+    byte[] content = Codecs.utf8Encode("eyJhbGciOiJFUzI1NiJ9.eyJrZXkiOiJ2YWx1ZSJ9");
+
+    EllipticCurveVerifier verifier = new EllipticCurveVerifier(
+        EllipticCurveVerifierTests.X,
+        EllipticCurveVerifierTests.Y,
+        EllipticCurveVerifierTests.CRV,
+        "SHA512withECDSA");
+    verifier.verify(content, sig);
+  }
+
+  @Test(expected = InvalidSignatureException.class)
+  public void brokenSignatureIsNotValid() {
+    byte[] sig = Codecs.b64UrlDecode(
+            "fx2_00D_famhmT9h_7cQ7Sfi3J13nFUOH1PsC3WwgVdMV5yI6CXHHcybZKa266yckCGHS1MGKgp3pBsUv93P1Q");
+    byte[] content = Codecs.utf8Encode("eyJhbGciOiJFUzI1NiJ9.eyJrZXkiOiJ2YWx1ZSJ9");
+
+    EllipticCurveVerifier verifier = new EllipticCurveVerifier(
+        EllipticCurveVerifierTests.X,
+        EllipticCurveVerifierTests.Y,
+        EllipticCurveVerifierTests.CRV,
+        EllipticCurveVerifierTests.ALG);
+    verifier.verify(content, sig);
+  }
+}


### PR DESCRIPTION
The implementation is inspired by the RSAVerifier and uses code from org.apache.xml.security.algorithms.implementations.SignatureECDSA to transcode from JWK to JCE compatible signatures.

It is meant to be used by the patch to `spring-security-oauth2` which introduces support for *Elliptic Curve* based *JWK* keys.

This PR is one of the two PRs to deliver #1159 