### PR TITLE
Update DefaultRedirectResolver

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolver.java
@@ -40,18 +40,7 @@ public class DefaultRedirectResolver implements RedirectResolver {
 
 	private Collection<String> redirectGrantTypes = Arrays.asList("implicit", "authorization_code");
 
-	private boolean matchSubdomains = true;
-
 	private boolean matchPorts = true;
-
-	/**
-	 * Flag to indicate that requested URIs will match if they are a subdomain of the registered value.
-	 * 
-	 * @param matchSubdomains the flag value to set (deafult true)
-	 */
-	public void setMatchSubdomains(boolean matchSubdomains) {
-		this.matchSubdomains = matchSubdomains;
-	}
 
 	/**
 	 * Flag that enables/disables port matching between the requested redirect URI and the registered redirect URI(s).
@@ -140,11 +129,8 @@ public class DefaultRedirectResolver implements RedirectResolver {
 	 * @param requested the requested host
 	 * @return true if they match
 	 */
-	protected boolean hostMatches(String registered, String requested) {
-		if (matchSubdomains) {
-			return registered.equals(requested) || requested.endsWith("." + registered);
-		}
-		return registered.equals(requested);
+	private boolean hostMatches(String registered, String requested) {
+		return registered.equals(requested) || requested.endsWith("." + registered);
 	}
 
 	/**


### PR DESCRIPTION
Hi.
I found setMatchSubdomains function is not used anywhere in DefaultRedirectResolver class and matchSubdomains boolean variable default value is true. So I'm updating hostMatches function. because I think hostMatchesfunction condition is always true.

I also update hostMatches access modifier to 'private'. bacause I think that function is only use in DefaultRedirectResolver class.

Thank you!