### PR TITLE
Address Bias in RandomValueStringGenerator

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/RandomValueStringGenerator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/RandomValueStringGenerator.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2011-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.springframework.security.oauth2.common.util;
 
 import java.security.SecureRandom;
@@ -11,7 +23,7 @@ import java.util.Random;
  */
 public class RandomValueStringGenerator {
 
-	private static final char[] DEFAULT_CODEC = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	private static final char[] DEFAULT_CODEC = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_"
 			.toCharArray();
 
 	private Random random = new SecureRandom();
@@ -43,7 +55,7 @@ public class RandomValueStringGenerator {
 	/**
 	 * Convert these random bytes to a verifier string. The length of the byte array can be
 	 * {@link #setLength(int) configured}. The default implementation mods the bytes to fit into the
-	 * ASCII letters 1-9, A-Z, a-z .
+	 * ASCII letters 1-9, A-Z, a-z, -_ .
 	 * 
 	 * @param verifierBytes The bytes.
 	 * @return The string.
@@ -66,11 +78,14 @@ public class RandomValueStringGenerator {
 	}
 	
 	/**
-	 * The length of string to generate.
+	 * The length of string to generate.  A length less than or equal to 0 will result in an IllegalArgumentException.
 	 * 
 	 * @param length the length to set
 	 */
 	public void setLength(int length) {
+		if(length <= 0) {
+			throw new IllegalArgumentException("Length must be greater than 0.");
+		}
 		this.length = length;
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/RandomValueStringGeneratorTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/RandomValueStringGeneratorTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.oauth2.common.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link RandomValueStringGenerator}
+ * @author Josh Kerr
+ */
+public class RandomValueStringGeneratorTests {
+
+    private RandomValueStringGenerator generator;
+
+    @Before
+    public void setup() {
+        generator = new RandomValueStringGenerator();
+    }
+
+    @Test
+    public void generate() {
+        String value = generator.generate();
+        assertNotNull(value);
+        assertEquals("Authorization code is not correct size", 6, value.length());
+    }
+
+    @Test
+    public void generate_LargeLengthOnConstructor() {
+        generator = new RandomValueStringGenerator(1024);
+        String value = generator.generate();
+        assertNotNull(value);
+        assertEquals("Authorization code is not correct size", 1024, value.length());
+    }
+
+    @Test
+    public void getAuthorizationCodeString() {
+        byte[] bytes = new byte[10];
+        new SecureRandom().nextBytes(bytes);
+        String value = generator.getAuthorizationCodeString(bytes);
+        assertNotNull(value);
+        assertEquals("Authorization code is not correct size", 10, value.length());
+    }
+
+    @Test
+    public void setLength() {
+        generator.setLength(12);
+        String value = generator.generate();
+        assertEquals("Authorization code is not correct size", 12, value.length());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setLength_NonPositiveNumber() {
+        generator.setLength(-1);
+        generator.generate();
+    }
+}


### PR DESCRIPTION
Fixes #639.

I added the URL safe characters hyphen (`-`) and underscore (`_`) as recommended.  If there are other characters that are preferred let me know.