### PR TITLE
Fix NPE when refresh_token is not provided

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -129,6 +129,9 @@ public class TokenEndpoint extends AbstractEndpoint {
 		}
 
 		if (isRefreshTokenRequest(parameters)) {
+			if (parameters.get("refresh_token") == null) {
+				throw new InvalidRequestException("Refresh token should be exists. Please check if refresh_token parameter is provided.");
+			}
 			// A refresh token has its own default scopes, so we should ignore any added by the factory here.
 			tokenRequest.setScope(OAuth2Utils.parseParameterList(parameters.get(OAuth2Utils.SCOPE)));
 		}
@@ -200,7 +203,7 @@ public class TokenEndpoint extends AbstractEndpoint {
 	}
 
 	private boolean isRefreshTokenRequest(Map<String, String> parameters) {
-		return "refresh_token".equals(parameters.get("grant_type")) && parameters.get("refresh_token") != null;
+		return "refresh_token".equals(parameters.get("grant_type"));
 	}
 
 	private boolean isAuthCodeRequest(Map<String, String> parameters) {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpointTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpointTests.java
@@ -45,6 +45,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
+import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
@@ -207,6 +208,49 @@ public class TokenEndpointTests {
 		OAuth2AccessToken expectedToken = new DefaultOAuth2AccessToken("FOO");
 
 		when(tokenGranter.grant(eq("authorization_code"), any(TokenRequest.class))).thenReturn(expectedToken);
+
+		when(authorizationRequestFactory.createTokenRequest(any(Map.class), eq(clientDetails))).thenReturn(
+				createFromParameters(parameters));
+
+		ResponseEntity<OAuth2AccessToken> response = endpoint.postAccessToken(clientAuthentication, parameters);
+
+		assertNotNull(response);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("application/json;charset=UTF-8", response.getHeaders().get("Content-Type").iterator().next());
+	}
+
+	@Test(expected = InvalidRequestException.class)
+	public void testRefreshTokenGrantTypeWithoutRefreshTokenParameter() throws Exception {
+		when(clientDetailsService.loadClientByClientId(clientId)).thenReturn(clientDetails);
+
+		HashMap<String, String> parameters = new HashMap<String, String>();
+		parameters.put("client_id", clientId);
+		parameters.put("scope", "read");
+		parameters.put("grant_type", "refresh_token");
+
+		OAuth2AccessToken expectedToken = new DefaultOAuth2AccessToken("FOO");
+
+		when(tokenGranter.grant(eq("refresh_token"), any(TokenRequest.class))).thenReturn(expectedToken);
+
+		when(authorizationRequestFactory.createTokenRequest(any(Map.class), eq(clientDetails))).thenReturn(
+				createFromParameters(parameters));
+
+		endpoint.postAccessToken(clientAuthentication, parameters);
+	}
+
+	@Test
+	public void testGetAccessTokenWithRefreshToken() throws Exception {
+		when(clientDetailsService.loadClientByClientId(clientId)).thenReturn(clientDetails);
+
+		HashMap<String, String> parameters = new HashMap<String, String>();
+		parameters.put("client_id", clientId);
+		parameters.put("scope", "read");
+		parameters.put("grant_type", "refresh_token");
+		parameters.put("refresh_token", "kJAHDFG");
+
+		OAuth2AccessToken expectedToken = new DefaultOAuth2AccessToken("FOO");
+
+		when(tokenGranter.grant(eq("refresh_token"), any(TokenRequest.class))).thenReturn(expectedToken);
 
 		when(authorizationRequestFactory.createTokenRequest(any(Map.class), eq(clientDetails))).thenReturn(
 				createFromParameters(parameters));


### PR DESCRIPTION
Related issue: #941 

The NullPointerException can occure when the `grant_type` is `refersh_token` but the `refresh_token` itself is not provided. And the response code would be 500 as it is a server error.

With this fix, it will return 4xx as it is one of the client side error that missed providing required parameter, `refresh_token`.
