### PR TITLE
remote-check-token-invalid

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.springframework.security.oauth2.provider.token;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpEntity;
@@ -41,7 +42,7 @@ import java.util.Map;
  *
  * @author Dave Syer
  * @author Luke Taylor
- *
+ * @author Xianhao Chen
  */
 public class RemoteTokenServices implements ResourceServerTokenServices {
 
@@ -112,9 +113,10 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 			throw new InvalidTokenException(accessToken);
 		}
 
+		Object activeValue = map.get("active");
 		// gh-838
-		if (!Boolean.TRUE.toString().equals(map.get("active"))) {
-			logger.debug("check_token returned active attribute: " + map.get("active"));
+		if (!(Boolean.TRUE.equals(activeValue) || Boolean.TRUE.toString().equals(activeValue))) {
+			logger.debug("check_token returned active attribute: " + activeValue);
 			throw new InvalidTokenException(accessToken);
 		}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -42,7 +42,6 @@ import java.util.Map;
  *
  * @author Dave Syer
  * @author Luke Taylor
- * @author Xianhao Chen
  */
 public class RemoteTokenServices implements ResourceServerTokenServices {
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -113,7 +113,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 		}
 
 		// gh-838
-		if (!Boolean.TRUE.equals(map.get("active"))) {
+		if (!Boolean.TRUE.toString().equals(map.get("active"))) {
 			logger.debug("check_token returned active attribute: " + map.get("active"));
 			throw new InvalidTokenException(accessToken);
 		}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Joe Grandja
- * @author Xianhao Chen
  */
 public class RemoteTokenServicesTest {
 	private static final String DEFAULT_CLIENT_ID = "client-id-1234";

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Joe Grandja
+ * @author Xianhao Chen
  */
 public class RemoteTokenServicesTest {
 	private static final String DEFAULT_CLIENT_ID = "client-id-1234";
@@ -88,5 +89,17 @@ public class RemoteTokenServicesTest {
 		this.remoteTokenServices.setRestTemplate(restTemplate);
 
 		this.remoteTokenServices.loadAuthentication("access-token-1234");
+	}
+	@Test
+	public void loadAuthenticationWhenIntrospectionResponseContainsActiveTrueByStringThenReturnAuthentication() throws Exception {
+		Map responseAttrs = new HashMap();
+		responseAttrs.put("active", "true");		// "active" is the only required attribute as per RFC 7662 (https://tools.ietf.org/search/rfc7662#section-2.2)
+		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
+		this.remoteTokenServices.setRestTemplate(restTemplate);
+
+		OAuth2Authentication authentication = this.remoteTokenServices.loadAuthentication("access-token-1234");
+		assertNotNull(authentication);
 	}
 }


### PR DESCRIPTION
issue #1355 Getting invalid token using spring boot autoconfigure for the resource server 

when I try to use the default RemoteTokenServices to check whether my token is valid in Spring Cloud, it failed. 
And When I debug line by line,  I find the line 116 in RemoteTokenServices checking the 'active' whether that is true or not, it failed to tell when it is true.  
So I override the RemoteTokenServices, and changed the line to be this, it succeeded.