### PR TITLE
Use constant instead of literal string

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/client/ClientCredentialsAccessTokenProvider.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/client/ClientCredentialsAccessTokenProvider.java
@@ -13,6 +13,7 @@ import org.springframework.security.oauth2.client.token.AccessTokenRequest;
 import org.springframework.security.oauth2.client.token.OAuth2AccessTokenSupport;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -48,7 +49,7 @@ public class ClientCredentialsAccessTokenProvider extends OAuth2AccessTokenSuppo
 	private MultiValueMap<String, String> getParametersForTokenRequest(ClientCredentialsResourceDetails resource) {
 
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
-		form.set("grant_type", "client_credentials");
+		form.set(OAuth2Utils.GRANT_TYPE, "client_credentials");
 
 		if (resource.isScoped()) {
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProvider.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProvider.java
@@ -215,7 +215,7 @@ public class AuthorizationCodeAccessTokenProvider extends OAuth2AccessTokenSuppo
 			OAuth2RefreshToken refreshToken, AccessTokenRequest request) throws UserRedirectRequiredException,
 			OAuth2AccessDeniedException {
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
-		form.add("grant_type", "refresh_token");
+		form.add(OAuth2Utils.GRANT_TYPE, "refresh_token");
 		form.add("refresh_token", refreshToken.getValue());
 		try {
 			return retrieveToken(request, resource, form, getHeadersForTokenRequest(request));
@@ -244,7 +244,7 @@ public class AuthorizationCodeAccessTokenProvider extends OAuth2AccessTokenSuppo
 			AccessTokenRequest request) {
 
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
-		form.set("grant_type", "authorization_code");
+		form.set(OAuth2Utils.GRANT_TYPE, "authorization_code");
 		form.set("code", request.getAuthorizationCode());
 
 		Object preservedState = request.getPreservedState();

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/password/ResourceOwnerPasswordAccessTokenProvider.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/password/ResourceOwnerPasswordAccessTokenProvider.java
@@ -13,6 +13,7 @@ import org.springframework.security.oauth2.client.token.AccessTokenRequest;
 import org.springframework.security.oauth2.client.token.OAuth2AccessTokenSupport;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -35,7 +36,7 @@ public class ResourceOwnerPasswordAccessTokenProvider extends OAuth2AccessTokenS
 			OAuth2RefreshToken refreshToken, AccessTokenRequest request) throws UserRedirectRequiredException,
 			OAuth2AccessDeniedException {
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
-		form.add("grant_type", "refresh_token");
+		form.add(OAuth2Utils.GRANT_TYPE, "refresh_token");
 		form.add("refresh_token", refreshToken.getValue());
 		return retrieveToken(request, resource, form, new HttpHeaders());
 	}
@@ -51,7 +52,7 @@ public class ResourceOwnerPasswordAccessTokenProvider extends OAuth2AccessTokenS
 	private MultiValueMap<String, String> getParametersForTokenRequest(ResourceOwnerPasswordResourceDetails resource, AccessTokenRequest request) {
 
 		MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
-		form.set("grant_type", "password");
+		form.set(OAuth2Utils.GRANT_TYPE, "password");
 
 		form.set("username", resource.getUsername());
 		form.set("password", resource.getPassword());

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/TokenRequest.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/TokenRequest.java
@@ -90,7 +90,7 @@ public class TokenRequest extends BaseRequest {
 		modifiable.remove("password");
 		modifiable.remove("client_secret");
 		// Add grant type so it can be retrieved from OAuth2Request
-		modifiable.put("grant_type", grantType);
+		modifiable.put(OAuth2Utils.GRANT_TYPE, grantType);
 		return new OAuth2Request(modifiable, client.getClientId(), client.getAuthorities(), true, this.getScope(),
 				client.getResourceIds(), null, null, null);
 	}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -396,7 +396,7 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 		}
 		String originalScope = authorizationRequest.getRequestParameters().get(OAuth2Utils.SCOPE);
 		if (originalScope == null || !OAuth2Utils.parseParameterList(originalScope).equals(accessToken.getScope())) {
-			vars.put("scope", OAuth2Utils.formatParameterList(accessToken.getScope()));
+			vars.put(OAuth2Utils.SCOPE, OAuth2Utils.formatParameterList(accessToken.getScope()));
 		}
 		Map<String, Object> additionalInformation = accessToken.getAdditionalInformation();
 		for (String key : additionalInformation.keySet()) {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -196,11 +196,11 @@ public class TokenEndpoint extends AbstractEndpoint {
 	}
 
 	private boolean isRefreshTokenRequest(Map<String, String> parameters) {
-		return "refresh_token".equals(parameters.get("grant_type")) && parameters.get("refresh_token") != null;
+		return "refresh_token".equals(parameters.get(OAuth2Utils.GRANT_TYPE)) && parameters.get("refresh_token") != null;
 	}
 
 	private boolean isAuthCodeRequest(Map<String, String> parameters) {
-		return "authorization_code".equals(parameters.get("grant_type")) && parameters.get("code") != null;
+		return "authorization_code".equals(parameters.get(OAuth2Utils.GRANT_TYPE)) && parameters.get("code") != null;
 	}
 
 	public void setOAuth2RequestValidator(OAuth2RequestValidator oAuth2RequestValidator) {

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpointAuthenticationFilter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpointAuthenticationFilter.java
@@ -203,7 +203,7 @@ public class TokenEndpointAuthenticationFilter implements Filter {
 	 * @return an authentication for validation (or null if there is no further authentication)
 	 */
 	protected Authentication extractCredentials(HttpServletRequest request) {
-		String grantType = request.getParameter("grant_type");
+		String grantType = request.getParameter(OAuth2Utils.GRANT_TYPE);
 		if (grantType != null && grantType.equals("password")) {
 			UsernamePasswordAuthenticationToken result = new UsernamePasswordAuthenticationToken(
 					request.getParameter("username"), request.getParameter("password"));
@@ -214,7 +214,7 @@ public class TokenEndpointAuthenticationFilter implements Filter {
 	}
 
 	private Set<String> getScope(HttpServletRequest request) {
-		return OAuth2Utils.parseParameterList(request.getParameter("scope"));
+		return OAuth2Utils.parseParameterList(request.getParameter(OAuth2Utils.SCOPE));
 	}
 	
 	public void init(FilterConfig filterConfig) throws ServletException {


### PR DESCRIPTION
Currently there is a `OAuth2Utils` class that has constant of common
token request's parameter key. Instead of using literal string. Instead
of using literal string, use of this constant value.

**Changes**

* `"grant_types"` &rarr; `OAuth2Utils.GRANT_TYPE`
* `"scopes"` &rarr; `OAuth2Utils.SCOPE`