### PR TITLE
TokenEndpoint: Logging generic exception with ERROR level

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -163,7 +163,7 @@ public class TokenEndpoint extends AbstractEndpoint {
 	
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<OAuth2Exception> handleException(Exception e) throws Exception {
-	    logger.info("Handling error: " + e.getClass().getSimpleName() + ", " + e.getMessage());
+	    logger.error("Handling error: " + e.getClass().getSimpleName() + ", " + e.getMessage());
 	    return getExceptionTranslator().translate(e);
 	}
 	


### PR DESCRIPTION
I need to suppress client-side errors in a certain log appender, but right now everything is logged with INFO level.
All other exception handlers are handling client-side errors, only this one is handling generic unexpected problems (e.g. NPE in downstream service). 
Because it's most likely server-side implementation problem and not client request problem, it should log with ERROR level.
