### PR TITLE
Allow missing "active" field in check_token/introspect response.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -113,7 +113,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 		}
 
 		// gh-838
-		if (!Boolean.TRUE.equals(map.get("active"))) {
+		if (map.containsKey("active") && !"true".equals(String.valueOf(map.get("active")))) {
 			logger.debug("check_token returned active attribute: " + map.get("active"));
 			throw new InvalidTokenException(accessToken);
 		}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
@@ -53,9 +53,22 @@ public class RemoteTokenServicesTest {
 
 	// gh-838
 	@Test
-	public void loadAuthenticationWhenIntrospectionResponseContainsActiveTrueThenReturnAuthentication() throws Exception {
+	public void loadAuthenticationWhenIntrospectionResponseContainsActiveTrueBooleanThenReturnAuthentication() throws Exception {
 		Map responseAttrs = new HashMap();
 		responseAttrs.put("active", true);		// "active" is the only required attribute as per RFC 7662 (https://tools.ietf.org/search/rfc7662#section-2.2)
+		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
+		this.remoteTokenServices.setRestTemplate(restTemplate);
+
+		OAuth2Authentication authentication = this.remoteTokenServices.loadAuthentication("access-token-1234");
+		assertNotNull(authentication);
+	}
+
+	@Test
+	public void loadAuthenticationWhenIntrospectionResponseContainsActiveTrueStringThenReturnAuthentication() throws Exception {
+		Map responseAttrs = new HashMap();
+		responseAttrs.put("active", "true");		// "active" is the only required attribute as per RFC 7662 (https://tools.ietf.org/search/rfc7662#section-2.2)
 		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
 		RestTemplate restTemplate = mock(RestTemplate.class);
 		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
@@ -79,14 +92,15 @@ public class RemoteTokenServicesTest {
 	}
 
 	// gh-838
-	@Test(expected = InvalidTokenException.class)
-	public void loadAuthenticationWhenIntrospectionResponseMissingActiveAttributeThenThrowInvalidTokenException() throws Exception {
+	@Test
+	public void loadAuthenticationWhenIntrospectionResponseMissingActiveAttributeThenReturnAuthentication() throws Exception {
 		Map responseAttrs = new HashMap();
 		ResponseEntity<Map> response = new ResponseEntity<Map>(responseAttrs, HttpStatus.OK);
 		RestTemplate restTemplate = mock(RestTemplate.class);
 		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
 		this.remoteTokenServices.setRestTemplate(restTemplate);
 
-		this.remoteTokenServices.loadAuthentication("access-token-1234");
+		OAuth2Authentication authentication = this.remoteTokenServices.loadAuthentication("access-token-1234");
+		assertNotNull(authentication);
 	}
 }


### PR DESCRIPTION
This PR amends the changes made to RemoteTokenServices in #838 to allow a **missing** "active" field in the check_token (introspect) response, in order to restore backward compatibility.

Indeed, prior to #1070, the check_token endpoint did NOT return the "active" field, so any server using an older version of spring-security-oauth (or any third-party server not complying with [RFC 7662](https://tools.ietf.org/search/rfc7662#section-2.2)) no longer works when used in conjuction with a more recent client, that expects the "active" field to be always present.

This is exactly what happened to one of my projects when we updated spring-security-oauth from a 2.0.x to a 2.2.x version. We saw a "check_token returned active attribute: null" message in the logs, followed by an InvalidTokenException. So IMHO, backward compatibility should be respected and only enforce the "active"=true check if the attribute is actually there.

Additionally, this PR also adds support for both Boolean and String values for this field (related to #1440 but with a different implementation).