### PR TITLE
Default serialization/deserialization can be overridden

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/JdbcClientTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/JdbcClientTokenServices.java
@@ -52,6 +52,14 @@ public class JdbcClientTokenServices implements ClientTokenServices {
 		this.keyGenerator = keyGenerator;
 	}
 
+	protected OAuth2AccessToken deserialize(byte[] byteArray) {
+		return SerializationUtils.deserialize(byteArray);
+	}
+
+	protected byte[] serialize(OAuth2AccessToken accessToken) {
+		return SerializationUtils.serialize(accessToken);
+	}
+
 	public OAuth2AccessToken getAccessToken(OAuth2ProtectedResourceDetails resource, Authentication authentication) {
 
 		OAuth2AccessToken accessToken = null;
@@ -59,7 +67,7 @@ public class JdbcClientTokenServices implements ClientTokenServices {
 		try {
 			accessToken = jdbcTemplate.queryForObject(selectAccessTokenSql, new RowMapper<OAuth2AccessToken>() {
 				public OAuth2AccessToken mapRow(ResultSet rs, int rowNum) throws SQLException {
-					return SerializationUtils.deserialize(rs.getBytes(2));
+					return deserialize(rs.getBytes(2));
 				}
 			}, keyGenerator.extractKey(resource, authentication));
 		}
@@ -78,7 +86,7 @@ public class JdbcClientTokenServices implements ClientTokenServices {
 		String name = authentication==null ? null : authentication.getName();
 		jdbcTemplate.update(
 				insertAccessTokenSql,
-				new Object[] { accessToken.getValue(), new SqlLobValue(SerializationUtils.serialize(accessToken)),
+				new Object[] { accessToken.getValue(), new SqlLobValue(serialize(accessToken)),
 						keyGenerator.extractKey(resource, authentication), name,
 						resource.getClientId() }, new int[] { Types.VARCHAR, Types.BLOB, Types.VARCHAR, Types.VARCHAR,
 						Types.VARCHAR });

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/JdbcAuthorizationCodeServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/code/JdbcAuthorizationCodeServices.java
@@ -37,10 +37,18 @@ public class JdbcAuthorizationCodeServices extends RandomValueAuthorizationCodeS
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}
 
+	protected OAuth2Authentication deserialize(byte[] byteArray) {
+		return SerializationUtils.deserialize(byteArray);
+	}
+
+	protected byte[] serialize(OAuth2Authentication authentication) {
+		return SerializationUtils.serialize(authentication);
+	}
+
 	@Override
 	protected void store(String code, OAuth2Authentication authentication) {
 		jdbcTemplate.update(insertAuthenticationSql,
-				new Object[] { code, new SqlLobValue(SerializationUtils.serialize(authentication)) }, new int[] {
+				new Object[] { code, new SqlLobValue(serialize(authentication)) }, new int[] {
 						Types.VARCHAR, Types.BLOB });
 	}
 
@@ -52,7 +60,7 @@ public class JdbcAuthorizationCodeServices extends RandomValueAuthorizationCodeS
 					new RowMapper<OAuth2Authentication>() {
 						public OAuth2Authentication mapRow(ResultSet rs, int rowNum)
 								throws SQLException {
-							return SerializationUtils.deserialize(rs.getBytes("authentication"));
+							return deserialize(rs.getBytes("authentication"));
 						}
 					}, code);
 		} catch (EmptyResultDataAccessException e) {


### PR DESCRIPTION
This PR allows overriding the default serialization mechanism (java) used 
to serialize OAuth2AccessToken and OAuth2Authentication. 
Note that this is already possible in JdbcTokenStore.
