### PR TITLE
Upgrade bcpkix-jdk15on to 1.60

### DIFF
--- a/spring-security-jwt/pom.xml
+++ b/spring-security-jwt/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.56</version>
+			<version>1.60</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
There are three CVE fixes since 1.56 listed in the release notes.

https://www.bouncycastle.org/releasenotes.html