### PR TITLE
Extracting Bearer token from multi value header

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/BearerTokenExtractor.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/authentication/BearerTokenExtractor.java
@@ -13,81 +13,87 @@
 
 package org.springframework.security.oauth2.provider.authentication;
 
-import java.util.Enumeration;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
+import javax.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+
 /**
  * {@link TokenExtractor} that strips the authenticator from a bearer token request (with an Authorization header in the
  * form "Bearer <code>&lt;TOKEN&gt;</code>", or as a request parameter if that fails). The access token is the principal in
  * the authentication token that is extracted.
- * 
+ *
  * @author Dave Syer
- * 
  */
 public class BearerTokenExtractor implements TokenExtractor {
 
-	private final static Log logger = LogFactory.getLog(BearerTokenExtractor.class);
+    private final static Log logger = LogFactory.getLog(BearerTokenExtractor.class);
 
-	@Override
-	public Authentication extract(HttpServletRequest request) {
-		String tokenValue = extractToken(request);
-		if (tokenValue != null) {
-			PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(tokenValue, "");
-			return authentication;
-		}
-		return null;
-	}
+    @Override
+    public Authentication extract(HttpServletRequest request) {
+        String tokenValue = extractToken(request);
+        if (tokenValue != null) {
+            PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(tokenValue, "");
+            return authentication;
+        }
+        return null;
+    }
 
-	protected String extractToken(HttpServletRequest request) {
-		// first check the header...
-		String token = extractHeaderToken(request);
+    protected String extractToken(HttpServletRequest request) {
+        // first check the header...
+        String token = extractHeaderToken(request);
 
-		// bearer type allows a request parameter as well
-		if (token == null) {
-			logger.debug("Token not found in headers. Trying request parameters.");
-			token = request.getParameter(OAuth2AccessToken.ACCESS_TOKEN);
-			if (token == null) {
-				logger.debug("Token not found in request parameters.  Not an OAuth2 request.");
-			}
-			else {
-				request.setAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_TYPE, OAuth2AccessToken.BEARER_TYPE);
-			}
-		}
+        // bearer type allows a request parameter as well
+        if (token == null) {
+            logger.debug("Token not found in headers. Trying request parameters.");
+            token = request.getParameter(OAuth2AccessToken.ACCESS_TOKEN);
+            if (token == null) {
+                logger.debug("Token not found in request parameters.  Not an OAuth2 request.");
+            } else {
+                request.setAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_TYPE, OAuth2AccessToken.BEARER_TYPE);
+            }
+        }
 
-		return token;
-	}
+        return token;
+    }
 
-	/**
-	 * Extract the OAuth bearer token from a header.
-	 * 
-	 * @param request The request.
-	 * @return The token, or null if no OAuth authorization header was supplied.
-	 */
-	protected String extractHeaderToken(HttpServletRequest request) {
-		Enumeration<String> headers = request.getHeaders("Authorization");
-		while (headers.hasMoreElements()) { // typically there is only one (most servers enforce that)
-			String value = headers.nextElement();
-			if ((value.toLowerCase().startsWith(OAuth2AccessToken.BEARER_TYPE.toLowerCase()))) {
-				String authHeaderValue = value.substring(OAuth2AccessToken.BEARER_TYPE.length()).trim();
-				// Add this here for the auth details later. Would be better to change the signature of this method.
-				request.setAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_TYPE,
-						value.substring(0, OAuth2AccessToken.BEARER_TYPE.length()).trim());
-				int commaIndex = authHeaderValue.indexOf(',');
-				if (commaIndex > 0) {
-					authHeaderValue = authHeaderValue.substring(0, commaIndex);
-				}
-				return authHeaderValue;
-			}
-		}
+    /**
+     * Extract the OAuth bearer token from a header.
+     *
+     * @param request The request.
+     * @return The token, or null if no OAuth authorization header was supplied.
+     */
+    protected String extractHeaderToken(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders("Authorization");
 
-		return null;
-	}
+        while (headers.hasMoreElements()) { // typically there is only one (most servers enforce that)
+            String value = headers.nextElement();
+
+            if (containsBearerToken(value)) {
+                request.setAttribute(OAuth2AuthenticationDetails.ACCESS_TOKEN_TYPE, OAuth2AccessToken.BEARER_TYPE);
+                return retrieveBearerToken(value);
+            }
+        }
+
+        return null;
+    }
+
+    private boolean containsBearerToken(String value) {
+        return value != null && value.toLowerCase().contains(OAuth2AccessToken.BEARER_TYPE.toLowerCase());
+    }
+
+    private String retrieveBearerToken(String value) {
+        int bearerBeginning = value.indexOf(OAuth2AccessToken.BEARER_TYPE);
+        int commaAfterBearer = value.indexOf(",", bearerBeginning);
+        if (commaAfterBearer > 0) {
+            return value.substring(bearerBeginning + OAuth2AccessToken.BEARER_TYPE.length(), commaAfterBearer);
+        } else {
+            return value.substring(bearerBeginning + OAuth2AccessToken.BEARER_TYPE.length()).trim();
+        }
+    }
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/BearerTokenExtractorTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/BearerTokenExtractorTest.java
@@ -1,0 +1,91 @@
+package org.springframework.security.oauth2.provider.authentication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Michał Drożdż
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BearerTokenExtractorTest {
+
+    private BearerTokenExtractor bearerTokenExtractor = new BearerTokenExtractor();
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    public void extractHeaderToken_noAuthorizationHeadersToken(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.<String>emptyEnumeration());
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void extractHeaderToken_noBearerToken(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Collections.singleton("Basic auth")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void extractHeaderToken_oneBearerToken(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Collections.singleton("Bearer auth")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertThat(result, is("auth"));
+    }
+
+    @Test
+    public void extractHeaderToken_multipleBearerTokens(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer auth", "Bearer auth2")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertThat(result, is("auth"));
+    }
+
+    @Test
+    public void extractHeaderToken_multipleTokenTypes(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Basic auth", "Bearer auth2")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertThat(result, is("auth2"));
+    }
+
+    @Test
+    public void extractHeaderToken_multipleTokenTypesInOneHeaderBasicFirst(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Basic auth, Bearer auth2")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void extractHeaderToken_multipleTokenTypesInOneHeaderBearerFirst(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer auth2, Basic auth")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertThat(result, is("auth2"));
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/BearerTokenExtractorTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/authentication/BearerTokenExtractorTest.java
@@ -77,12 +77,21 @@ public class BearerTokenExtractorTest {
 
         String result = bearerTokenExtractor.extractHeaderToken(request);
 
-        assertThat(result, is(nullValue()));
+        assertThat(result, is("auth2"));
     }
 
     @Test
     public void extractHeaderToken_multipleTokenTypesInOneHeaderBearerFirst(){
         when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer auth2, Basic auth")));
+
+        String result = bearerTokenExtractor.extractHeaderToken(request);
+
+        assertThat(result, is("auth2"));
+    }
+
+    @Test
+    public void extractHeaderToken_multipleTokenValuesInOneBearer(){
+        when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer auth2, auth")));
 
         String result = bearerTokenExtractor.extractHeaderToken(request);
 


### PR DESCRIPTION
When an `Authorization` header consists of multiple token types e.g. `Basic auth, Bearer auth`, `extractHeaderToken` will return null whereas it would be good to receive `auth`. I'm not sure if anyone uses authorization header like that, but it might be possible. 

I have prepared PR to extract token correctly in such case. Check out if it's needed or not.