### PR TITLE
Fixed URI matching if URI has no host

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolver.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolver.java
@@ -183,15 +183,15 @@ public class DefaultRedirectResolver implements RedirectResolver {
 	/**
 	 * Check if host matches the registered value.
 	 * 
-	 * @param registered the registered host
-	 * @param requested the requested host
+	 * @param registered the registered host. Can be null.
+	 * @param requested the requested host. Can be null.
 	 * @return true if they match
 	 */
 	protected boolean hostMatches(String registered, String requested) {
 		if (matchSubdomains) {
-			return registered.equals(requested) || requested.endsWith("." + registered);
+			return isEqual(registered, requested) || (requested != null && requested.endsWith("." + registered));
 		}
-		return registered.equals(requested);
+		return isEqual(registered, requested);
 	}
 
 	/**

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolverTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolverTests.java
@@ -15,20 +15,20 @@
  */
 package org.springframework.security.oauth2.provider.endpoint;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
-import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
-import org.springframework.security.oauth2.common.exceptions.RedirectMismatchException;
-import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
+import org.springframework.security.oauth2.common.exceptions.InvalidRequestException;
+import org.springframework.security.oauth2.common.exceptions.RedirectMismatchException;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 
 /**
  * @author Dave Syer
@@ -299,6 +299,14 @@ public class DefaultRedirectResolverTests {
 		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
 		String requestedRedirect = "http://anywhere.com/?p1&p2=v2";
+		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
+	}
+	
+	@Test
+	public void testRedirectNoHost() {
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("scheme:/path"));
+		client.setRegisteredRedirectUri(redirectUris);
+		String requestedRedirect = "scheme:/path";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 }


### PR DESCRIPTION
This fixes the `NullPointerException` that is thrown if a redirect URI has no host component, as explained in #1618 . Unit test is included.