### PR TITLE
spring-cloud-security issue #61

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProvider.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProvider.java
@@ -53,8 +53,8 @@ import org.springframework.security.oauth2.client.resource.UserRedirectRequiredE
 import org.springframework.security.oauth2.client.token.AccessTokenProvider;
 import org.springframework.security.oauth2.client.token.AccessTokenRequest;
 import org.springframework.security.oauth2.client.token.DefaultRequestEnhancer;
-import org.springframework.security.oauth2.client.token.OAuth2AccessTokenSupport;
 import org.springframework.security.oauth2.client.token.RequestEnhancer;
+import org.springframework.security.oauth2.client.token.grant.redirect.AbstractRedirectOAuth2AccessTokenSupport;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
@@ -69,7 +69,8 @@ import org.springframework.web.client.ResponseExtractor;
  * @author Ryan Heaton
  * @author Dave Syer
  */
-public class AuthorizationCodeAccessTokenProvider extends OAuth2AccessTokenSupport implements AccessTokenProvider {
+public class AuthorizationCodeAccessTokenProvider
+		extends AbstractRedirectOAuth2AccessTokenSupport implements AccessTokenProvider {
 
 	private StateKeyGenerator stateKeyGenerator = new DefaultStateKeyGenerator();
 
@@ -78,7 +79,7 @@ public class AuthorizationCodeAccessTokenProvider extends OAuth2AccessTokenSuppo
 	private RequestEnhancer authorizationRequestEnhancer = new DefaultRequestEnhancer();
 
 	private boolean stateMandatory = true;
-	
+
 	/**
 	 * Flag to say that the use of state parameter is mandatory.
 	 * 
@@ -356,7 +357,7 @@ public class AuthorizationCodeAccessTokenProvider extends OAuth2AccessTokenSuppo
 		}
 
 		UserRedirectRequiredException redirectException = new UserRedirectRequiredException(
-				resource.getUserAuthorizationUri(), requestParameters);
+				resolveAuthorizationUri(resource), requestParameters);
 
 		String stateKey = stateKeyGenerator.generateKey(resource);
 		redirectException.setStateKey(stateKey);
@@ -372,7 +373,7 @@ public class AuthorizationCodeAccessTokenProvider extends OAuth2AccessTokenSuppo
 			AccessTokenRequest request) {
 		String message = String.format("Do you approve the client '%s' to access your resources with scope=%s",
 				resource.getClientId(), resource.getScope());
-		return new UserApprovalRequiredException(resource.getUserAuthorizationUri(), Collections.singletonMap(
+		return new UserApprovalRequiredException(resolveAuthorizationUri(resource), Collections.singletonMap(
 				OAuth2Utils.USER_OAUTH_APPROVAL, message), resource.getClientId(), resource.getScope());
 	}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/implicit/ImplicitAccessTokenProvider.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/implicit/ImplicitAccessTokenProvider.java
@@ -15,7 +15,7 @@ import org.springframework.security.oauth2.client.resource.UserRedirectRequiredE
 import org.springframework.security.oauth2.client.token.AccessTokenProvider;
 import org.springframework.security.oauth2.client.token.AccessTokenRequest;
 import org.springframework.security.oauth2.client.token.DefaultAccessTokenRequest;
-import org.springframework.security.oauth2.client.token.OAuth2AccessTokenSupport;
+import org.springframework.security.oauth2.client.token.grant.redirect.AbstractRedirectOAuth2AccessTokenSupport;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2RefreshToken;
@@ -37,7 +37,8 @@ import org.springframework.web.client.ResponseExtractor;
  * 
  * @author Dave Syer
  */
-public class ImplicitAccessTokenProvider extends OAuth2AccessTokenSupport implements AccessTokenProvider {
+public class ImplicitAccessTokenProvider
+		extends AbstractRedirectOAuth2AccessTokenSupport implements AccessTokenProvider {
 
 	public boolean supportsResource(OAuth2ProtectedResourceDetails resource) {
 		return resource instanceof ImplicitResourceDetails && "implicit".equals(resource.getGrantType());
@@ -62,7 +63,7 @@ public class ImplicitAccessTokenProvider extends OAuth2AccessTokenSupport implem
 					resource, getParametersForTokenRequest(resource, request), getHeadersForTokenRequest(request));
 			if (token==null) {
 				// Probably an authenticated request, but approval is required.  TODO: prompt somehow?
-				throw new UserRedirectRequiredException(resource.getUserAuthorizationUri(), request.toSingleValueMap());				
+				throw new UserRedirectRequiredException(resolveAuthorizationUri(resource), request.toSingleValueMap());
 			}
 			return token;
 		}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/AbstractRedirectOAuth2AccessTokenSupport.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/AbstractRedirectOAuth2AccessTokenSupport.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.client.token.grant.redirect;
+
+import org.springframework.security.oauth2.client.token.OAuth2AccessTokenSupport;
+
+/**
+ * Abstract base class providing support for concrete implementations that
+ * need to issue redirect instructions to OAuth2 clients (browsers).
+ *
+ * @author Andy Elliott
+ */
+public class AbstractRedirectOAuth2AccessTokenSupport extends OAuth2AccessTokenSupport {
+
+    private Oauth2ClientRedirectResolver oauth2ClientRedirectResolver = new DefaultOauth2ClientRedirectResolver();
+
+    /**
+     * Set an alternative to the {@link DefaultOauth2ClientRedirectResolver}.
+     *
+     * @param oauth2ClientRedirectResolver An alternative <code>Oauth2ClientRedirectResolver</code>
+     */
+    public void setOauth2ClientRedirectResolver(Oauth2ClientRedirectResolver oauth2ClientRedirectResolver) {
+        this.oauth2ClientRedirectResolver = oauth2ClientRedirectResolver;
+    }
+
+    // Convenience method for concrete classes to call without having to call
+    // an oauth2ClientRedirectResolver getter then the resolve method.
+    protected String resolveAuthorizationUri(RedirectResourceDetails resource) {
+        return oauth2ClientRedirectResolver.resolveAuthorizationUri(resource);
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/AbstractRedirectResourceDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/AbstractRedirectResourceDetails.java
@@ -7,7 +7,8 @@ import org.springframework.security.oauth2.client.token.DefaultAccessTokenReques
 /**
  * @author Dave Syer
  */
-public abstract class AbstractRedirectResourceDetails extends BaseOAuth2ProtectedResourceDetails {
+public abstract class AbstractRedirectResourceDetails
+		extends BaseOAuth2ProtectedResourceDetails implements RedirectResourceDetails {
 
 	private String preEstablishedRedirectUri;
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/DefaultOauth2ClientRedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/DefaultOauth2ClientRedirectResolver.java
@@ -13,15 +13,13 @@
 package org.springframework.security.oauth2.client.token.grant.redirect;
 
 /**
- * @inheritDoc
+ * @see Oauth2ClientRedirectResolver
  *
  * @author Andy Elliott
  */
 public class DefaultOauth2ClientRedirectResolver implements Oauth2ClientRedirectResolver {
 
     /**
-     * @inheritDoc
-     *
      * Default implementation of {@link Oauth2ClientRedirectResolver#resolveAuthorizationUri}
      * that simply returns the value from calling {@link RedirectResourceDetails#getUserAuthorizationUri()}
      */

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/DefaultOauth2ClientRedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/DefaultOauth2ClientRedirectResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.client.token.grant.redirect;
+
+/**
+ * @inheritDoc
+ *
+ * @author Andy Elliott
+ */
+public class DefaultOauth2ClientRedirectResolver implements Oauth2ClientRedirectResolver {
+
+    /**
+     * @inheritDoc
+     *
+     * Default implementation of {@link Oauth2ClientRedirectResolver#resolveAuthorizationUri}
+     * that simply returns the value from calling {@link RedirectResourceDetails#getUserAuthorizationUri()}
+     */
+    @Override
+    public String resolveAuthorizationUri(RedirectResourceDetails resource) {
+        return resource.getUserAuthorizationUri();
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/Oauth2ClientRedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/Oauth2ClientRedirectResolver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.client.token.grant.redirect;
+
+/**
+ * Resolve redirection URIs that will be sent back to calling clients,
+ * specifically intended to support redirect URIs that will be handled
+ * by browsers.
+ *
+ * @author Andy Elliott
+ */
+public interface Oauth2ClientRedirectResolver {
+
+    /**
+     * Return a valid, resolved URI that will be used to redirect the
+     * client (browser) to the authorization end point.
+     */
+    String resolveAuthorizationUri(RedirectResourceDetails resource);
+
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/RedirectResourceDetails.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/RedirectResourceDetails.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2006-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.client.token.grant.redirect;
+
+/**
+ * Currently only defines the method required to return the user authorization
+ * uri but can obviously be extended to cover related operations.
+ *
+ * @author Andy Elliott
+ */
+public interface RedirectResourceDetails {
+
+    /**
+     * @return The configured user authorization uri
+     */
+    String getUserAuthorizationUri();
+
+}


### PR DESCRIPTION
The issue this PR relates to is recorded in Spring Cloud Security project but the required changes are obviously in Spring Security OAuth2. I made a [comment](https://github.com/spring-cloud/spring-cloud-security/issues/61#issuecomment-437578764) on that discussion that I felt the change to support browser redirects should not be pulling in a discovery service and that instead the change should simply provide a mechanism where people can provide their own mechanism for doing so.

This PR doesn't modify the existing behaviour in any way but adds the ability to introduce service aware resolvers that can be used to resolve a service name based URI into an absolute URI that can be used with browsers.