### PR TITLE
Provide more extension points to DefaultAccessTokenConverter

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultAccessTokenConverter.java
@@ -75,7 +75,7 @@ public class DefaultAccessTokenConverter implements AccessTokenConverter {
 	/**
 	 * Flag to indicate that the grant type should be included in the converted token.
 	 *
-	 * @return the flag value (default false)
+	 * @return the flag value
 	 */
 	public boolean isIncludeGrantType() {
 		return includeGrantType;


### PR DESCRIPTION
This pull request makes it easier for developers to subclass and override parts of the class.

1.  Getters added to member vars so that they can be accessed in a sublass
2.  Convert private methods to protected to allow them to be overridden
3.  Added a protected extractRequestAuthorities method to allow subclasses to customize the non-user authorities in the token.

Item 3 allows a developer to include authorities like ROLE_ADMIN in a JWT but have the AccessTokenConverter add individual permission authorities(CAN_DO_X, CAN_DO_Y) based on what the role has authority to do.   In my use case the ROLE_ADMIN has 100+ individual permissions and I do not want to include them all in the JWT.  They are statically defined for the roles and I want to add them while decoding the token.  Without this change I would have to cut and paste this whole file into my code base.