### PR TITLE
Update DefaultRedirectResolver and remove unused variable

### DIFF
--- a/samples/oauth2/tonr/src/main/resources/sparklr.properties
+++ b/samples/oauth2/tonr/src/main/resources/sparklr.properties
@@ -1,5 +1,3 @@
 sparklrPhotoListURL=http://localhost:8080/sparklr2/photos?format=xml
 sparklrPhotoURLPattern=http://localhost:8080/sparklr2/photos/%s
 sparklrTrustedMessageURL=http://localhost:8080/sparklr2/photos/trusted/message
-accessTokenUri=http://localhost:8080/sparklr2/oauth/token
-userAuthorizationUri=http://localhost:8080/sparklr2/oauth/authorize

--- a/samples/oauth2/tonr/src/main/resources/sparklr.properties
+++ b/samples/oauth2/tonr/src/main/resources/sparklr.properties
@@ -1,3 +1,5 @@
 sparklrPhotoListURL=http://localhost:8080/sparklr2/photos?format=xml
 sparklrPhotoURLPattern=http://localhost:8080/sparklr2/photos/%s
 sparklrTrustedMessageURL=http://localhost:8080/sparklr2/photos/trusted/message
+accessTokenUri=http://localhost:8080/sparklr2/oauth/token
+userAuthorizationUri=http://localhost:8080/sparklr2/oauth/authorize

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolver.java
@@ -40,18 +40,7 @@ public class DefaultRedirectResolver implements RedirectResolver {
 
 	private Collection<String> redirectGrantTypes = Arrays.asList("implicit", "authorization_code");
 
-	private boolean matchSubdomains = true;
-
 	private boolean matchPorts = true;
-
-	/**
-	 * Flag to indicate that requested URIs will match if they are a subdomain of the registered value.
-	 * 
-	 * @param matchSubdomains the flag value to set (deafult true)
-	 */
-	public void setMatchSubdomains(boolean matchSubdomains) {
-		this.matchSubdomains = matchSubdomains;
-	}
 
 	/**
 	 * Flag that enables/disables port matching between the requested redirect URI and the registered redirect URI(s).
@@ -140,11 +129,8 @@ public class DefaultRedirectResolver implements RedirectResolver {
 	 * @param requested the requested host
 	 * @return true if they match
 	 */
-	protected boolean hostMatches(String registered, String requested) {
-		if (matchSubdomains) {
-			return registered.equals(requested) || requested.endsWith("." + registered);
-		}
-		return registered.equals(requested);
+	private boolean hostMatches(String registered, String requested) {
+		return registered.equals(requested) || requested.endsWith("." + registered);
 	}
 
 	/**

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/AuthorizationServerClientCredentialsPasswordValidXmlTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/AuthorizationServerClientCredentialsPasswordValidXmlTests.java
@@ -43,7 +43,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebAppConfiguration
 public class AuthorizationServerClientCredentialsPasswordValidXmlTests {
 	private static final String CLIENT_ID = "acme";
-	private static final String CLIENT_SECRET = "secret";
 	private static final String USER_ID = "acme";
 	private static final String USER_SECRET = "password";
 


### PR DESCRIPTION
Hi

1) Update DefaultRedirectResolver
I found setMatchSubdomains function is not used anywhere in DefaultRedirectResolver class and matchSubdomains boolean variable default value is true. So I'm updating hostMatches function. because I think hostMatchesfunction condition is always true. 
I also update hostMatches access modifier to 'private'. bacause I think that function is only use in DefaultRedirectResolver class.

2) Remove Unused variable
I found the unused variable in AuthorizationServerClientCredentialsPasswordValidXmlTests class 
and I also found unused properties in sparkl.properties.
So I've removed it.

Thank you. :)