### PR TITLE
fix #1230 RedisConnection.set() MethodNotFoundException

### DIFF
--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -19,6 +19,8 @@
 		<spring.security.jwt.version>1.0.8.RELEASE</spring.security.jwt.version>
 		<junit.version>4.11</junit.version>
 		<powermock.version>1.5.4</powermock.version>
+		<spring-data-redis.version>1.5.0.RELEASE</spring-data-redis.version>
+		<jedis.version>2.6.3</jedis.version>
 	</properties>
 
 	<profiles>
@@ -29,6 +31,8 @@
 				<servlet-api.version>3.1.0</servlet-api.version>
 				<junit.version>4.12</junit.version>
 				<powermock.version>1.6.1</powermock.version>
+				<spring-data-redis.version>2.0.1.RELEASE</spring-data-redis.version>
+				<jedis.version>2.9.0</jedis.version>
 			</properties>
 		</profile>
 	</profiles>
@@ -161,14 +165,14 @@
 		<dependency>
         	<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
-			<version>1.5.0.RELEASE</version>
+			<version>${spring-data-redis.version}</version>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>2.6.3</version>
+			<version>${jedis.version}</version>
 			<optional>true</optional>
 		</dependency>
 


### PR DESCRIPTION
upgrade "spring-date-redis" to 2.0.1.RELEASE and jedis to 2.9.0 in profile `spring5`
fix #1230 