### PR TITLE
Log generic Exceptions to ERROR with stack trace

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.java
@@ -165,8 +165,8 @@ public class TokenEndpoint extends AbstractEndpoint {
 	
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<OAuth2Exception> handleException(Exception e) throws Exception {
-		if (logger.isWarnEnabled()) {
-			logger.warn("Handling error: " + e.getClass().getSimpleName() + ", " + e.getMessage());
+		if (logger.isErrorEnabled()) {
+			logger.error("Handling error: " + e.getClass().getSimpleName() + ", " + e.getMessage(), e);
 		}
 		return getExceptionTranslator().translate(e);
 	}


### PR DESCRIPTION
As described in #1545, generic Exceptions like NullPointerExceptions are written to WARN log with stack trace omitted, so it's impossible to trace the root cause of such Exceptions.

This change attaches the Exception to the logger, so its full stack trace will be logged. Additionally, the log level will be ERROR.

All other Exceptions related to the protocol, like Bad Credentials, are treated in separate ExceptionsHandlers, so we assume that every other Exception is unexpected and should get some attention.