### PR TITLE
RFC 7662 Token introspection username parameter

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/UserAuthenticationConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/UserAuthenticationConverter.java
@@ -27,7 +27,7 @@ public interface UserAuthenticationConverter {
 
 	final String AUTHORITIES = AccessTokenConverter.AUTHORITIES;
 
-	final String USERNAME = "user_name";
+	final String USERNAME = "username";
 
 	/**
 	 * Extract information about the user to be used in an access token (i.e. for resource servers).


### PR DESCRIPTION
RFC 7662 specifies the response parameters for token introspection and it contains username in place of user_name.
With username parameter, it will be possible to use DefaultUserAuthenticationConverter when you use RemoteTokenServices and an introspect link to a third party authorization server to validate a token