### PR TITLE
Exclude ENC keys from JWK set without failing entire set

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
@@ -97,7 +97,7 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 				// gh-1470 - skip unsupported public key use (enc) without discarding the entire set
 				JwkDefinition.PublicKeyUse publicKeyUse =
 						JwkDefinition.PublicKeyUse.fromValue(attributes.get(PUBLIC_KEY_USE));
-				if (!JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
+				if (JwkDefinition.PublicKeyUse.ENC.equals(publicKeyUse)) {
 					continue;
 				}
 			

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
@@ -94,6 +94,13 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 					}
 				}
 
+				// gh-1470 - skip unsupported public key use (enc) without discarding the entire set
+				JwkDefinition.PublicKeyUse publicKeyUse =
+						JwkDefinition.PublicKeyUse.fromValue(attributes.get(PUBLIC_KEY_USE));
+				if (!JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
+					continue;
+				}
+			
 				JwkDefinition jwkDefinition = null;
 				JwkDefinition.KeyType keyType =
 						JwkDefinition.KeyType.fromValue(attributes.get(KEY_TYPE));

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverterTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverterTest.java
@@ -139,12 +139,11 @@ public class JwkSetConverterTest {
 
 	@Test
 	public void convertWhenJwkSetStreamHasRSAJwkElementWithENCPublicKeyUseAttributeThenThrowJwkException() throws Exception {
-		this.thrown.expect(JwkException.class);
-		this.thrown.expectMessage("enc (use) is currently not supported.");
 		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
 		Map<String, Object> jwkObject = this.createJwkObject(JwkDefinition.KeyType.RSA, "key-id-1", JwkDefinition.PublicKeyUse.ENC);
 		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject});
-		this.converter.convert(this.asInputStream(jwkSetObject));
+		Set<JwkDefinition> jwkSet = this.converter.convert(this.asInputStream(jwkSetObject));
+		assertTrue("JWK Set NOT empty", jwkSet.isEmpty());
 	}
 
 	@Test
@@ -190,13 +189,12 @@ public class JwkSetConverterTest {
 	}
 
 	@Test
-	public void convertWhenJwkSetStreamHasECJwkElementWithENCPublicKeyUseAttributeThenThrowJwkException() throws Exception {
-		this.thrown.expect(JwkException.class);
-		this.thrown.expectMessage("enc (use) is currently not supported.");
+	public void convertWhenJwkSetStreamHasECJwkElementWithENCPublicKeyUseAttributeThenReturnEmptyKeySet() throws Exception {
 		Map<String, Object> jwkSetObject = new HashMap<String, Object>();
 		Map<String, Object> jwkObject = this.createEllipticCurveJwkObject("key-id-1", JwkDefinition.PublicKeyUse.ENC, null);
 		jwkSetObject.put(JwkAttributes.KEYS, new Map[] {jwkObject});
-		this.converter.convert(this.asInputStream(jwkSetObject));
+		Set<JwkDefinition> jwkSet = this.converter.convert(this.asInputStream(jwkSetObject));
+		assertTrue("JWK Set NOT empty", jwkSet.isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
As described in https://github.com/spring-projects/spring-security-oauth/issues/1470 the entire JWK chain will be rejected if it contains keys with public key use `enc` (defined by standard but not supported by `spring-security`). Thus integration with some OpenId Connect providers (like `gluu`) is not possible.

Fix will exclude `enc` keys without rejecting the entire set thus making integration possible.