### PR TITLE
Add support for Elliptic Curve JWK signatures

### DIFF
--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -16,7 +16,7 @@
 		<jackson1.version>1.9.13</jackson1.version>
 		<jackson2.version>2.3.2</jackson2.version>
 		<servlet-api.version>3.0.1</servlet-api.version>
-		<spring.security.jwt.version>1.0.8.RELEASE</spring.security.jwt.version>
+		<spring.security.jwt.version>1.0.9.BUILD-SNAPSHOT</spring.security.jwt.version>
 		<junit.version>4.11</junit.version>
 		<powermock.version>1.5.4</powermock.version>
 	</properties>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/EllipticCurveJwkDefinition.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/EllipticCurveJwkDefinition.java
@@ -1,0 +1,52 @@
+package org.springframework.security.oauth2.provider.token.store.jwk;
+
+/**
+ * A JSON Web Key (JWK) representation of an Elliptic Curve key.
+ *
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7517">JSON Web Key (JWK)</a>
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7518#page-28">JSON Web Algorithms (JWA)</a>
+ *
+ * @author Michael Duergner <michael@sprucehill.io>
+ */
+final class EllipticCurveJwkDefinition extends JwkDefinition {
+
+    private final String x;
+
+    private final String y;
+
+    private final String curve;
+
+    /**
+     * Creates an instance of an Elliptic Curve JSON Web Key (JWK).
+     *
+     * @param keyId        the Key ID
+     * @param publicKeyUse the intended use of the Public Key
+     * @param algorithm    the algorithm intended to be used
+     * @param x            the x value to be used
+     * @param y            the y value to be used
+     * @param curve        the curve to be used
+     */
+    EllipticCurveJwkDefinition(String keyId,
+                                         PublicKeyUse publicKeyUse,
+                                         CryptoAlgorithm algorithm,
+                                         String x,
+                                         String y,
+                                         String curve) {
+        super(keyId, KeyType.EC, publicKeyUse, algorithm);
+        this.x = x;
+        this.y = y;
+        this.curve = curve;
+    }
+
+    String getX() {
+        return x;
+    }
+
+    String getY() {
+        return y;
+    }
+
+    String getCurve() {
+        return curve;
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkAttributes.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkAttributes.java
@@ -19,6 +19,7 @@ package org.springframework.security.oauth2.provider.token.store.jwk;
  * Shared attribute values used by {@link JwkTokenStore} and associated collaborators.
  *
  * @author Joe Grandja
+ * @author Michael Duergner
  */
 final class JwkAttributes {
 
@@ -53,6 +54,21 @@ final class JwkAttributes {
 	 * The &quot;e&quot; (exponent) parameter contains the exponent value for a RSA public key.
 	 */
 	static final String RSA_PUBLIC_KEY_EXPONENT = "e";
+
+	/**
+	 * The &quot;x&quot; parameter contains the x value for a EC public key.
+	 */
+	static final String EC_PUBLIC_KEY_X = "x";
+
+	/**
+	 * The &quot;y&quot; parameter contains the y value for a EC public key.
+	 */
+	static final String EC_PUBLIC_KEY_Y = "y";
+
+	/**
+	 * The &quot;crv&quot; (curve) parameter contains the curve value for a EC public key.
+	 */
+	static final String EC_PUBLIC_KEY_CURVE = "crv";
 
 	/**
 	 * A JWK Set is a JSON object that has a &quot;keys&quot; member

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinition.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinition.java
@@ -21,6 +21,7 @@ package org.springframework.security.oauth2.provider.token.store.jwk;
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7517">JSON Web Key (JWK)</a>
  *
  * @author Joe Grandja
+ * @author Michael Duergner
  */
 abstract class JwkDefinition {
 	private final String keyId;
@@ -164,7 +165,10 @@ abstract class JwkDefinition {
 	enum CryptoAlgorithm {
 		RS256("SHA256withRSA", "RS256"),
 		RS384("SHA384withRSA", "RS384"),
-		RS512("SHA512withRSA", "RS512");
+		RS512("SHA512withRSA", "RS512"),
+		ES256("SHA256withECDSA", "ES256"),
+		ES384("SHA384withECDSA", "ES384"),
+		ES512("SHA512withECDSA", "ES512");
 
 		private final String standardName;		// JCA Standard Name
 		private final String headerParamValue;

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
@@ -45,6 +45,7 @@ import static org.springframework.security.oauth2.provider.token.store.jwk.JwkAt
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7517#page-10">JWK Set Format</a>
  *
  * @author Joe Grandja
+ * @author Michael Duergner
  */
 class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 	private final JsonFactory factory = new JsonFactory();
@@ -121,13 +122,18 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 		JwkDefinition.KeyType keyType =
 				JwkDefinition.KeyType.fromValue(attributes.get(KEY_TYPE));
 
-		if (!JwkDefinition.KeyType.RSA.equals(keyType)) {
+		if (JwkDefinition.KeyType.RSA.equals(keyType)) {
+			return this.createRsaJwkDefinition(attributes);
+		}
+		else if (JwkDefinition.KeyType.EC.equals(keyType)) {
+			return this.createEllipticCurveJwkDefinition(attributes);
+		}
+		else {
 			throw new JwkException((keyType != null ? keyType.value() : "unknown") +
 					" (" + KEY_TYPE + ") is currently not supported." +
-					" Valid values for '" + KEY_TYPE + "' are: " + JwkDefinition.KeyType.RSA.value());
+					" Valid values for '" + KEY_TYPE + "' are: " + JwkDefinition.KeyType.RSA.value() +
+					", " + JwkDefinition.KeyType.EC.value());
 		}
-
-		return this.createRsaJwkDefinition(attributes);
 	}
 
 	/**
@@ -176,6 +182,62 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 
 		RsaJwkDefinition jwkDefinition = new RsaJwkDefinition(
 				keyId, publicKeyUse, algorithm, modulus, exponent);
+
+		return jwkDefinition;
+	}
+
+	/**
+	 * Creates a {@link EllipticCurveJwkDefinition} based on the supplied attributes.
+	 *
+	 * @param attributes the attributes used to create the {@link EllipticCurveJwkDefinition}
+	 * @return a {@link JwkDefinition} representation of a EC Key
+	 * @throws JwkException if at least one attribute value is missing or invalid for a EC Key
+	 */
+	private JwkDefinition createEllipticCurveJwkDefinition(Map<String, String> attributes) {
+		// kid
+		String keyId = attributes.get(KEY_ID);
+		if (!StringUtils.hasText(keyId)) {
+			throw new JwkException(KEY_ID + " is a required attribute for a JWK.");
+		}
+
+		// use
+		JwkDefinition.PublicKeyUse publicKeyUse =
+				JwkDefinition.PublicKeyUse.fromValue(attributes.get(PUBLIC_KEY_USE));
+		if (!JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
+			throw new JwkException((publicKeyUse != null ? publicKeyUse.value() : "unknown") +
+					" (" + PUBLIC_KEY_USE + ") is currently not supported.");
+		}
+
+		// alg
+		JwkDefinition.CryptoAlgorithm algorithm =
+				JwkDefinition.CryptoAlgorithm.fromHeaderParamValue(attributes.get(ALGORITHM));
+		if (algorithm != null &&
+				!JwkDefinition.CryptoAlgorithm.ES256.equals(algorithm) &&
+				!JwkDefinition.CryptoAlgorithm.ES384.equals(algorithm) &&
+				!JwkDefinition.CryptoAlgorithm.ES512.equals(algorithm)) {
+			throw new JwkException(algorithm.standardName() + " (" + ALGORITHM + ") is currently not supported.");
+		}
+
+		// x
+		String x = attributes.get(EC_PUBLIC_KEY_X);
+		if (!StringUtils.hasText(x)) {
+			throw new JwkException(EC_PUBLIC_KEY_X + " is a required attribute for a EC JWK.");
+		}
+
+		// y
+		String y = attributes.get(EC_PUBLIC_KEY_Y);
+		if (!StringUtils.hasText(y)) {
+			throw new JwkException(EC_PUBLIC_KEY_Y + " is a required attribute for a EC JWK.");
+		}
+
+		// crv
+		String curve = attributes.get(EC_PUBLIC_KEY_CURVE);
+		if (!StringUtils.hasText(curve)) {
+			throw new JwkException(EC_PUBLIC_KEY_CURVE + " is a required attribute for a EC JWK.");
+		}
+
+		EllipticCurveJwkDefinition jwkDefinition = new EllipticCurveJwkDefinition(
+				keyId, publicKeyUse, algorithm, x, y, curve);
 
 		return jwkDefinition;
 	}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverterTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverterTest.java
@@ -107,16 +107,6 @@ public class JwkSetConverterTest {
 	}
 
 	@Test
-	public void convertWhenJwkSetStreamHasJwkElementWithECKeyTypeThenThrowJwkException() throws Exception {
-		this.thrown.expect(JwkException.class);
-		this.thrown.expectMessage("EC (kty) is currently not supported.");
-		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
-		Map<String, Object> jwkObject = this.createJwkObject(JwkDefinition.KeyType.EC);
-		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject});
-		this.converter.convert(this.asInputStream(jwkSetObject));
-	}
-
-	@Test
 	public void convertWhenJwkSetStreamHasJwkElementWithOCTKeyTypeThenThrowJwkException() throws Exception {
 		this.thrown.expect(JwkException.class);
 		this.thrown.expectMessage("oct (kty) is currently not supported.");
@@ -179,6 +169,41 @@ public class JwkSetConverterTest {
 	}
 
 	@Test
+	public void convertWhenJwkSetStreamHasJwkElementWithMissingEllipticCurveXAttributeThenThrowJwkException() throws Exception {
+		this.thrown.expect(JwkException.class);
+		this.thrown.expectMessage("x is a required attribute for a EC JWK.");
+		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
+		Map<String, Object> jwkObject = this.createEllipticCurveJwkObject("key-id-1",
+				JwkDefinition.PublicKeyUse.SIG, JwkDefinition.CryptoAlgorithm.ES256);
+		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject});
+		this.converter.convert(this.asInputStream(jwkSetObject));
+	}
+
+	@Test
+	public void convertWhenJwkSetStreamHasJwkElementWithMissingEllipticCurveYAttributeThenThrowJwkException() throws Exception {
+		this.thrown.expect(JwkException.class);
+		this.thrown.expectMessage("y is a required attribute for a EC JWK.");
+		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
+		Map<String, Object> jwkObject = this.createEllipticCurveJwkObject("key-id-1",
+				JwkDefinition.PublicKeyUse.SIG, JwkDefinition.CryptoAlgorithm.ES256,
+				"IsxeG33-QlL2u-O38QKwAbw5tJTZ-jtMVSlzjNXhvys");
+		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject});
+		this.converter.convert(this.asInputStream(jwkSetObject));
+	}
+
+	@Test
+	public void convertWhenJwkSetStreamHasJwkElementWithMissingEllipticCurveCurveAttributeThenThrowJwkException() throws Exception {
+		this.thrown.expect(JwkException.class);
+		this.thrown.expectMessage("crv is a required attribute for a EC JWK.");
+		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
+		Map<String, Object> jwkObject = this.createEllipticCurveJwkObject("key-id-1",
+				JwkDefinition.PublicKeyUse.SIG, JwkDefinition.CryptoAlgorithm.ES256,
+				"IsxeG33-QlL2u-O38QKwAbw5tJTZ-jtMVSlzjNXhvys", "FPTFJF1M0sNRlOVZIH4e1DoZ_hdg1OvF6BlP2QHmSCg");
+		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject});
+		this.converter.convert(this.asInputStream(jwkSetObject));
+	}
+
+	@Test
 	public void convertWhenJwkSetStreamIsValidThenReturnJwkSet() throws Exception {
 		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
 		Map<String, Object> jwkObject = this.createJwkObject(JwkDefinition.KeyType.RSA, "key-id-1",
@@ -195,6 +220,14 @@ public class JwkSetConverterTest {
 		jwkSet = this.converter.convert(this.asInputStream(jwkSetObject));
 		assertNotNull(jwkSet);
 		assertEquals("JWK Set NOT size=2", 2, jwkSet.size());
+
+		Map<String, Object> jwkObject3 = this.createEllipticCurveJwkObject("key-id-3",
+				JwkDefinition.PublicKeyUse.SIG, JwkDefinition.CryptoAlgorithm.ES256,
+				"IsxeG33-QlL2u-O38QKwAbw5tJTZ-jtMVSlzjNXhvys", "FPTFJF1M0sNRlOVZIH4e1DoZ_hdg1OvF6BlP2QHmSCg", "P-256");
+		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject, jwkObject2, jwkObject3});
+		jwkSet = this.converter.convert(this.asInputStream(jwkSetObject));
+		assertNotNull(jwkSet);
+		assertEquals("JWK Set NOT size=3", 3, jwkSet.size());
 	}
 
 	@Test
@@ -279,6 +312,57 @@ public class JwkSetConverterTest {
 		if (x5c != null) {
 			// x5c (X.509 certificate chain)
 			jwkObject.put("x5c", x5c);
+		}
+		return jwkObject;
+	}
+
+	private Map<String, Object> createEllipticCurveJwkObject(String keyId,
+															 JwkDefinition.PublicKeyUse publicKeyUse,
+															 JwkDefinition.CryptoAlgorithm algorithm) {
+		return this.createEllipticCurveJwkObject(keyId, publicKeyUse, algorithm, null, null, null);
+	}
+
+	private Map<String, Object> createEllipticCurveJwkObject(String keyId,
+															 JwkDefinition.PublicKeyUse publicKeyUse,
+															 JwkDefinition.CryptoAlgorithm algorithm,
+															 String x) {
+		return this.createEllipticCurveJwkObject(keyId, publicKeyUse, algorithm, x, null, null);
+	}
+
+	private Map<String, Object> createEllipticCurveJwkObject(String keyId,
+															 JwkDefinition.PublicKeyUse publicKeyUse,
+															 JwkDefinition.CryptoAlgorithm algorithm,
+															 String x,
+															 String y) {
+		return this.createEllipticCurveJwkObject(keyId, publicKeyUse, algorithm, x, y, null);
+	}
+
+	private Map<String, Object> createEllipticCurveJwkObject(String keyId,
+												JwkDefinition.PublicKeyUse publicKeyUse,
+												JwkDefinition.CryptoAlgorithm algorithm,
+												String x,
+												String y,
+												String curve) {
+
+		Map<String, Object> jwkObject = new HashMap<String, Object>();
+		jwkObject.put(JwkAttributes.KEY_TYPE, JwkDefinition.KeyType.EC);
+		if (keyId != null) {
+			jwkObject.put(JwkAttributes.KEY_ID, keyId);
+		}
+		if (publicKeyUse != null) {
+			jwkObject.put(JwkAttributes.PUBLIC_KEY_USE, publicKeyUse.value());
+		}
+		if (algorithm != null) {
+			jwkObject.put(JwkAttributes.ALGORITHM, algorithm.headerParamValue());
+		}
+		if (x != null) {
+			jwkObject.put(JwkAttributes.EC_PUBLIC_KEY_X, x);
+		}
+		if (y != null) {
+			jwkObject.put(JwkAttributes.EC_PUBLIC_KEY_Y, y);
+		}
+		if (curve != null) {
+			jwkObject.put(JwkAttributes.EC_PUBLIC_KEY_CURVE, curve);
 		}
 		return jwkObject;
 	}


### PR DESCRIPTION
This will utilize the changes to spring-security-jwt for handling Elliptic Curve signatures. It integrates fully into the existing codebase and will simply allow to verify signatures based on Elliptic Curve when they are read from a JWK definition.

This PR depends on #1161 to be merged. Once this PR is merged a new version of `spring-security-jwt` should be released and this PR needs to be updated to use the final version instead of the `1.0.9.BUILD-SNAPSHOT` version it currently uses.

This PR is the seconds part of delivering #1159