### PR TITLE
UTF-8 for oauth2ExceptionSerializer

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson2Serializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson2Serializer.java
@@ -13,6 +13,7 @@
 package org.springframework.security.oauth2.common.exceptions;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map.Entry;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson2Serializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/OAuth2ExceptionJackson2Serializer.java
@@ -38,7 +38,7 @@ public class OAuth2ExceptionJackson2Serializer extends StdSerializer<OAuth2Excep
 		jgen.writeStringField("error", value.getOAuth2ErrorCode());
 		String errorMessage = value.getMessage();
 		if (errorMessage != null) {
-			errorMessage = HtmlUtils.htmlEscape(errorMessage);
+			errorMessage = HtmlUtils.htmlEscape(errorMessage, StandardCharsets.UTF_8.name());
 		}
 		jgen.writeStringField("error_description", errorMessage);
 		if (value.getAdditionalInformation()!=null) {


### PR DESCRIPTION
Had an issue with modified exception, which contained UTF-8 symbols like 'š'. It was serialized to JSON as 'scaron'. Generally, it's ok, but in my case I had to write my own serializer to accomplish the task of returning a proper UTF-8 exception message. Wouldn't it be better to use UTF-8 charset here instead of default ISO-8859-1?