### PR TITLE
Little update to TokenEndpoint.java to use right parameters annotation for RequestMethod.POST

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -49,6 +49,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody
 
 /**
  * <p>

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -84,7 +84,7 @@ public class TokenEndpoint extends AbstractEndpoint {
 	}
 	
 	@RequestMapping(value = "/oauth/token", method=RequestMethod.POST)
-	public ResponseEntity<OAuth2AccessToken> postAccessToken(Principal principal, @RequestParam
+	public ResponseEntity<OAuth2AccessToken> postAccessToken(Principal principal, @RequestBody
 	Map<String, String> parameters) throws HttpRequestMethodNotSupportedException {
 
 		if (!(principal instanceof Authentication)) {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestBody;
 
 /**
  * <p>


### PR DESCRIPTION
Obvious Fix: Change the parameter annotation at line 87 from @RequestParam to @RequestBody. It's more standardized.