### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <description>Parent Project for OAuth Support for Spring Security</description>
   <packaging>pom</packaging>
   <version>2.3.6.BUILD-SNAPSHOT</version>
-  <url>http://static.springframework.org/spring-security/oauth</url>
+  <url>https://docs.spring.io/spring-security/oauth</url>
 
   <modules>
     <module>spring-security-oauth</module>
@@ -27,20 +27,20 @@
   </properties>
 
   <scm>
-    <url>http://github.com/SpringSource/spring-security-oauth</url>
+    <url>https://github.com/SpringSource/spring-security-oauth</url>
     <connection>scm:git:git://github.com/SpringSource/spring-security-oauth.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/SpringSource/spring-security-oauth.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>
     <system>JIRA</system>
-    <url>http://opensource.atlassian.com/projects/spring/browse/SECOAUTH</url>
+    <url>https://opensource.atlassian.com/projects/spring/browse/SECOAUTH</url>
   </issueManagement>
   <mailingLists>
     <mailingList>
       <name>Spring Security OAuth Forum</name>
-      <post>http://forum.springframework.org/forumdisplay.php?f=79</post>
-      <archive>http://forum.springframework.org/forumdisplay.php?f=79</archive>
+      <post>https://forum.springframework.org/forumdisplay.php?f=79</post>
+      <archive>https://forum.springframework.org/forumdisplay.php?f=79</archive>
     </mailingList>
   </mailingLists>
   <ciManagement>
@@ -50,7 +50,7 @@
   <licenses>
     <license>
       <name>Apache 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 
@@ -94,22 +94,22 @@
         <repository>
           <id>repo.spring.io-milestone</id>
           <name>Spring Framework Milestone Repository</name>
-          <url>http://repo.spring.io/libs-milestone-local</url>
+          <url>https://repo.spring.io/libs-milestone-local</url>
         </repository>
         <repository>
           <id>repo.spring.io-release</id>
           <name>Spring Framework Release Repository</name>
-          <url>http://repo.spring.io/libs-release-local</url>
+          <url>https://repo.spring.io/libs-release-local</url>
         </repository>
         <repository>
           <id>repo.spring.io-snapshot</id>
           <name>Spring Framework Maven Snapshot Repository</name>
-          <url>http://repo.spring.io/libs-snapshot-local</url>
+          <url>https://repo.spring.io/libs-snapshot-local</url>
           <snapshots><enabled>true</enabled></snapshots>
         </repository>
         <repository>
           <id>oauth.googlecode.net</id>
-          <url>http://oauth.googlecode.com/svn/code/maven/</url>
+          <url>https://oauth.googlecode.com/svn/code/maven/</url>
         </repository>
       </repositories>
     </profile>
@@ -119,7 +119,7 @@
             <repository>
               <id>repo.spring.io</id>
               <name>Spring Milestone Repository</name>
-              <url>http://repo.spring.io/libs-milestone-local</url>
+              <url>https://repo.spring.io/libs-milestone-local</url>
             </repository>
       </distributionManagement>
     </profile>
@@ -176,12 +176,12 @@
             <repository>
                 <id>repo.spring.io-milestone</id>
                 <name>Spring Framework Milestone Repository</name>
-                <url>http://repo.spring.io/libs-milestone-local</url>
+                <url>https://repo.spring.io/libs-milestone-local</url>
             </repository>
             <repository>
                 <id>repo.spring.io-snapshot</id>
                 <name>Spring Framework Maven Snapshot Repository</name>
-                <url>http://repo.spring.io/libs-snapshot-local</url>
+                <url>https://repo.spring.io/libs-snapshot-local</url>
                 <snapshots><enabled>true</enabled></snapshots>
             </repository>
         </repositories>
@@ -472,17 +472,17 @@
           <links>
             <link>http://java.sun.com/j2ee/1.4/docs/api</link>
             <link>http://java.sun.com/j2se/1.5.0/docs/api</link>
-            <link>http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
-            <link>http://jakarta.apache.org/commons/dbcp/apidocs/</link>
-            <link>http://jakarta.apache.org/commons/fileupload/apidocs/</link>
-            <link>http://jakarta.apache.org/commons/httpclient/apidocs/</link>
-            <link>http://jakarta.apache.org/commons/pool/apidocs/</link>
-            <link>http://jakarta.apache.org/commons/logging/apidocs/</link>
+            <link>https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
+            <link>https://jakarta.apache.org/commons/dbcp/apidocs/</link>
+            <link>https://jakarta.apache.org/commons/fileupload/apidocs/</link>
+            <link>https://jakarta.apache.org/commons/httpclient/apidocs/</link>
+            <link>https://jakarta.apache.org/commons/pool/apidocs/</link>
+            <link>https://jakarta.apache.org/commons/logging/apidocs/</link>
             <link>http://junit.sourceforge.net/javadoc/</link>
-            <link>http://logging.apache.org/log4j/docs/api/</link>
-            <link>http://jakarta.apache.org/regexp/apidocs/</link>
-            <link>http://jakarta.apache.org/velocity/api/</link>
-            <link>http://static.springframework.org/spring/docs/2.5.x/api/</link>
+            <link>https://logging.apache.org/log4j/docs/api/</link>
+            <link>https://jakarta.apache.org/regexp/apidocs/</link>
+            <link>https://jakarta.apache.org/velocity/api/</link>
+            <link>https://docs.spring.io/spring/docs/2.5.x/api/</link>
           </links>
           <excludePackageNames>example</excludePackageNames>
         </configuration>
@@ -504,13 +504,13 @@
     <repository>
       <id>repo.spring.io</id>
       <name>Spring Release Repository</name>
-      <url>http://repo.spring.io/libs-release-local</url>
+      <url>https://repo.spring.io/libs-release-local</url>
     </repository>
 
     <snapshotRepository>
       <id>repo.spring.io</id>
       <name>Spring Snapshot Repository</name>
-      <url>http://repo.spring.io/libs-snapshot-local</url>
+      <url>https://repo.spring.io/libs-snapshot-local</url>
     </snapshotRepository>
 
   </distributionManagement>

--- a/samples/oauth/sparklr/pom.xml
+++ b/samples/oauth/sparklr/pom.xml
@@ -47,7 +47,7 @@
 		<repository>
 			<id>spring</id>
 			<name>Spring Framework Repository</name>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/samples/oauth/tonr/pom.xml
+++ b/samples/oauth/tonr/pom.xml
@@ -51,7 +51,7 @@
 		<repository>
 			<id>spring</id>
 			<name>Spring Framework Repository</name>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/samples/oauth2/sparklr/pom.xml
+++ b/samples/oauth2/sparklr/pom.xml
@@ -110,7 +110,7 @@
 		<repository>
 			<id>spring</id>
 			<name>Spring Framework Repository</name>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/samples/oauth2/tonr/pom.xml
+++ b/samples/oauth2/tonr/pom.xml
@@ -121,7 +121,7 @@
 		<repository>
 			<id>spring</id>
 			<name>Spring Framework Repository</name>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -19,7 +19,7 @@
     <module>oauth2/tonr</module>
   </modules>
 
-  <url>http://static.springframework.org/spring-security/oauth/samples</url>
+  <url>https://docs.spring.io/spring-security/oauth/samples</url>
 
   <build>
 	<plugins>

--- a/spring-security-jwt/mvnw
+++ b/spring-security-jwt/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-security-jwt/mvnw.cmd
+++ b/spring-security-jwt/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-security-jwt/pom.xml
+++ b/spring-security-jwt/pom.xml
@@ -13,15 +13,15 @@
 	It belongs to the family of Spring Security crypto libraries that handle encoding and decoding text as
 	a general, useful thing to be able to do.</description>
 
-	<url>http://github.com/spring-projects/spring-security-oauth</url>
+	<url>https://github.com/spring-projects/spring-security-oauth</url>
 	<organization>
 		<name>SpringSource</name>
-		<url>http://www.springsource.com</url>
+		<url>https://www.springsource.com</url>
 	</organization>
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
 
@@ -178,7 +178,7 @@
 	</profiles>
 
 	<scm>
-		<url>http://github.com/spring-projects/spring-security-oauth</url>
+		<url>https://github.com/spring-projects/spring-security-oauth</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-security-oauth.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-security-oauth.git</developerConnection>
 	</scm>

--- a/tests/annotation/common/pom.xml
+++ b/tests/annotation/common/pom.xml
@@ -57,7 +57,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -65,7 +65,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -75,7 +75,7 @@
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/tests/annotation/pom.xml
+++ b/tests/annotation/pom.xml
@@ -94,7 +94,7 @@
 		<repository>
 		  <id>spring-snapshots</id>
 		  <name>Spring Snapshots</name>
-		  <url>http://repo.spring.io/libs-snapshot-local</url>
+		  <url>https://repo.spring.io/libs-snapshot-local</url>
 		  <snapshots>
 			<enabled>true</enabled>
 		  </snapshots>
@@ -102,7 +102,7 @@
 		<repository>
 		  <id>spring-milestones</id>
 		  <name>Spring Milestones</name>
-		  <url>http://repo.spring.io/libs-milestone-local</url>
+		  <url>https://repo.spring.io/libs-milestone-local</url>
 		  <snapshots>
 			<enabled>false</enabled>
 		  </snapshots>
@@ -110,7 +110,7 @@
 		<repository>
 		  <id>spring-releases</id>
 		  <name>Spring Releases</name>
-		  <url>http://repo.spring.io/release</url>
+		  <url>https://repo.spring.io/release</url>
 		  <snapshots>
 			<enabled>false</enabled>
 		  </snapshots>
@@ -120,7 +120,7 @@
 		<pluginRepository>
 		  <id>spring-snapshots</id>
 		  <name>Spring Snapshots</name>
-		  <url>http://repo.spring.io/libs-snapshot-local</url>
+		  <url>https://repo.spring.io/libs-snapshot-local</url>
 		  <snapshots>
 			<enabled>true</enabled>
 		  </snapshots>
@@ -128,7 +128,7 @@
 		<pluginRepository>
 		  <id>spring-milestones</id>
 		  <name>Spring Milestones</name>
-		  <url>http://repo.spring.io/libs-milestone-local</url>
+		  <url>https://repo.spring.io/libs-milestone-local</url>
 		  <snapshots>
 			<enabled>false</enabled>
 		  </snapshots>

--- a/tests/xml/common/pom.xml
+++ b/tests/xml/common/pom.xml
@@ -66,7 +66,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -74,7 +74,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -84,7 +84,7 @@
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://junit.sourceforge.net/javadoc/ (200) migrated to:  
  http://junit.sourceforge.net/javadoc/ ([https](https://junit.sourceforge.net/javadoc/) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jakarta.apache.org/regexp/apidocs/ (404) migrated to:  
  https://jakarta.apache.org/regexp/apidocs/ ([https](https://jakarta.apache.org/regexp/apidocs/) result 404).
* http://logging.apache.org/log4j/docs/api/ (404) migrated to:  
  https://logging.apache.org/log4j/docs/api/ ([https](https://logging.apache.org/log4j/docs/api/) result 404).
* http://oauth.googlecode.com/svn/code/maven/ (404) migrated to:  
  https://oauth.googlecode.com/svn/code/maven/ ([https](https://oauth.googlecode.com/svn/code/maven/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://github.com/spring-projects/spring-security-oauth migrated to:  
  https://github.com/spring-projects/spring-security-oauth ([https](https://github.com/spring-projects/spring-security-oauth) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring-security/oauth (301) migrated to:  
  https://docs.spring.io/spring-security/oauth ([https](https://static.springframework.org/spring-security/oauth) result 301).
* http://static.springframework.org/spring-security/oauth/samples (301) migrated to:  
  https://docs.spring.io/spring-security/oauth/samples ([https](https://static.springframework.org/spring-security/oauth/samples) result 301).
* http://static.springframework.org/spring/docs/2.5.x/api/ (301) migrated to:  
  https://docs.spring.io/spring/docs/2.5.x/api/ ([https](https://static.springframework.org/spring/docs/2.5.x/api/) result 301).
* http://forum.springframework.org/forumdisplay.php?f=79 migrated to:  
  https://forum.springframework.org/forumdisplay.php?f=79 ([https](https://forum.springframework.org/forumdisplay.php?f=79) result 301).
* http://github.com/SpringSource/spring-security-oauth migrated to:  
  https://github.com/SpringSource/spring-security-oauth ([https](https://github.com/SpringSource/spring-security-oauth) result 301).
* http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ migrated to:  
  https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ ([https](https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/) result 301).
* http://jakarta.apache.org/commons/dbcp/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/dbcp/apidocs/ ([https](https://jakarta.apache.org/commons/dbcp/apidocs/) result 301).
* http://jakarta.apache.org/commons/fileupload/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/fileupload/apidocs/ ([https](https://jakarta.apache.org/commons/fileupload/apidocs/) result 301).
* http://jakarta.apache.org/commons/httpclient/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/httpclient/apidocs/ ([https](https://jakarta.apache.org/commons/httpclient/apidocs/) result 301).
* http://jakarta.apache.org/commons/logging/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/logging/apidocs/ ([https](https://jakarta.apache.org/commons/logging/apidocs/) result 301).
* http://jakarta.apache.org/commons/pool/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/pool/apidocs/ ([https](https://jakarta.apache.org/commons/pool/apidocs/) result 301).
* http://jakarta.apache.org/velocity/api/ migrated to:  
  https://jakarta.apache.org/velocity/api/ ([https](https://jakarta.apache.org/velocity/api/) result 301).
* http://opensource.atlassian.com/projects/spring/browse/SECOAUTH migrated to:  
  https://opensource.atlassian.com/projects/spring/browse/SECOAUTH ([https](https://opensource.atlassian.com/projects/spring/browse/SECOAUTH) result 301).
* http://www.springsource.com migrated to:  
  https://www.springsource.com ([https](https://www.springsource.com) result 301).
* http://repo.spring.io/libs-milestone-local migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-release-local migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/libs-snapshot-local migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/j2ee/1.4/docs/api
* http://java.sun.com/j2se/1.5.0/docs/api
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance