### PR TITLE
Fixed java.lang.NoSuchMethodError: org.springframework.data.redis.connection.RedisConnection.set([B[B)V

### DIFF
--- a/spring-security-oauth2/pom.xml
+++ b/spring-security-oauth2/pom.xml
@@ -161,14 +161,14 @@
 		<dependency>
         	<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-redis</artifactId>
-			<version>1.5.0.RELEASE</version>
+			<version>2.0.5.RELEASE</version>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>redis.clients</groupId>
 			<artifactId>jedis</artifactId>
-			<version>2.6.3</version>
+			<version>2.9.0</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStore.java
@@ -157,9 +157,9 @@ public class RedisTokenStore implements TokenStore {
 		RedisConnection conn = getConnection();
 		try {
 			conn.openPipeline();
-			conn.set(accessKey, serializedAccessToken);
-			conn.set(authKey, serializedAuth);
-			conn.set(authToAccessKey, serializedAccessToken);
+			conn.stringCommands().set(accessKey, serializedAccessToken);
+			conn.stringCommands().set(authKey, serializedAuth);
+			conn.stringCommands().set(authToAccessKey, serializedAccessToken);
 			if (!authentication.isClientOnly()) {
 				conn.rPush(approvalKey, serializedAccessToken);
 			}
@@ -177,9 +177,9 @@ public class RedisTokenStore implements TokenStore {
 				byte[] refresh = serialize(token.getRefreshToken().getValue());
 				byte[] auth = serialize(token.getValue());
 				byte[] refreshToAccessKey = serializeKey(REFRESH_TO_ACCESS + token.getRefreshToken().getValue());
-				conn.set(refreshToAccessKey, auth);
+				conn.stringCommands().set(refreshToAccessKey, auth);
 				byte[] accessToRefreshKey = serializeKey(ACCESS_TO_REFRESH + token.getValue());
-				conn.set(accessToRefreshKey, refresh);
+				conn.stringCommands().set(accessToRefreshKey, refresh);
 				if (refreshToken instanceof ExpiringOAuth2RefreshToken) {
 					ExpiringOAuth2RefreshToken expiringRefreshToken = (ExpiringOAuth2RefreshToken) refreshToken;
 					Date expiration = expiringRefreshToken.getExpiration();
@@ -269,8 +269,8 @@ public class RedisTokenStore implements TokenStore {
 		RedisConnection conn = getConnection();
 		try {
 			conn.openPipeline();
-			conn.set(refreshKey, serializedRefreshToken);
-			conn.set(refreshAuthKey, serialize(authentication));
+			conn.stringCommands().set(refreshKey, serializedRefreshToken);
+			conn.stringCommands().set(refreshAuthKey, serialize(authentication));
 			if (refreshToken instanceof ExpiringOAuth2RefreshToken) {
 				ExpiringOAuth2RefreshToken expiringRefreshToken = (ExpiringOAuth2RefreshToken) refreshToken;
 				Date expiration = expiringRefreshToken.getExpiration();


### PR DESCRIPTION
In Spring Boot 2.0 I have the following error:

```
java.lang.NoSuchMethodError: org.springframework.data.redis.connection.RedisConnection.set([B[B)V
	at org.springframework.security.oauth2.provider.token.store.redis.RedisTokenStore.storeAccessToken(RedisTokenStore.java:160) ~[spring-security-oauth2-2.2.1.RELEASE.jar:na]
	at org.springframework.security.oauth2.provider.token.DefaultTokenServices.createAccessToken(DefaultTokenServices.java:122) ~[spring-security-oauth2-2.2.1.RELEASE.jar:na]
	at org.springframework.security.oauth2.provider.token.DefaultTokenServices$$FastClassBySpringCGLIB$$5a1f25c.invoke(<generated>) ~[spring-security-oauth2-2.2.1.RELEASE.jar:na]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204) ~[spring-core-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:747) ~[spring-aop-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:294) ~[spring-tx-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:98) ~[spring-tx-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:185) ~[spring-aop-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:689) ~[spring-aop-5.0.5.BUILD-SNAPSHOT.jar:5.0.5.BUILD-SNAPSHOT]
	at org.springframework.security.oauth2.provider.token.DefaultTokenServices$$EnhancerBySpringCGLIB$$797b9d07.createAccessToken(<generated>) ~[spring-security-oauth2-2.2.1.RELEASE.jar:na]
	at com.coinokay.api.security.authentication.CoinokayAuthenticationSuccessHandler.onAuthenticationSuccess(CoinokayAuthenticationSuccessHandler.java:77) ~[classes/:na]
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.successfulAuthentication(AbstractAuthenticationProcessingFilter.java:326) ~[spring-security-web-5.0.3.RELEASE.jar:5.0.3.RELEASE]
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:240) ~[spring-security-web-5.0.3.RELEASE.jar:5.0.3.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.0.3.RELEASE.jar:5.0.3.RELEASE]
```

After I replaced all `conn.set()` with `conn.stringCommands().set()` in `RedisTokenStore.java`, the error disappears.

