### PR TITLE
Fix OAuth2AuthenticationDetails display string

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationDetails.java
@@ -63,19 +63,22 @@ public class OAuth2AuthenticationDetails implements Serializable {
 		if (remoteAddress!=null) {
 			builder.append("remoteAddress=").append(remoteAddress);
 		}
-		if (builder.length()>1) {
-			builder.append(", ");
-		}
 		if (sessionId!=null) {
-			builder.append("sessionId=<SESSION>");
-			if (builder.length()>1) {
+			if (builder.length() > 1) {
 				builder.append(", ");
 			}
+			builder.append("sessionId=<SESSION>");
 		}
 		if (tokenType!=null) {
+			if (builder.length() > 1) {
+				builder.append(", ");
+			}
 			builder.append("tokenType=").append(this.tokenType);
 		}
 		if (tokenValue!=null) {
+			if (builder.length() > 1) {
+				builder.append(", ");
+			}
 			builder.append("tokenValue=<TOKEN>");
 		}
 		this.display = builder.toString();


### PR DESCRIPTION
The logic for inserting comma's between the components of the string was incorrect and would produce strings like e.g. `remoteAddress=0:0:0:0:0:0:0:1, tokenType=BearertokenValue=<TOKEN>` (missing comma between `tokenType` and `tokenValue` fields). This fix correctly inserts commas before appending a new field if there was already a field added before it.