### PR TITLE
Performance fix in JwtDefinitionSource

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
@@ -93,21 +93,12 @@ class JwkDefinitionSource {
 		}
 		
 		this.jwkDefinitions.clear();
-		
 		for (URL jwkSetUrl : jwkSetUrls) {
-			try {
 				this.jwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
-		 	} catch (OAuth2Exception ex) {
-				//should probably do something besides squash this error
-		 		log.info("Not able to retrieve cert from " + jwkSetUrl.toString());
-			}
-		  }
-		
-		if(this.jwkDefinitions.isEmpty()) {
-			throw new JwkException("Exception: server_error, Cannot retreive CERTs from all the provided JWK Urls: ", jwkSetUrls);
 		}
 		
 		return this.getDefinition(keyId);
+		
 		
 	}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
@@ -93,12 +93,12 @@ class JwkDefinitionSource {
 		}
 		
 		this.jwkDefinitions.clear();
+		
 		for (URL jwkSetUrl : jwkSetUrls) {
-				this.jwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
+		   this.jwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
 		}
 		
 		return this.getDefinition(keyId);
-		
 		
 	}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
@@ -91,13 +91,24 @@ class JwkDefinitionSource {
 		if (result != null) {
 			return result;
 		}
-		synchronized (this.jwkDefinitions) {
-			this.jwkDefinitions.clear();
-			for (URL jwkSetUrl : jwkSetUrls) {
+		
+		this.jwkDefinitions.clear();
+		
+		for (URL jwkSetUrl : jwkSetUrls) {
+			try {
 				this.jwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
+		 	} catch (OAuth2Exception ex) {
+				//should probably do something besides squash this error
+		 		log.info("Not able to retrieve cert from " + jwkSetUrl.toString());
 			}
-			return this.getDefinition(keyId);
+		  }
+		
+		if(this.jwkDefinitions.isEmpty()) {
+			throw new JwkException("Exception: server_error, Cannot retreive CERTs from all the provided JWK Urls: ", jwkSetUrls);
 		}
+		
+		return this.getDefinition(keyId);
+		
 	}
 
 	/**


### PR DESCRIPTION
Removing the syncronized block as the ConcurrentHashMap is already synchronized and Thread safe which reduces performance