### PR TITLE
make redirect resolver configureable by endpoint config

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configuration/AuthorizationServerEndpointsConfiguration.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configuration/AuthorizationServerEndpointsConfiguration.java
@@ -44,6 +44,7 @@ import org.springframework.security.oauth2.provider.code.AuthorizationCodeServic
 import org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint;
 import org.springframework.security.oauth2.provider.endpoint.CheckTokenEndpoint;
 import org.springframework.security.oauth2.provider.endpoint.FrameworkEndpointHandlerMapping;
+import org.springframework.security.oauth2.provider.endpoint.RedirectResolver;
 import org.springframework.security.oauth2.provider.endpoint.TokenEndpoint;
 import org.springframework.security.oauth2.provider.endpoint.TokenKeyEndpoint;
 import org.springframework.security.oauth2.provider.endpoint.WhitelabelApprovalEndpoint;
@@ -95,6 +96,7 @@ public class AuthorizationServerEndpointsConfiguration {
 		authorizationEndpoint.setOAuth2RequestFactory(oauth2RequestFactory());
 		authorizationEndpoint.setOAuth2RequestValidator(oauth2RequestValidator());
 		authorizationEndpoint.setUserApprovalHandler(userApprovalHandler());
+		authorizationEndpoint.setRedirectResolver(redirectResolver());
 		return authorizationEndpoint;
 	}
 
@@ -198,6 +200,10 @@ public class AuthorizationServerEndpointsConfiguration {
 
 	private WebResponseExceptionTranslator exceptionTranslator() {
 		return getEndpointsConfigurer().getExceptionTranslator();
+	}
+
+	private RedirectResolver redirectResolver() {
+		return getEndpointsConfigurer().getRedirectResolver();
 	}
 
 	private TokenGranter tokenGranter() throws Exception {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerEndpointsConfigurer.java
@@ -52,7 +52,9 @@ import org.springframework.security.oauth2.provider.client.InMemoryClientDetails
 import org.springframework.security.oauth2.provider.code.AuthorizationCodeServices;
 import org.springframework.security.oauth2.provider.code.AuthorizationCodeTokenGranter;
 import org.springframework.security.oauth2.provider.code.InMemoryAuthorizationCodeServices;
+import org.springframework.security.oauth2.provider.endpoint.DefaultRedirectResolver;
 import org.springframework.security.oauth2.provider.endpoint.FrameworkEndpointHandlerMapping;
+import org.springframework.security.oauth2.provider.endpoint.RedirectResolver;
 import org.springframework.security.oauth2.provider.error.DefaultWebResponseExceptionTranslator;
 import org.springframework.security.oauth2.provider.error.WebResponseExceptionTranslator;
 import org.springframework.security.oauth2.provider.implicit.ImplicitTokenGranter;
@@ -137,6 +139,8 @@ public final class AuthorizationServerEndpointsConfigurer {
 
 	private WebResponseExceptionTranslator exceptionTranslator;
 
+	private RedirectResolver redirectResolver = new DefaultRedirectResolver();
+
 	public AuthorizationServerTokenServices getTokenServices() {
 		return ProxyCreator.getProxy(AuthorizationServerTokenServices.class,
 				new ObjectFactory<AuthorizationServerTokenServices>() {
@@ -214,6 +218,11 @@ public final class AuthorizationServerEndpointsConfigurer {
 		if (tokenServices != null) {
 			this.tokenServicesOverride = true;
 		}
+		return this;
+	}
+
+	public AuthorizationServerEndpointsConfigurer redirectResolver(RedirectResolver redirectResolver) {
+		this.redirectResolver = redirectResolver;
 		return this;
 	}
 
@@ -358,6 +367,10 @@ public final class AuthorizationServerEndpointsConfigurer {
 
 	public WebResponseExceptionTranslator getExceptionTranslator() {
 		return exceptionTranslator();
+	}
+
+	public RedirectResolver getRedirectResolver() {
+		return redirectResolver;
 	}
 
 	private ResourceServerTokenServices resourceTokenServices() {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/AuthorizationServerConfigurationTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/AuthorizationServerConfigurationTests.java
@@ -48,12 +48,14 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.jwt.crypto.sign.MacSigner;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
+import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler;
@@ -63,6 +65,8 @@ import org.springframework.security.oauth2.provider.client.ClientCredentialsToke
 import org.springframework.security.oauth2.provider.client.InMemoryClientDetailsService;
 import org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint;
 import org.springframework.security.oauth2.provider.endpoint.CheckTokenEndpoint;
+import org.springframework.security.oauth2.provider.endpoint.DefaultRedirectResolver;
+import org.springframework.security.oauth2.provider.endpoint.RedirectResolver;
 import org.springframework.security.oauth2.provider.endpoint.TokenEndpoint;
 import org.springframework.security.oauth2.provider.error.DefaultWebResponseExceptionTranslator;
 import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
@@ -109,7 +113,9 @@ public class AuthorizationServerConfigurationTests {
 				new Object[] { null, new Class<?>[] { AuthorizationServerAllowsSpecificRequestMethods.class } },
 				new Object[] { null, new Class<?>[] { AuthorizationServerAllowsOnlyPost.class } },
 				new Object[] { BeanCreationException.class, new Class<?>[] { AuthorizationServerTypes.class } },
-				new Object[] { null, new Class<?>[] { AuthorizationServerCustomGranter.class } }
+				new Object[] { null, new Class<?>[] { AuthorizationServerCustomGranter.class } },
+				new Object[] { null, new Class<?>[] { AuthorizationServerRedirectResolver.class } },
+				new Object[] { null, new Class<?>[] { AuthorizationServerDefaultRedirectResolver.class } }
 		// @formatter:on
 		);
 	}
@@ -543,6 +549,53 @@ public class AuthorizationServerConfigurationTests {
 		public void run() {
 			assertNotNull(
 					ReflectionTestUtils.getField(context.getBean(AuthorizationEndpoint.class), "userApprovalHandler"));
+		}
+
+	}
+
+	@Configuration
+	@EnableWebMvcSecurity
+	@EnableAuthorizationServer
+	protected static class AuthorizationServerRedirectResolver extends AuthorizationServerConfigurerAdapter
+			implements Runnable {
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Override
+		public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
+			endpoints.redirectResolver(new CustomRedirectResolver());
+		}
+
+		@Override
+		public void run() {
+			RedirectResolver resolver = (RedirectResolver) ReflectionTestUtils.getField(context.getBean(AuthorizationEndpoint.class), "redirectResolver");
+
+			assertNotNull(resolver);
+			assertTrue(resolver instanceof CustomRedirectResolver);
+		}
+
+		static class CustomRedirectResolver implements RedirectResolver {
+			@Override
+			public String resolveRedirect(final String requestedRedirect, final ClientDetails client) throws OAuth2Exception {
+				return "go/here";
+			}
+		}
+	}
+
+	@Configuration
+	@EnableWebMvcSecurity
+	@EnableAuthorizationServer
+	protected static class AuthorizationServerDefaultRedirectResolver extends AuthorizationServerConfigurerAdapter
+			implements Runnable {
+
+		@Autowired
+		private ApplicationContext context;
+
+		@Override
+		public void run() {
+			assertNotNull(
+					ReflectionTestUtils.getField(context.getBean(AuthorizationEndpoint.class), "redirectResolver"));
 		}
 
 	}


### PR DESCRIPTION
Actually its hard to customise the `RedirectResolver` for the corresponding `AuthorizationEndpoint` (at least for my setup?). 

For example I have one config `AuthorizationServerConfiguration` which extends `AuthorizationServerConfigurerAdapter` and configures the `AuthorizationEndpoint` using `configure(AuthorizationServerEndpointsConfigurer configurer)`

At the moment I'm not able to pass in a `RedirectResolver` to the configurer. Since I'm also configuring a CompositeTokenGranter which requires the AuthorizationEndpoint I'm also not able to inject the endpoint and call `setRedirectResolver`. Even when using `PostConstruct` it wont work until I create a separate configuration class for this. All dependencies (required by `AuthorizationServerConfiguration`) are initialised in one configuration (AuthorizationEndpoint doesnt exist at this point) and using `PostConstruct` in my `AuthorizationServerConfiguration` causes a cyclic dependency. 

The only way I see is to create my own `AuthorizationEndpoint` based on the existing one and use a qualifier/primary for my custom one...

Is there maybe a straight forward way to set the redirect resolver without that change? I'd love to make it possible to configure it by using the `AuthorizationServerEndpointsConfigurer`. Thanks

(actually I've no clue whats wrong with the tests at travis .. :/)