### PR TITLE
Make client id and scope attribute names of the converted token configurable

### DIFF
--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -30,11 +30,14 @@ import org.springframework.security.oauth2.provider.RequestTokenFactory;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * @author Dave Syer
+ * Tests for {@link DefaultAccessTokenConverter}.
  *
+ * @author Dave Syer
+ * @author Vedran Pavic
  */
 public class DefaultAccessTokenConverterTests {
 
@@ -155,6 +158,83 @@ public class DefaultAccessTokenConverterTests {
 		assertEquals(new HashSet<String>(Arrays.asList(scopes.split(" "))),
 						converter.extractAccessToken("token-value",
 										singletonMap(AccessTokenConverter.SCOPE, scopes)).getScope());
+	}
+
+	// gh-1214
+	@Test
+	public void convertAccessTokenCustomScopeAttribute() {
+		String scopeAttribute = "scp";
+		DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
+		converter.setScopeAttribute(scopeAttribute);
+		DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken("FOO");
+		OAuth2Authentication authentication = new OAuth2Authentication(request, userAuthentication);
+		token.setScope(authentication.getOAuth2Request().getScope());
+		Map<String, ?> map = converter.convertAccessToken(token, authentication);
+		assertEquals(Collections.singleton("read"), map.get(scopeAttribute));
+	}
+
+	// gh-1214
+	@Test
+	public void convertAccessTokenCustomClientIdAttribute() {
+		String clientIdAttribute = "cid";
+		DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
+		converter.setClientIdAttribute(clientIdAttribute);
+		DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken("FOO");
+		OAuth2Authentication authentication = new OAuth2Authentication(request, userAuthentication);
+		Map<String, ?> map = converter.convertAccessToken(token, authentication);
+		assertEquals("id", map.get(clientIdAttribute));
+	}
+
+	// gh-1214
+	@Test
+	public void extractAccessTokenCustomScopeAttribute() {
+		String scopeAttribute = "scp";
+		DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
+		converter.setScopeAttribute(scopeAttribute);
+		String scope = "read";
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		tokenAttrs.put(scopeAttribute, scope);
+		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value", tokenAttrs);
+		assertEquals(Collections.singleton(scope), accessToken.getScope());
+	}
+
+	// gh-1214
+	@Test
+	public void extractAccessTokenCustomClientIdAttribute() {
+		String clientIdAttribute = "cid";
+		DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
+		converter.setClientIdAttribute(clientIdAttribute);
+		String clientId = "id";
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		tokenAttrs.put(clientIdAttribute, clientId);
+		OAuth2AccessToken accessToken = converter.extractAccessToken("token-value", tokenAttrs);
+		assertFalse(accessToken.getAdditionalInformation().containsKey("cid"));
+	}
+
+	// gh-1214
+	@Test
+	public void extractAuthenticationCustomScopeAttribute() {
+		String scopeAttribute = "scp";
+		DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
+		converter.setScopeAttribute(scopeAttribute);
+		String scope = "read";
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		tokenAttrs.put(scopeAttribute, scope);
+		OAuth2Authentication authentication = converter.extractAuthentication(tokenAttrs);
+		assertEquals(Collections.singleton(scope), authentication.getOAuth2Request().getScope());
+	}
+
+	// gh-1214
+	@Test
+	public void extractAuthenticationClientIdAttribute() {
+		String clientIdAttribute = "cid";
+		DefaultAccessTokenConverter converter = new DefaultAccessTokenConverter();
+		converter.setClientIdAttribute(clientIdAttribute);
+		String clientId = "id";
+		Map<String, Object> tokenAttrs = new HashMap<String, Object>();
+		tokenAttrs.put(clientIdAttribute, clientId);
+		OAuth2Authentication authentication = converter.extractAuthentication(tokenAttrs);
+		assertEquals(clientId, authentication.getOAuth2Request().getClientId());
 	}
 
 }


### PR DESCRIPTION
At present, `DefaultAccessTokenConverter` uses `client_id` and `scope` attribute names in the converted token, which translates to claim names when JWT based access tokens are used. This causes problems with providers that align with OAuth 2.0 Token Exchange (https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-12) and use `cid` and `scp` claims.

This PR updates the `DefaultAccessTokenConverter` to make client id and scope attribute names of the converted token configurable.

This resolves #1214