### PR TITLE
JwkVerifyingJwtAccessTokenConverter expects "kid" header and can't work with "x5t" header

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/EllipticCurveJwkDefinition.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/EllipticCurveJwkDefinition.java
@@ -32,6 +32,7 @@ final class EllipticCurveJwkDefinition extends JwkDefinition {
 	 * Creates an instance of an Elliptic Curve JSON Web Key (JWK).
 	 *
 	 * @param keyId        the Key ID
+	 * @param x5t the X.509 Certificate SHA-1 Thumbprint (&quot;x5t&quot;)
 	 * @param publicKeyUse the intended use of the Public Key
 	 * @param algorithm    the algorithm intended to be used
 	 * @param x            the x value to be used
@@ -39,12 +40,13 @@ final class EllipticCurveJwkDefinition extends JwkDefinition {
 	 * @param curve        the curve to be used
 	 */
 	EllipticCurveJwkDefinition(String keyId,
+							   String x5t,
 							   PublicKeyUse publicKeyUse,
 							   CryptoAlgorithm algorithm,
 							   String x,
 							   String y,
 							   String curve) {
-		super(keyId, KeyType.EC, publicKeyUse, algorithm);
+		super(keyId, x5t, KeyType.EC, publicKeyUse, algorithm);
 		this.x = x;
 		this.y = y;
 		this.curve = curve;

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkAttributes.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkAttributes.java
@@ -29,6 +29,11 @@ final class JwkAttributes {
 	static final String KEY_ID = "kid";
 
 	/**
+	 * The &quot;x5t&quot; (X.509 Certificate SHA-1 Thumbprint) parameter used in a JWT header and in a JWK.
+	 */
+	static final String X5T = "x5t";
+
+	/**
 	 * The &quot;kty&quot; (key type) parameter identifies the cryptographic algorithm family
 	 * used by a JWK, for example, &quot;RSA&quot; or &quot;EC&quot;.
 	 */

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinition.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinition.java
@@ -25,6 +25,7 @@ package org.springframework.security.oauth2.provider.token.store.jwk;
  */
 abstract class JwkDefinition {
 	private final String keyId;
+	private final String x5t;
 	private final KeyType keyType;
 	private final PublicKeyUse publicKeyUse;
 	private final CryptoAlgorithm algorithm;
@@ -33,15 +34,18 @@ abstract class JwkDefinition {
 	 * Creates an instance with the common attributes of a JWK.
 	 *
 	 * @param keyId the Key ID
+	 * @param x5t the X.509 Certificate SHA-1 Thumbprint (&quot;x5t&quot;)
 	 * @param keyType the Key Type
 	 * @param publicKeyUse the intended use of the Public Key
 	 * @param algorithm the algorithm intended to be used
 	 */
 	protected JwkDefinition(String keyId,
+							String x5t,
 							KeyType keyType,
 							PublicKeyUse publicKeyUse,
 							CryptoAlgorithm algorithm) {
 		this.keyId = keyId;
+		this.x5t = x5t;
 		this.keyType = keyType;
 		this.publicKeyUse = publicKeyUse;
 		this.algorithm = algorithm;
@@ -52,6 +56,13 @@ abstract class JwkDefinition {
 	 */
 	String getKeyId() {
 		return this.keyId;
+	}
+
+	/**
+	 * @return the  X.509 Certificate SHA-1 Thumbprint (&quot;x5t&quot;)
+	 */
+	String getX5t() {
+		return this.x5t;
 	}
 
 	/**
@@ -89,6 +100,12 @@ abstract class JwkDefinition {
 		if (!this.getKeyId().equals(that.getKeyId())) {
 			return false;
 		}
+		if (this.getX5t() == null) {
+			if (that.getX5t() != null)
+				return false;
+		}
+		else if (!this.getX5t().equals(that.getX5t()))
+			return false;
 
 		return this.getKeyType().equals(that.getKeyType());
 	}
@@ -97,6 +114,7 @@ abstract class JwkDefinition {
 	public int hashCode() {
 		int result = this.getKeyId().hashCode();
 		result = 31 * result + this.getKeyType().hashCode();
+		result = 31 * result + ((this.getX5t() == null) ? 0 : this.getX5t().hashCode());
 		return result;
 	}
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
@@ -30,6 +30,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Joe Grandja
  * @author Michael Duergner
+ * @author Bjoern Eickvonder
  */
 class JwkDefinitionSource {
 	private final List<URL> jwkSetUrls;
@@ -79,20 +81,21 @@ class JwkDefinitionSource {
 	}
 
 	/**
-	 * Returns the JWK definition matching the provided keyId (&quot;kid&quot;).
+	 * Returns the JWK definition matching the provided keyId (&quot;kid&quot;) or provided thumbprint (&quot;x5t&quot;).
 	 * If the JWK definition is not available in the internal cache then {@link #loadJwkDefinitions(URL)}
 	 * will be called (to re-load the cache) and then followed-up with a second attempt to locate the JWK definition.
 	 *
-	 * @param keyId the Key ID (&quot;kid&quot;)
+	 * @param keyId the Key ID (&quot;kid&quot;), if not given x5t will be checked
+	 * @param x5t the X.509 Certificate SHA-1 Thumbprint (&quot;x5t&quot;), will only be checked if keyId is not given
 	 * @return the matching {@link JwkDefinition} or null if not found
 	 */
-	JwkDefinitionHolder getDefinitionLoadIfNecessary(String keyId) {
-		JwkDefinitionHolder result = this.getDefinition(keyId);
+	JwkDefinitionHolder getDefinitionLoadIfNecessary(String keyId, String x5t) {
+		JwkDefinitionHolder result = this.getDefinition(keyId, x5t);
 		if (result != null) {
 			return result;
 		}
 		synchronized (this.jwkDefinitions) {
-			result = this.getDefinition(keyId);
+			result = this.getDefinition(keyId, x5t);
 			if (result != null) {
 				return result;
 			}
@@ -100,18 +103,32 @@ class JwkDefinitionSource {
 			for (URL jwkSetUrl : jwkSetUrls) {
 				this.jwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
 			}
-			return this.getDefinition(keyId);
+			return this.getDefinition(keyId, x5t);
 		}
 	}
 
 	/**
 	 * Returns the JWK definition matching the provided keyId (&quot;kid&quot;).
 	 *
-	 * @param keyId the Key ID (&quot;kid&quot;)
+	 * @param keyId the Key ID (&quot;kid&quot;), if not given x5t will be checked
+	 * @param x5t the X.509 Certificate SHA-1 Thumbprint (&quot;x5t&quot;), will only be checked if keyId is not given
 	 * @return the matching {@link JwkDefinition} or null if not found
 	 */
-	private JwkDefinitionHolder getDefinition(String keyId) {
-		return this.jwkDefinitions.get(keyId);
+	private JwkDefinitionHolder getDefinition(String keyId, String x5t) {
+		JwkDefinitionHolder result = null;
+		if (keyId != null) {
+			result = this.jwkDefinitions.get(keyId);
+		}
+		else if (x5t != null) {
+			Iterator<JwkDefinitionHolder> iter = this.jwkDefinitions.values().iterator();
+			while (result == null && iter.hasNext()) {
+				JwkDefinitionHolder entry = iter.next();
+				if (x5t.equals(entry.getJwkDefinition().getX5t())) {
+					result = entry;
+				}
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverter.java
@@ -101,7 +101,7 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 				if (JwkDefinition.PublicKeyUse.ENC.equals(publicKeyUse)) {
 					continue;
 				}
-			
+
 				JwkDefinition jwkDefinition = null;
 				JwkDefinition.KeyType keyType =
 						JwkDefinition.KeyType.fromValue(attributes.get(KEY_TYPE));
@@ -142,6 +142,7 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 		if (!StringUtils.hasText(keyId)) {
 			throw new JwkException(KEY_ID + " is a required attribute for a JWK.");
 		}
+		String x5t = attributes.get(X5T);
 
 		// use
 		JwkDefinition.PublicKeyUse publicKeyUse =
@@ -174,7 +175,7 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 		}
 
 		RsaJwkDefinition jwkDefinition = new RsaJwkDefinition(
-				keyId, publicKeyUse, algorithm, modulus, exponent);
+				keyId, x5t, publicKeyUse, algorithm, modulus, exponent);
 
 		return jwkDefinition;
 	}
@@ -192,6 +193,7 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 		if (!StringUtils.hasText(keyId)) {
 			throw new JwkException(KEY_ID + " is a required attribute for an EC JWK.");
 		}
+		String x5t = attributes.get(X5T);
 
 		// use
 		JwkDefinition.PublicKeyUse publicKeyUse =
@@ -230,7 +232,7 @@ class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition>> {
 		}
 
 		EllipticCurveJwkDefinition jwkDefinition = new EllipticCurveJwkDefinition(
-				keyId, publicKeyUse, algorithm, x, y, curve);
+				keyId, x5t, publicKeyUse, algorithm, x, y, curve);
 
 		return jwkDefinition;
 	}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/RsaJwkDefinition.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/RsaJwkDefinition.java
@@ -31,18 +31,19 @@ final class RsaJwkDefinition extends JwkDefinition {
 	 * Creates an instance of a RSA JSON Web Key (JWK).
 	 *
 	 * @param keyId the Key ID
+	 * @param x5t the X.509 Certificate SHA-1 Thumbprint (&quot;x5t&quot;)	 *
 	 * @param publicKeyUse the intended use of the Public Key
 	 * @param algorithm the algorithm intended to be used
 	 * @param modulus the modulus value for the Public Key
 	 * @param exponent the exponent value for the Public Key
 	 */
 	RsaJwkDefinition(String keyId,
+					 String x5t,
 					 PublicKeyUse publicKeyUse,
 					 CryptoAlgorithm algorithm,
 					 String modulus,
 					 String exponent) {
-
-		super(keyId, KeyType.RSA, publicKeyUse, algorithm);
+		super(keyId, x5t, KeyType.RSA, publicKeyUse, algorithm);
 		this.modulus = modulus;
 		this.exponent = exponent;
 	}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSourceITests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSourceITests.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Rob Winch
  */
-public class JwkDefinitionSourceITest {
+public class JwkDefinitionSourceITests {
 
 	private MockWebServer server;
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSourceTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSourceTests.java
@@ -57,7 +57,7 @@ public class JwkDefinitionSourceTests {
 		JwkDefinitionSource jwkDefinitionSource = spy(new JwkDefinitionSource(DEFAULT_JWK_SET_URL));
 		mockStatic(JwkDefinitionSource.class);
 		when(JwkDefinitionSource.loadJwkDefinitions(any(URL.class))).thenReturn(Collections.<String, JwkDefinitionSource.JwkDefinitionHolder>emptyMap());
-		jwkDefinitionSource.getDefinitionLoadIfNecessary("invalid-key-id");
+		jwkDefinitionSource.getDefinitionLoadIfNecessary("invalid-key-id", null);
 		verifyStatic();
 	}
 
@@ -66,7 +66,7 @@ public class JwkDefinitionSourceTests {
 	public void getVerifierWhenModulusMostSignificantBitIs1ThenVerifierStillVerifyContentSignature() throws Exception {
 		String jwkSetUrl = JwkDefinitionSourceTests.class.getResource("jwk-set.json").toString();
 		JwkDefinitionSource jwkDefinitionSource = new JwkDefinitionSource(jwkSetUrl);
-		SignatureVerifier verifier = jwkDefinitionSource.getDefinitionLoadIfNecessary("_Ci3-VfV_N0YAG22NQOgOUpFBDDcDe_rJxpu5JK702o").getSignatureVerifier();
+		SignatureVerifier verifier = jwkDefinitionSource.getDefinitionLoadIfNecessary("_Ci3-VfV_N0YAG22NQOgOUpFBDDcDe_rJxpu5JK702o", null).getSignatureVerifier();
 		String token = this.readToken("token.jwt");
 		int secondPeriodIndex = token.indexOf('.', token.indexOf('.') + 1);
 		String contentString = token.substring(0, secondPeriodIndex);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSourceTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSourceTests.java
@@ -39,7 +39,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JwkDefinitionSource.class)
-public class JwkDefinitionSourceTest {
+public class JwkDefinitionSourceTests {
 	private static final String DEFAULT_JWK_SET_URL = "https://identity.server1.io/token_keys";
 
 	@Test(expected = IllegalArgumentException.class)
@@ -64,7 +64,7 @@ public class JwkDefinitionSourceTest {
 	// gh-1010
 	@Test
 	public void getVerifierWhenModulusMostSignificantBitIs1ThenVerifierStillVerifyContentSignature() throws Exception {
-		String jwkSetUrl = JwkDefinitionSourceTest.class.getResource("jwk-set.json").toString();
+		String jwkSetUrl = JwkDefinitionSourceTests.class.getResource("jwk-set.json").toString();
 		JwkDefinitionSource jwkDefinitionSource = new JwkDefinitionSource(jwkSetUrl);
 		SignatureVerifier verifier = jwkDefinitionSource.getDefinitionLoadIfNecessary("_Ci3-VfV_N0YAG22NQOgOUpFBDDcDe_rJxpu5JK702o").getSignatureVerifier();
 		String token = this.readToken("token.jwt");
@@ -80,7 +80,7 @@ public class JwkDefinitionSourceTest {
 		StringBuilder sb = new StringBuilder();
 		InputStream in = null;
 		try {
-			in = JwkDefinitionSourceTest.class.getResourceAsStream(resource);
+			in = JwkDefinitionSourceTests.class.getResourceAsStream(resource);
 			int ch;
 			while ((ch = in.read()) != -1) {
 				sb.append((char) ch);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionTests.java
@@ -27,13 +27,15 @@ public class JwkDefinitionTests {
 	@Test
 	public void constructorWhenArgumentsPassedThenAttributesAreCorrectlySet() throws Exception {
 		String keyId = "key-id-1";
+		String x5t = "x5t-1";
 		JwkDefinition.KeyType keyType = JwkDefinition.KeyType.RSA;
 		JwkDefinition.PublicKeyUse publicKeyUse = JwkDefinition.PublicKeyUse.SIG;
 		JwkDefinition.CryptoAlgorithm algorithm = JwkDefinition.CryptoAlgorithm.RS512;
 
-		JwkDefinition jwkDefinition = new JwkDefinition(keyId, keyType, publicKeyUse, algorithm) { };
+		JwkDefinition jwkDefinition = new JwkDefinition(keyId, x5t, keyType, publicKeyUse, algorithm) { };
 
 		assertEquals(keyId, jwkDefinition.getKeyId());
+		assertEquals(x5t, jwkDefinition.getX5t());
 		assertEquals(keyType, jwkDefinition.getKeyType());
 		assertEquals(publicKeyUse, jwkDefinition.getPublicKeyUse());
 		assertEquals(algorithm, jwkDefinition.getAlgorithm());

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionTests.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Joe Grandja
  */
-public class JwkDefinitionTest {
+public class JwkDefinitionTests {
 
 	@Test
 	public void constructorWhenArgumentsPassedThenAttributesAreCorrectlySet() throws Exception {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkSetConverterTests.java
@@ -36,7 +36,7 @@ import static org.springframework.security.oauth2.provider.token.store.jwk.JwkAt
  * @author Joe Grandja
  * @author Vedran Pavic
  */
-public class JwkSetConverterTest {
+public class JwkSetConverterTests {
 	private final JwkSetConverter converter = new JwkSetConverter();
 	private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkTokenStoreITests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkTokenStoreITests.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Joe Grandja
  */
-public class JwkTokenStoreITest {
+public class JwkTokenStoreITests {
 	private MockWebServer server;
 
 	@Before

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkTokenStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkTokenStoreTests.java
@@ -48,7 +48,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(JwkTokenStore.class)
-public class JwkTokenStoreTest {
+public class JwkTokenStoreTests {
 	private JwkTokenStore jwkTokenStore = new JwkTokenStore("https://identity.server1.io/token_keys");
 
 	@Rule

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkTokenStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkTokenStoreTests.java
@@ -129,7 +129,7 @@ public class JwkTokenStoreTests {
 		when(jwkDefinitionHolder.getSignatureVerifier()).thenReturn(mock(SignatureVerifier.class));
 
 		JwkDefinitionSource jwkDefinitionSource = mock(JwkDefinitionSource.class);
-		when(jwkDefinitionSource.getDefinitionLoadIfNecessary(anyString())).thenReturn(jwkDefinitionHolder);
+		when(jwkDefinitionSource.getDefinitionLoadIfNecessary(anyString(), anyString())).thenReturn(jwkDefinitionHolder);
 
 		JwkVerifyingJwtAccessTokenConverter jwtVerifyingAccessTokenConverter =
 				new JwkVerifyingJwtAccessTokenConverter(jwkDefinitionSource);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkVerifyingJwtAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkVerifyingJwtAccessTokenConverterTests.java
@@ -34,7 +34,7 @@ import static org.springframework.security.oauth2.provider.token.store.jwk.JwtTe
 /**
  * @author Joe Grandja
  */
-public class JwkVerifyingJwtAccessTokenConverterTest {
+public class JwkVerifyingJwtAccessTokenConverterTests {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkVerifyingJwtAccessTokenConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkVerifyingJwtAccessTokenConverterTests.java
@@ -134,6 +134,6 @@ public class JwkVerifyingJwtAccessTokenConverterTests {
 												String modulus,
 												String exponent) {
 
-		return new RsaJwkDefinition(keyId, publicKeyUse, algorithm, modulus, exponent);
+		return new RsaJwkDefinition(keyId, null, publicKeyUse, algorithm, modulus, exponent);
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtHeaderConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtHeaderConverterTests.java
@@ -32,7 +32,7 @@ import static org.springframework.security.oauth2.provider.token.store.jwk.JwtTe
  * @author Joe Grandja
  * @author Vedran Pavic
  */
-public class JwtHeaderConverterTest {
+public class JwtHeaderConverterTests {
 	private final JwtHeaderConverter converter = new JwtHeaderConverter();
 
 	@Rule

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtTestUtil.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/JwtTestUtil.java
@@ -44,13 +44,16 @@ class JwtTestUtil {
 	}
 
 	static byte[] createDefaultJwtHeader() throws Exception {
-		return createJwtHeader("key-id-1", JwkDefinition.CryptoAlgorithm.RS256);
+		return createJwtHeader("key-id-1", null, JwkDefinition.CryptoAlgorithm.RS256);
 	}
 
-	static byte[] createJwtHeader(String keyId, JwkDefinition.CryptoAlgorithm algorithm) throws Exception {
+	static byte[] createJwtHeader(String keyId, String x5t, JwkDefinition.CryptoAlgorithm algorithm) throws Exception {
 		Map<String, Object> jwtHeader = new HashMap<String, Object>();
 		if (keyId != null) {
 			jwtHeader.put(JwkAttributes.KEY_ID, keyId);
+		}
+		if (x5t != null) {
+			jwtHeader.put(JwkAttributes.X5T, x5t);
 		}
 		if (algorithm != null) {
 			jwtHeader.put(JwkAttributes.ALGORITHM, algorithm.headerParamValue());

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/RsaJwkDefinitionTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/RsaJwkDefinitionTests.java
@@ -27,15 +27,17 @@ public class RsaJwkDefinitionTests {
 	@Test
 	public void constructorWhenArgumentsPassedThenAttributesAreCorrectlySet() throws Exception {
 		String keyId = "key-id-1";
+		String x5t = "x5t-1";
 		JwkDefinition.PublicKeyUse publicKeyUse = JwkDefinition.PublicKeyUse.ENC;
 		JwkDefinition.CryptoAlgorithm algorithm = JwkDefinition.CryptoAlgorithm.RS384;
 		String modulus = "AMh-pGAj9vX2gwFDyrXot1f2YfHgh8h0Qx6w9IqLL";
 		String exponent = "AQAB";
 
 		RsaJwkDefinition rsaJwkDefinition = new RsaJwkDefinition(
-				keyId, publicKeyUse, algorithm, modulus, exponent);
+				keyId, x5t, publicKeyUse, algorithm, modulus, exponent);
 
 		assertEquals(keyId, rsaJwkDefinition.getKeyId());
+		assertEquals(x5t, rsaJwkDefinition.getX5t());
 		assertEquals(JwkDefinition.KeyType.RSA, rsaJwkDefinition.getKeyType());
 		assertEquals(publicKeyUse, rsaJwkDefinition.getPublicKeyUse());
 		assertEquals(algorithm, rsaJwkDefinition.getAlgorithm());

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/RsaJwkDefinitionTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/jwk/RsaJwkDefinitionTests.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Joe Grandja
  */
-public class RsaJwkDefinitionTest {
+public class RsaJwkDefinitionTests {
 
 	@Test
 	public void constructorWhenArgumentsPassedThenAttributesAreCorrectlySet() throws Exception {


### PR DESCRIPTION
This pull request solves the issue #1617 by adding x5t parameter to the JwkDefinition and allowing a x5t header to be matched if kid header is missing which is the case in our environment where the identity server is backed by an ADFS which does not provide a kid header in the token header.

Additionally this pull request renames the JWK test cases (from *Test to *Tests) such that they are executed by Maven build.

