### PR TITLE
fix accessToken to ThreadLocal

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/DefaultOAuth2ClientContext.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/DefaultOAuth2ClientContext.java
@@ -10,51 +10,51 @@ import org.springframework.security.oauth2.common.OAuth2AccessToken;
 
 /**
  * The OAuth 2 security context (for a specific user or client or combination thereof).
- * 
+ *
  * @author Dave Syer
  */
 public class DefaultOAuth2ClientContext implements OAuth2ClientContext, Serializable {
 
-	private static final long serialVersionUID = 914967629530462926L;
+    private static final long serialVersionUID = 914967629530462926L;
 
-	private OAuth2AccessToken accessToken;
+    private ThreadLocal<OAuth2AccessToken> accessToken = new ThreadLocal<>();
 
-	private AccessTokenRequest accessTokenRequest;
+    private AccessTokenRequest accessTokenRequest;
 
-	private Map<String, Object> state = new HashMap<String, Object>();
+    private Map<String, Object> state = new HashMap<String, Object>();
 
-	public DefaultOAuth2ClientContext() {
-		this(new DefaultAccessTokenRequest());
-	}
+    public DefaultOAuth2ClientContext() {
+        this(new DefaultAccessTokenRequest());
+    }
 
-	public DefaultOAuth2ClientContext(AccessTokenRequest accessTokenRequest) {
-		this.accessTokenRequest = accessTokenRequest;
-	}
+    public DefaultOAuth2ClientContext(AccessTokenRequest accessTokenRequest) {
+        this.accessTokenRequest = accessTokenRequest;
+    }
 
-	public DefaultOAuth2ClientContext(OAuth2AccessToken accessToken) {
-		this.accessToken = accessToken;
-		this.accessTokenRequest = new DefaultAccessTokenRequest();
-	}
+    public DefaultOAuth2ClientContext(OAuth2AccessToken accessToken) {
+        this.accessToken.set(accessToken);
+        this.accessTokenRequest = new DefaultAccessTokenRequest();
+    }
 
-	public OAuth2AccessToken getAccessToken() {
-		return accessToken;
-	}
+    public OAuth2AccessToken getAccessToken() {
+        return accessToken.get();
+    }
 
-	public void setAccessToken(OAuth2AccessToken accessToken) {
-		this.accessToken = accessToken;
-		this.accessTokenRequest.setExistingToken(accessToken);
-	}
+    public void setAccessToken(OAuth2AccessToken accessToken) {
+        this.accessToken.set(accessToken);
+        this.accessTokenRequest.setExistingToken(accessToken);
+    }
 
-	public AccessTokenRequest getAccessTokenRequest() {
-		return accessTokenRequest;
-	}
+    public AccessTokenRequest getAccessTokenRequest() {
+        return accessTokenRequest;
+    }
 
-	public void setPreservedState(String stateKey, Object preservedState) {
-		state.put(stateKey, preservedState);
-	}
+    public void setPreservedState(String stateKey, Object preservedState) {
+        state.put(stateKey, preservedState);
+    }
 
-	public Object removePreservedState(String stateKey) {
-		return state.remove(stateKey);
-	}
+    public Object removePreservedState(String stateKey) {
+        return state.remove(stateKey);
+    }
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/DefaultOAuth2ClientContext.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/DefaultOAuth2ClientContext.java
@@ -17,7 +17,7 @@ public class DefaultOAuth2ClientContext implements OAuth2ClientContext, Serializ
 
     private static final long serialVersionUID = 914967629530462926L;
 
-    private ThreadLocal<OAuth2AccessToken> accessToken = new ThreadLocal<>();
+    private ThreadLocal<OAuth2AccessToken> accessToken = new ThreadLocal<OAuth2AccessToken>();
 
     private AccessTokenRequest accessTokenRequest;
 


### PR DESCRIPTION
accessToken field should be a thread local variable,because the getMap function which in org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices may be called by multiple threads at the same time. this problem had been reproduced in my performance test environment.