### PR TITLE
Making oauth2 compatible between jdbc and jwtconverter.

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/AccessTokenConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/AccessTokenConverter.java
@@ -38,8 +38,12 @@ public interface AccessTokenConverter {
 	final String JTI = "jti";
 	
 	final String GRANT_TYPE = "grant_type";
+	
+	final String TOKEN_TYPE = "token_type";
 
 	final String ATI = "ati";
+	
+	final String RTI = "rti";
 
 	final String SCOPE = OAuth2AccessToken.SCOPE;
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -104,9 +104,14 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 				tokenStore.removeAccessToken(existingAccessToken);
 			}
 			else {
-				// Re-store the access token in case the authentication has changed
-				tokenStore.storeAccessToken(existingAccessToken, authentication);
-				return existingAccessToken;
+			    if (tokenStore.readRefreshToken(existingAccessToken.getRefreshToken().getValue()) != null) {
+	                // Re-store the access token in case the authentication has changed
+	                tokenStore.storeAccessToken(existingAccessToken, authentication);
+	                return existingAccessToken;
+			    }
+			    else {
+			        tokenStore.removeAccessToken(existingAccessToken);
+			    }
 			}
 		}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -104,7 +104,8 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 				tokenStore.removeAccessToken(existingAccessToken);
 			}
 			else {
-			    if (tokenStore.readRefreshToken(existingAccessToken.getRefreshToken().getValue()) != null) {
+                if (existingAccessToken.getRefreshToken() != null
+                        && tokenStore.readRefreshToken(existingAccessToken.getRefreshToken().getValue()) != null) {
 	                // Re-store the access token in case the authentication has changed
 	                tokenStore.storeAccessToken(existingAccessToken, authentication);
 	                return existingAccessToken;

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJdbcAndJwtConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJdbcAndJwtConverterTests.java
@@ -1,0 +1,97 @@
+package org.springframework.security.oauth2.provider.token;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.TokenRequest;
+import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
+import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
+
+/**
+ * @author Dave Syer
+ * 
+ */
+public class DefaultTokenServicesWithJdbcAndJwtConverterTests extends AbstractDefaultTokenServicesTests {
+
+	private EmbeddedDatabase db;
+
+	private JwtAccessTokenConverter enhancer = new JwtAccessTokenConverter();
+
+	@Test
+	public void testRefreshedTokenIsReused() throws Exception {
+		OAuth2Authentication authentication = createAuthentication();
+		getTokenServices().setSupportRefreshToken(true);
+		getTokenServices().setReuseRefreshToken(true);
+		OAuth2AccessToken accessToken = getTokenServices().createAccessToken(authentication);
+		TokenRequest tokenRequest = new TokenRequest(Collections.singletonMap("client_id", "id"), "id", null, null);
+		OAuth2AccessToken refreshedAccessToken = getTokenServices().refreshAccessToken(accessToken.getRefreshToken().getValue(), tokenRequest);
+		assertTrue(accessToken.getRefreshToken().equals(refreshedAccessToken.getRefreshToken()));
+		OAuth2AccessToken result = getTokenStore().getAccessToken(authentication);
+		assertEquals(refreshedAccessToken, result);
+		assertEquals(refreshedAccessToken.getRefreshToken(), result.getRefreshToken());
+		assertEquals(refreshedAccessToken.getRefreshToken(), getTokenStore().readRefreshToken(accessToken.getRefreshToken().getValue()));
+	}
+
+	@Test
+	public void testAccessTokenRefreshTokenMissing() throws Exception {
+		OAuth2Authentication authentication = createAuthentication();
+		getTokenServices().setSupportRefreshToken(true);
+		getTokenServices().setReuseRefreshToken(true);
+		OAuth2AccessToken accessToken = getTokenServices().createAccessToken(authentication);
+		getTokenStore().removeRefreshToken(accessToken.getRefreshToken());
+		
+		accessToken = getTokenServices().createAccessToken(authentication);
+		TokenRequest tokenRequest = new TokenRequest(Collections.singletonMap("client_id", "id"), "id", null, null);
+		OAuth2AccessToken refreshedAccessToken = getTokenServices().refreshAccessToken(accessToken.getRefreshToken().getValue(), tokenRequest);
+		
+		assertTrue(accessToken.getRefreshToken().equals(refreshedAccessToken.getRefreshToken()));
+		OAuth2AccessToken result = getTokenStore().getAccessToken(authentication);
+		assertEquals(refreshedAccessToken, result);
+		assertEquals(refreshedAccessToken.getRefreshToken(), result.getRefreshToken());
+		assertEquals(refreshedAccessToken.getRefreshToken(), getTokenStore().readRefreshToken(accessToken.getRefreshToken().getValue()));
+	}
+	
+	@Override
+	protected void configureTokenServices(DefaultTokenServices services) throws Exception {
+		enhancer.afterPropertiesSet();
+		services.setTokenEnhancer(enhancer);
+		super.configureTokenServices(services);
+	}
+
+	protected TokenStore createTokenStore() {
+		db = new EmbeddedDatabaseBuilder().addDefaultScripts().build();
+		return new JdbcTokenStore(db);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		db.shutdown();
+	}
+
+	protected int getAccessTokenCount() {
+		return new JdbcTemplate(db).queryForObject("SELECT COUNT(*) FROM OAUTH_ACCESS_TOKEN", Integer.class);
+	}
+
+	protected int getRefreshTokenCount() {
+		return new JdbcTemplate(db).queryForObject("SELECT COUNT(*) FROM OAUTH_REFRESH_TOKEN", Integer.class);
+	}
+
+	protected TokenEnhancer createTokenEnhancer1Tester(ExpiringOAuth2RefreshToken refreshToken) {
+		return enhancer;
+	}
+
+	protected TokenEnhancer createTokenEnhancer2Tester() {
+		return enhancer;
+	}
+
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJwtTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJwtTests.java
@@ -104,21 +104,21 @@ public class DefaultTokenServicesWithJwtTests extends AbstractDefaultTokenServic
 		Map<String, ?> refreshTokenClaims = parser.parseMap(
 				JwtHelper.decode(refreshedAccessToken.getRefreshToken().getValue()).getClaims());
 
-		assertEquals("Access token ID (JTI) does not match refresh token ATI",
-				accessTokenClaims.get(AccessTokenConverter.JTI),
-				refreshTokenClaims.get(AccessTokenConverter.ATI));
+		assertEquals("Refresh token ID (JTI) does not match refresh token RTI",
+				accessTokenClaims.get(AccessTokenConverter.RTI),
+				refreshTokenClaims.get(AccessTokenConverter.JTI));
 
 		Map<String, ?> previousRefreshTokenClaims = parser.parseMap(
 				JwtHelper.decode(refreshToken.getValue()).getClaims());
 
-		// The ATI claim in the refresh token is a reference to the JTI claim in the access token.
-		// So when an access token is refreshed, the ATI claim in the refresh token needs to be updated
+		// The JTI claim in the refresh token is a reference to the RTI claim in the access token.
+		// So when an access token is refreshed, the RTI claim in the refresh token needs to be updated
 		// to the JTI claim in the refreshed access token.
 		// Therefore, if DefaultTokenServices.reuseRefreshToken == true,
 		// then all claims in the previous and current refresh token
-		// should be equal minus the ATI claim
-		previousRefreshTokenClaims.remove(AccessTokenConverter.ATI);
-		refreshTokenClaims.remove(AccessTokenConverter.ATI);
+		// should be equal minus the JTI claim
+		previousRefreshTokenClaims.remove(AccessTokenConverter.JTI);
+		refreshTokenClaims.remove(AccessTokenConverter.JTI);
 		assertEquals("Refresh token not re-used", previousRefreshTokenClaims, refreshTokenClaims);
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJwtTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJwtTests.java
@@ -56,9 +56,9 @@ public class DefaultTokenServicesWithJwtTests extends AbstractDefaultTokenServic
 				refreshedAccessToken.getValue()).getClaims());
 		Map<String, ?> refreshTokenInfo = parser.parseMap(JwtHelper.decode(
 				refreshedAccessToken.getRefreshToken().getValue()).getClaims());
-		assertEquals("Access token ID does not match refresh token ATI",
-				accessTokenInfo.get(AccessTokenConverter.JTI),
-				refreshTokenInfo.get(AccessTokenConverter.ATI));
+		assertEquals("Refresh token ID does not match refresh token JTI",
+				accessTokenInfo.get(AccessTokenConverter.RTI),
+				refreshTokenInfo.get(AccessTokenConverter.JTI));
 		assertNotSame("Refresh token re-used", expectedExpiringRefreshToken.getValue(),
 				refreshedAccessToken.getRefreshToken().getValue());
 	}
@@ -79,9 +79,9 @@ public class DefaultTokenServicesWithJwtTests extends AbstractDefaultTokenServic
 				refreshedAccessToken.getValue()).getClaims());
 		Map<String, ?> refreshTokenInfo = parser.parseMap(JwtHelper.decode(
 				refreshedAccessToken.getRefreshToken().getValue()).getClaims());
-		assertEquals("Access token ID does not match refresh token ATI",
-				accessTokenInfo.get(AccessTokenConverter.JTI),
-				refreshTokenInfo.get(AccessTokenConverter.ATI));
+		assertEquals("Refresh token ID does not match refresh token JTI",
+				accessTokenInfo.get(AccessTokenConverter.RTI),
+				refreshTokenInfo.get(AccessTokenConverter.JTI));
 	}
 
 	// gh-1109

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JwtAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JwtAccessTokenConverterTests.java
@@ -94,12 +94,16 @@ public class JwtAccessTokenConverterTests {
 		assertNotNull(token.getValue());
 		assertNotNull(token.getRefreshToken());
 		JsonParser parser = JsonParserFactory.create();
-		Map<String, Object> claims = parser.parseMap(JwtHelper.decode(
+		Map<String, Object> refreshClaims = parser.parseMap(JwtHelper.decode(
 				token.getRefreshToken().getValue()).getClaims());
-		assertEquals(Arrays.asList("read"), claims.get(AccessTokenConverter.SCOPE));
-		assertEquals("FOO", claims.get(AccessTokenConverter.ATI));
-		assertEquals("BAR", claims.get(AccessTokenConverter.JTI));
-		assertNull(claims.get(AccessTokenConverter.EXP));
+		Map<String, Object> accessClaims = parser.parseMap(JwtHelper.decode(
+				token.getValue()).getClaims());
+		assertEquals(Arrays.asList("read"), refreshClaims.get(AccessTokenConverter.SCOPE));
+		assertEquals("refresh_token", refreshClaims.get(AccessTokenConverter.TOKEN_TYPE));
+		assertEquals("BAR", refreshClaims.get(AccessTokenConverter.JTI));
+		assertEquals("FOO", accessClaims.get(AccessTokenConverter.JTI));
+		assertEquals("BAR", accessClaims.get(AccessTokenConverter.RTI));
+		assertNull(refreshClaims.get(AccessTokenConverter.EXP));
 		tokenEnhancer.afterPropertiesSet();
 		assertTrue(tokenEnhancer.isRefreshToken(tokenEnhancer.extractAccessToken(token
 				.getRefreshToken().getValue(), tokenEnhancer.decode(token
@@ -119,12 +123,16 @@ public class JwtAccessTokenConverterTests {
 		assertNotNull(token.getValue());
 		assertNotNull(token.getRefreshToken());
 		JsonParser parser = JsonParserFactory.create();
-		Map<String, Object> claims = parser.parseMap(JwtHelper.decode(
+		Map<String, Object> refreshClaims = parser.parseMap(JwtHelper.decode(
 				token.getRefreshToken().getValue()).getClaims());
-		assertEquals(Arrays.asList("read"), claims.get(AccessTokenConverter.SCOPE));
-		assertEquals("FOO", claims.get(AccessTokenConverter.ATI));
-		assertEquals("BAR", claims.get(AccessTokenConverter.JTI));
-		assertEquals(0, claims.get(AccessTokenConverter.EXP));
+		Map<String, Object> accessClaims = parser.parseMap(JwtHelper.decode(
+				token.getValue()).getClaims());
+		assertEquals(Arrays.asList("read"), refreshClaims.get(AccessTokenConverter.SCOPE));
+		assertEquals("refresh_token", refreshClaims.get(AccessTokenConverter.TOKEN_TYPE));
+		assertEquals("BAR", refreshClaims.get(AccessTokenConverter.JTI));
+		assertEquals("FOO", accessClaims.get(AccessTokenConverter.JTI));
+		assertEquals("BAR", accessClaims.get(AccessTokenConverter.RTI));
+		assertEquals(0, refreshClaims.get(AccessTokenConverter.EXP));
 		tokenEnhancer.afterPropertiesSet();
 		assertTrue(tokenEnhancer.isRefreshToken(tokenEnhancer.extractAccessToken(token
 				.getRefreshToken().getValue(), tokenEnhancer.decode(token
@@ -146,9 +154,12 @@ public class JwtAccessTokenConverterTests {
 		JsonParser parser = JsonParserFactory.create();
 		Map<String, Object> claims = parser.parseMap(JwtHelper.decode(
 				token.getRefreshToken().getValue()).getClaims());
+		Map<String, Object> accessClaims = parser.parseMap(JwtHelper.decode(
+				token.getValue()).getClaims());
 		assertEquals(Arrays.asList("read"), claims.get(AccessTokenConverter.SCOPE));
-		assertEquals("FOO", claims.get(AccessTokenConverter.ATI));
+		assertEquals("refresh_token", claims.get(AccessTokenConverter.TOKEN_TYPE));
 		assertEquals("Wrong claims: " + claims, "BAR", claims.get(AccessTokenConverter.JTI));
+		assertEquals("BAR", accessClaims.get(AccessTokenConverter.RTI));
 	}
 
 	@Test

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JwtTokenStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JwtTokenStoreTests.java
@@ -67,7 +67,7 @@ public class JwtTokenStoreTests {
 
 	protected void convertToRefreshToken(DefaultOAuth2AccessToken original) {
 		Map<String, Object> map = new HashMap<String, Object>(original.getAdditionalInformation());
-		map.put(AccessTokenConverter.ATI, "FOO");
+		map.put(AccessTokenConverter.TOKEN_TYPE, "FOO");
 		original.setAdditionalInformation(map);
 	}
 

--- a/tests/annotation/jwt/src/test/java/demo/ClientCredentialsProviderTests.java
+++ b/tests/annotation/jwt/src/test/java/demo/ClientCredentialsProviderTests.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.test.OAuth2ContextConfiguration;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import sparklr.common.AbstractClientCredentialsProviderTests;
 
@@ -33,10 +35,12 @@ public class ClientCredentialsProviderTests extends AbstractClientCredentialsPro
 		OAuth2AccessToken token = context.getAccessToken();
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<String, String>();
+        requestBody.add("token", token.getValue());
 		@SuppressWarnings("rawtypes")
 		ResponseEntity<Map> response = new TestRestTemplate("my-client-with-secret", "secret").exchange(http
 				.getUrl(checkTokenPath()), HttpMethod.POST,
-				new HttpEntity<String>("token=" + token.getValue(), headers), Map.class);
+				new HttpEntity<MultiValueMap<String, String>>(requestBody, headers), Map.class);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 		@SuppressWarnings("unchecked")
 		Map<String, Object> map = (Map<String, Object>) response.getBody();

--- a/tests/annotation/jwt/src/test/java/demo/ResourceOwnerPasswordProviderTests.java
+++ b/tests/annotation/jwt/src/test/java/demo/ResourceOwnerPasswordProviderTests.java
@@ -17,6 +17,8 @@ import org.springframework.security.oauth2.client.test.OAuth2ContextConfiguratio
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.UserAuthenticationConverter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import sparklr.common.AbstractResourceOwnerPasswordProviderTests;
 
@@ -31,9 +33,11 @@ public class ResourceOwnerPasswordProviderTests extends AbstractResourceOwnerPas
 		OAuth2AccessToken token = context.getAccessToken();
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<String, String>();
+        requestBody.add("token", token.getValue());
 		@SuppressWarnings("rawtypes")
 		ResponseEntity<Map> response = new TestRestTemplate("my-client-with-secret", "secret").exchange(http
-				.getUrl(checkTokenPath()), HttpMethod.POST, new HttpEntity<String>("token=" + token.getValue(),
+				.getUrl(checkTokenPath()), HttpMethod.POST, new HttpEntity<MultiValueMap<String, String>>(requestBody,
 				headers), Map.class);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 		@SuppressWarnings("unchecked")

--- a/tests/annotation/mappings/src/test/java/demo/ClientCredentialsProviderTests.java
+++ b/tests/annotation/mappings/src/test/java/demo/ClientCredentialsProviderTests.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.test.OAuth2ContextConfiguration;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.token.AccessTokenConverter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import sparklr.common.AbstractClientCredentialsProviderTests;
 
@@ -33,10 +35,12 @@ public class ClientCredentialsProviderTests extends AbstractClientCredentialsPro
 		OAuth2AccessToken token = context.getAccessToken();
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+		MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<String, String>();
+		requestBody.add("token", token.getValue());
 		@SuppressWarnings("rawtypes")
-		ResponseEntity<Map> response = new TestRestTemplate("my-client-with-secret", "secret").exchange(http
-				.getUrl(checkTokenPath()), HttpMethod.POST,
-				new HttpEntity<String>("token=" + token.getValue(), headers), Map.class);
+		ResponseEntity<Map> response = new TestRestTemplate("my-client-with-secret", "secret").exchange(
+				http.getUrl(checkTokenPath()), HttpMethod.POST,
+				new HttpEntity<MultiValueMap<String, String>>(requestBody, headers), Map.class);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 		@SuppressWarnings("unchecked")
 		Map<String, Object> map = (Map<String, Object>) response.getBody();


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
I want to merge these changes in the current master. I have implemented an oauth server using the jdbc storage along side jwt converter. I found a lot of issues and finally landed in this pull request.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
