### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.md
+++ b/README.md
@@ -54,22 +54,22 @@ Lists of issues addressed per release can be found in [github](https://github.co
 
 ## Additional Resources
 
-* [Spring Security OAuth User Guide](http://projects.spring.io/spring-security-oauth/docs/Home.html)
-* [Spring Security OAuth Source](http://github.com/spring-projects/spring-security-oauth)
-* [Stackoverflow](http://stackoverflow.com/questions/tagged/spring-security+spring+oauth)
+* [Spring Security OAuth User Guide](https://projects.spring.io/spring-security-oauth/docs/Home.html)
+* [Spring Security OAuth Source](https://github.com/spring-projects/spring-security-oauth)
+* [Stackoverflow](https://stackoverflow.com/questions/tagged/spring-security+spring+oauth)
 
 # Contributing to Spring Security OAuth
 
 Here are some ways for you to get involved in the community:
 
 * Get involved with the Spring community on the Spring Community Forums.  Please help out on the
-  [forum](http://forum.springsource.org/forumdisplay.php?f=79) by responding to questions and joining the debate.
+  [forum](https://forum.spring.io/forumdisplay.php?f=79) by responding to questions and joining the debate.
 * Create [github issues](https://github.com/spring-projects/spring-security-oauth/issues) for bugs and new features and comment and
   vote on the ones that you are interested in.
 * Github is for social coding: if you want to write code, we encourage contributions through pull requests from
-  [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please
+  [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please
   reference a github issue as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the
 [contributor's agreement](https://support.springsource.com/spring_committer_signup).

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -7,9 +7,9 @@ home: ../
 
 # Welcome
 
-OAuth for Spring Security provides an [OAuth](http://oauth.net)
+OAuth for Spring Security provides an [OAuth](https://oauth.net)
 implementation for
-[Spring Security](http://projects.spring.io/spring-security/).
+[Spring Security](https://projects.spring.io/spring-security/).
 Support is provided for the implementation of OAuth providers and
 OAuth consumers. There is support for [Oauth 1(a)](oauth1.html) (including
 [two-legged OAuth](twolegged.html), a.k.a. "Signed Fetch") and for
@@ -17,11 +17,11 @@ OAuth consumers. There is support for [Oauth 1(a)](oauth1.html) (including
 
 Applying security to an application is not for the faint of heart, and OAuth is no exception. Before you get started,
 you're going to want to make sure you understand OAuth and the problem it's designed to address. There is good
-documentation at [the OAuth site](http://oauth.net). You will also want to make sure you understand how 
-[Spring](http://springframework.org/) and [Spring Security](http://projects.spring.io/spring-security/) work.
+documentation at [the OAuth site](https://oauth.net). You will also want to make sure you understand how 
+[Spring](https://springframework.org/) and [Spring Security](https://projects.spring.io/spring-security/) work.
 
-You're going to want to be quite familiar with both [OAuth](http://oauth.net) (and/or [OAuth2](http://tools.ietf.org/html/draft-ietf-oauth-v2))
-and [Spring Security](http://projects.spring.io/spring-security/), to maximize the effectiveness of this developers guide. OAuth for
+You're going to want to be quite familiar with both [OAuth](https://oauth.net) (and/or [OAuth2](https://tools.ietf.org/html/draft-ietf-oauth-v2))
+and [Spring Security](https://projects.spring.io/spring-security/), to maximize the effectiveness of this developers guide. OAuth for
 Spring Security is tightly tied to both technologies, so the more familiar you are with them, the more likely you'll be to recognize the terminology
 and patterns that are used.
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -10,9 +10,9 @@ home: ../
 ## Preparation
 
 You're going to want to be quite familiar with
-[OAuth2](http://tools.ietf.org/html/draft-ietf-oauth-v2) (and/or
-[OAuth](http://oauth.net) ) and
-[Spring Security](http://projects.spring.io/spring-security/),
+[OAuth2](https://tools.ietf.org/html/draft-ietf-oauth-v2) (and/or
+[OAuth](https://oauth.net) ) and
+[Spring Security](https://projects.spring.io/spring-security/),
 to maximize the effectiveness of this developers guide. OAuth for
 Spring Security is tightly tied to both technologies, so the more
 familiar you are with them, the more likely you'll be to recognize the

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -19,7 +19,7 @@ Full releases go in Maven [central], and in the SpringSource repository but mile
     <repository>
         <id>spring-milestone</id>
         <name>Spring Maven MILESTONE Repository</name>
-        <url>http://maven.springframework.org/milestone</url>
+        <url>https://maven.springframework.org/milestone</url>
     </repository>
 
 and for snapshots:
@@ -27,9 +27,9 @@ and for snapshots:
     <repository>
         <id>spring-snnapshot</id>
         <name>Spring Maven SNAPSHOT Repository</name>
-        <url>http://maven.springframework.org/snapshot</url>
+        <url>https://maven.springframework.org/snapshot</url>
     </repository>
 
-[mavenrepo]: http://shrub.appspot.com/maven.springframework.org/release/org/springframework/security/oauth/spring-security-oauth/
-[central]: http://repo1.maven.org/maven2/org/springframework/security/oauth/spring-security-oauth/
+[mavenrepo]: https://shrub.appspot.com/maven.springframework.org/release/org/springframework/security/oauth/spring-security-oauth/
+[central]: https://repo1.maven.org/maven2/org/springframework/security/oauth/spring-security-oauth/
 [Github]: https://github.com/spring-projects/spring-security-oauth

--- a/docs/oauth1.md
+++ b/docs/oauth1.md
@@ -96,7 +96,7 @@ Spring Security authentication manager.
 ### Provider Configuration
 
 For the OAuth 1.0 provider, configuration is simplified using the custom spring configuration elements. The schema for these elements rests at
-[http://www.springframework.org/schema/security/spring-security-oauth.xsd][oauth1.xsd]. The namespace is `http://www.springframework.org/schema/security/oauth`.
+[https://www.springframework.org/schema/security/spring-security-oauth.xsd][oauth1.xsd]. The namespace is `http://www.springframework.org/schema/security/oauth`.
 
 The following configuration elements are used to supply provider configuration:
 
@@ -144,7 +144,7 @@ It supports an `id` attribute (bean id) and a `verifierLengthBytes` attribute th
 
 ### Configuring An OAuth-Aware Expression Handler
 
-You may want to take advantage of Spring Security's [expression-based access control](http://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html).
+You may want to take advantage of Spring Security's [expression-based access control](https://docs.spring.io/spring-security/site/docs/3.0.x/reference/el-access.html).
 You can register a oauth-aware expression handler with the `expression-handler` element. Use the id of the oauth expression handler to add oauth-aware
 expressions to the built-in expressions.
 
@@ -196,7 +196,7 @@ RestTemplate (new in Spring 3), but is supplied with a specific `ProtectedResour
 ### Consumer Configuration
 
 For the OAuth 1.0 consumer, configuration is simplified using the custom spring configuration elements. The schema for these elements rests at
-[http://www.springframework.org/schema/security/spring-security-oauth.xsd][oauth1.xsd].
+[https://www.springframework.org/schema/security/spring-security-oauth.xsd][oauth1.xsd].
 The namespace is `http://www.springframework.org/schema/security/oauth`.
 
 Two custom configuration elements are used to supply provider configuration:
@@ -267,33 +267,33 @@ wanted to replace it you could override the bean definition:
      
 In this example, the explicit bean definition overrides the one created by the `<provider/>` because of the ordering in the application context declaration (this is a standard Spring bean factory feature). Bean definitions created by the namespace parsers follow the convention that they start with "oauth" and generally they are the class name of the default implementation provided by the framework.
 
-[ConsumerDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html
-[ConsumerDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html
-[InMemoryConsumerDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/InMemoryConsumerDetailsService.html
-[BaseConsumerDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/BaseConsumerDetails.html
-[OAuthProviderTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/OAuthProviderTokenServices.html
-[RandomValueProviderTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/RandomValueProviderTokenServices.html
-[InMemoryProviderTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/InMemoryProviderTokenServices.html
-[UnauthenticatedRequestTokenProcessingFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UnauthenticatedRequestTokenProcessingFilter.html
-[UserAuthorizationProcessingFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UserAuthorizationProcessingFilter.html
-[AccessTokenProcessingFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/AccessTokenProcessingFilter.html
-[ProtectedResourceProcessingFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ProtectedResourceProcessingFilter.html
-[OAuthNonceServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/OAuthNonceServices.html
-[ExpiringTimestampNonceServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/ExpiringTimestampNonceServices.html
-[InMemoryNonceServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/InMemoryNonceServices.html
-[OAuthCallbackServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/OAuthCallbackServices.html
-[InMemoryCallbackServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/InMemoryCallbackServices.html
-[OAuthVerifierServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/OAuthVerifierServices.html
-[RandomValueInMemoryVerifierServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/RandomValueInMemoryVerifierServices.html
-[attributes-package]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/package-summary.html
-[ConsumerSecurityConfig]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityConfig.html
-[ConsumerSecurityVoter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityVoter.html
-[ProtectedResourceDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/ProtectedResourceDetailsService.html
-[InMemoryProtectedResourceDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/InMemoryProtectedResourceDetailsService.html
-[BaseProtectedResourceDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/BaseProtectedResourceDetails.html
-[OAuthConsumerTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/OAuthConsumerTokenServices.html
-[HttpSessionBasedTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.html
-[OAuthConsumerContextFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerContextFilter.html
-[OAuthConsumerProcessingFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerProcessingFilter.html
-[OAuthRestTemplate]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthRestTemplate.html
-[oauth1.xsd]: http://www.springframework.org/schema/security/spring-security-oauth.xsd "oauth1.xsd"
+[ConsumerDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html
+[ConsumerDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html
+[InMemoryConsumerDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/InMemoryConsumerDetailsService.html
+[BaseConsumerDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/BaseConsumerDetails.html
+[OAuthProviderTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/OAuthProviderTokenServices.html
+[RandomValueProviderTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/RandomValueProviderTokenServices.html
+[InMemoryProviderTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/InMemoryProviderTokenServices.html
+[UnauthenticatedRequestTokenProcessingFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UnauthenticatedRequestTokenProcessingFilter.html
+[UserAuthorizationProcessingFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UserAuthorizationProcessingFilter.html
+[AccessTokenProcessingFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/AccessTokenProcessingFilter.html
+[ProtectedResourceProcessingFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ProtectedResourceProcessingFilter.html
+[OAuthNonceServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/OAuthNonceServices.html
+[ExpiringTimestampNonceServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/ExpiringTimestampNonceServices.html
+[InMemoryNonceServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/InMemoryNonceServices.html
+[OAuthCallbackServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/OAuthCallbackServices.html
+[InMemoryCallbackServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/InMemoryCallbackServices.html
+[OAuthVerifierServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/OAuthVerifierServices.html
+[RandomValueInMemoryVerifierServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/RandomValueInMemoryVerifierServices.html
+[attributes-package]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/package-summary.html
+[ConsumerSecurityConfig]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityConfig.html
+[ConsumerSecurityVoter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityVoter.html
+[ProtectedResourceDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/ProtectedResourceDetailsService.html
+[InMemoryProtectedResourceDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/InMemoryProtectedResourceDetailsService.html
+[BaseProtectedResourceDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/BaseProtectedResourceDetails.html
+[OAuthConsumerTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/OAuthConsumerTokenServices.html
+[HttpSessionBasedTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.html
+[OAuthConsumerContextFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerContextFilter.html
+[OAuthConsumerProcessingFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerProcessingFilter.html
+[OAuthRestTemplate]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthRestTemplate.html
+[oauth1.xsd]: https://www.springframework.org/schema/security/spring-security-oauth.xsd "oauth1.xsd"

--- a/docs/oauth2.md
+++ b/docs/oauth2.md
@@ -9,7 +9,7 @@ home: ../
 
 ## Introduction
 
-This is the user guide for the support for [`OAuth 2.0`](http://tools.ietf.org/html/draft-ietf-oauth-v2). For OAuth 1.0, everything is different, so [see its user guide](oauth1.html).
+This is the user guide for the support for [`OAuth 2.0`](https://tools.ietf.org/html/draft-ietf-oauth-v2). For OAuth 1.0, everything is different, so [see its user guide](oauth1.html).
 
 This user guide is divided into two parts, the first for the OAuth 2.0 provider, the second for the OAuth 2.0 client. For both the provider and the client, the best source of sample code is the [integration tests](https://github.com/spring-projects/spring-security-oauth/tree/master/tests) and [sample apps](https://github.com/spring-projects/spring-security-oauth/tree/master/samples/oauth2).
 
@@ -28,7 +28,7 @@ The following filter is required to implement an OAuth 2.0 Resource Server:
 
 * The [`OAuth2AuthenticationProcessingFilter`][OAuth2AuthenticationProcessingFilter] is used to load the Authentication for the request given an authenticated access token.
 
-For all the OAuth 2.0 provider features, configuration is simplified using special Spring OAuth `@Configuration` adapters.  There is also an XML namespace for OAuth configuration, and the schema resides at [http://www.springframework.org/schema/security/spring-security-oauth2.xsd][oauth2.xsd]. The namespace is `http://www.springframework.org/schema/security/oauth2`.
+For all the OAuth 2.0 provider features, configuration is simplified using special Spring OAuth `@Configuration` adapters.  There is also an XML namespace for OAuth configuration, and the schema resides at [https://www.springframework.org/schema/security/spring-security-oauth2.xsd][oauth2.xsd]. The namespace is `http://www.springframework.org/schema/security/oauth2`.
 
 ## Authorization Server Configuration
 
@@ -270,22 +270,22 @@ To use Facebook as an example, there is a Facebook feature in the `tonr2` applic
 
 Facebook token responses also contain a non-compliant JSON entry for the expiry time of the token (they use `expires` instead of `expires_in`), so if you want to use the expiry time in your application you will have to decode it manually using a custom `OAuth2SerializationService`.
 
-  [AuthorizationEndpoint]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.html "AuthorizationEndpoint"
-  [TokenEndpoint]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.html "TokenEndpoint"
-  [DefaultTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/DefaultTokenServices.html "DefaultTokenServices"
-  [InMemoryTokenStore]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/InMemoryTokenStore.html "InMemoryTokenStore"
-  [JdbcTokenStore]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.html "JdbcTokenStore"
-  [ClientDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetailsService.html "ClientDetailsService"
-  [ClientDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetails.html "ClientDetails"
-  [InMemoryClientDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/InMemoryClientDetailsService.html "InMemoryClientDetailsService"
-  [BaseClientDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/BaseClientDetails.html "BaseClientDetails"
-  [AuthorizationServerTokenServices]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/AuthorizationServerTokenServices.html "AuthorizationServerTokenServices"
-  [OAuth2AuthenticationProcessingFilter]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationProcessingFilter.html "OAuth2AuthenticationProcessingFilter"
-  [oauth2.xsd]: http://www.springframework.org/schema/security/spring-security-oauth2.xsd "oauth2.xsd"
-  [expressions]: http://docs.spring.io/spring-security/site/docs/3.2.5.RELEASE/reference/htmlsingle/#el-access "Expression Access Control"
+  [AuthorizationEndpoint]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.html "AuthorizationEndpoint"
+  [TokenEndpoint]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.html "TokenEndpoint"
+  [DefaultTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/DefaultTokenServices.html "DefaultTokenServices"
+  [InMemoryTokenStore]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/InMemoryTokenStore.html "InMemoryTokenStore"
+  [JdbcTokenStore]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.html "JdbcTokenStore"
+  [ClientDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetailsService.html "ClientDetailsService"
+  [ClientDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetails.html "ClientDetails"
+  [InMemoryClientDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/InMemoryClientDetailsService.html "InMemoryClientDetailsService"
+  [BaseClientDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/BaseClientDetails.html "BaseClientDetails"
+  [AuthorizationServerTokenServices]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/AuthorizationServerTokenServices.html "AuthorizationServerTokenServices"
+  [OAuth2AuthenticationProcessingFilter]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationProcessingFilter.html "OAuth2AuthenticationProcessingFilter"
+  [oauth2.xsd]: https://www.springframework.org/schema/security/spring-security-oauth2.xsd "oauth2.xsd"
+  [expressions]: https://docs.spring.io/spring-security/site/docs/3.2.5.RELEASE/reference/htmlsingle/#el-access "Expression Access Control"
 
   [AccessTokenProviderChain]: /spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChain.java
   [OAuth2RestTemplate]: /spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/OAuth2RestTemplate.java
   [OAuth2ProtectedResourceDetails]: /spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/resource/OAuth2ProtectedResourceDetails.java
-  [restTemplate]: http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html "RestTemplate"
-  [Facebook]: http://developers.facebook.com/docs/authentication "Facebook"
+  [restTemplate]: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html "RestTemplate"
+  [Facebook]: https://developers.facebook.com/docs/authentication "Facebook"

--- a/docs/support.md
+++ b/docs/support.md
@@ -8,13 +8,13 @@ home: ../
 # Support
 
 Questions about OAuth for Spring Security can be posed on
-[Stackoverflow](http://stackoverflow.com/questions/tagged/spring-security+spring+oauth)
+[Stackoverflow](https://stackoverflow.com/questions/tagged/spring-security+spring+oauth)
 using tags 'spring', 'spring-security' and 'oauth'. (There is also a
-[Spring Forum](http://forum.springsource.org/forumdisplay.php?f=79)
+[Spring Forum](https://forum.spring.io/forumdisplay.php?f=79)
 that might be useful, but most people prefer the interface at
 Stackoverflow).  To report bugs, submit enchancement requests or add
 something to the wish list, use
 [Github](https://github.com/spring-projects/spring-security-oauth/issues).
 
-Commercial support is available from [Pivotal](http://gopivotal.com)
-or through [Web Cohesion](http://www.webcohesion.com).
+Commercial support is available from [Pivotal](https://pivotal.io)
+or through [Web Cohesion](https://www.webcohesion.com).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -9,7 +9,7 @@ home: ../
 
 ## Introduction
 
-There's a good [getting started guide](http://www.hueniverse.com/hueniverse/2007/10/beginners-gui-1.html) that illustrates OAuth
+There's a good [getting started guide](https://www.hueniverse.com/hueniverse/2007/10/beginners-gui-1.html) that illustrates OAuth
 1.0 by describing two different (but related) services.  One is a photo-sharing application.  The other is a photo-printing
 application.  In OAuth terms, the photo sharing application is the OAuth _provider_ and the photo printing application
 is the OAuth _consumer_ or _client_.
@@ -31,7 +31,7 @@ OAuth 1.0|OAuth 2.0
 Sparklr 1 | Sparklr 2
 Tonr 1 | Tonr 2
 
-Each application is a standard [Maven](http://maven.apache.org/) project, so you will need Maven installed. Each
+Each application is a standard [Maven](https://maven.apache.org/) project, so you will need Maven installed. Each
 application is also a Spring MVC application with Spring Security integrated. If you are familiar with Spring and Spring
 Security, the configuration files will look familiar to you (the OAuth2 samples use a single application context whereas
 many MVC applications use a root context and a child for the DispatcherServlet).
@@ -41,7 +41,7 @@ many MVC applications use a root context and a child for the DispatcherServlet).
 Checkout the Sparklr and Tonr applications, and take a look around. Note especially the Spring configuration files in `src/main/webapp/WEB-INF`.
   
 For Sparklr, you'll notice the definition of the OAuth provider mechanism and the consumer/client details along with the
-[standard spring security configuration](http://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/ns-config.html) elements.  For Tonr,
+[standard spring security configuration](https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/ns-config.html) elements.  For Tonr,
 you'll notice the definition of the OAuth consumer/client mechanism and the resource details.  For more information about the necessary
 components of an OAuth provider and consumer, see the [developers guide](devguide.html).
 

--- a/docs/twolegged.md
+++ b/docs/twolegged.md
@@ -11,7 +11,7 @@ Two-legged OAuth (also known as "signed fetch") is basically OAuth without the u
 to a provider (i.e. server) by leveraging the OAuth signature algorithm. This means that the provider has an extra level of trust with the consumer and will
 therefore provide data to the consumer without making an end-user authorize a token.
 
-This has particular applicability to gadget frameworks. For example, [OpenSocial](http://www.opensocial.org/) platforms often use 2-legged OAuth so gadget
+This has particular applicability to gadget frameworks. For example, [OpenSocial](https://www.opensocial.org/) platforms often use 2-legged OAuth so gadget
 developers can have the gadget (the OAuth consumer) make Web service requests to their remote server (the OAuth provider). Since the gadget developer and
 the server developer are often the same entity, the server can trust the gadget without the need for the gadget to obtain special permission from the user to
 access the user's data.
@@ -27,7 +27,7 @@ authentication will be set up in the context. However, if a user authentication 
 `org.springframework.security.oauth.provider.OAuthAuthenticationHandler` that loads the user authentication, and provide a reference to the alternate
 implementation using the "auth-handler-ref" attribute of the "provider" configuration element.
 
-[ConsumerDetailsService]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html
-[ConsumerDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html
-[ExtraTrustConsumerDetails]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html
-[isRequiredToObtainAuthenticatedToken]: http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html#isRequiredToObtainAuthenticatedToken()
+[ConsumerDetailsService]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html
+[ConsumerDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html
+[ExtraTrustConsumerDetails]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html
+[isRequiredToObtainAuthenticatedToken]: https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html#isRequiredToObtainAuthenticatedToken()

--- a/notice.txt
+++ b/notice.txt
@@ -5,16 +5,16 @@
 ======================================================================
 
 This product includes software developed by
-the Apache Software Foundation (http://www.apache.org).
+the Apache Software Foundation (https://www.apache.org).
 
 This product includes software developed by the Spring Framework
-Project (http://www.springframework.org).
+Project (https://www.springframework.org).
 
 The end-user documentation included with a redistribution, if any,
 must include the following acknowledgement:
 
   "This product includes software developed by Web Cohesion
-   (http://www.webcohesion.com)."
+   (https://www.webcohesion.com)."
 
 Alternately, this acknowledgement may appear in the software itself,
 if and wherever such third-party acknowledgements normally appear.

--- a/samples/README.md
+++ b/samples/README.md
@@ -59,7 +59,7 @@ To deploy the apps in Eclipse you will need the Maven plugin (`m2e`)
 and the Web Tools Project (WTP) plugins.  If you have SpringSource
 Toolsuite (STS) you should already have those, aso you can deploy the
 apps very simply.  (Update the WTP plugin to at least version 0.12 at
-http://download.eclipse.org/technology/m2e/releases if you have an older
+https://download.eclipse.org/technology/m2e/releases if you have an older
 one, or the context roots for the apps will be wrong.)
 
 * Ensure the Spring Security OAuth dependencies are available locally

--- a/samples/oauth/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
@@ -2,7 +2,7 @@
 <%@ page import="org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter" %>
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>

--- a/samples/oauth/sparklr/src/main/webapp/index.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/index.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>

--- a/samples/oauth/sparklr/src/main/webapp/login.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/login.jsp
@@ -6,7 +6,7 @@
   <c:redirect url="index.jsp"/>
 </authz:authorize>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>

--- a/samples/oauth/sparklr/src/main/webapp/request_token_authorized.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/request_token_authorized.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>

--- a/samples/oauth/tonr/src/main/java/org/springframework/security/oauth/examples/tonr/impl/GoogleServiceImpl.java
+++ b/samples/oauth/tonr/src/main/java/org/springframework/security/oauth/examples/tonr/impl/GoogleServiceImpl.java
@@ -38,7 +38,7 @@ public class GoogleServiceImpl implements GoogleService {
       parser.parse(photosXML, new DefaultHandler() {
         @Override
         public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-          if ("http://search.yahoo.com/mrss/".equals(uri)
+          if ("https://search.yahoo.com/mrss/".equals(uri)
             && "thumbnail".equalsIgnoreCase(localName)) {
             int width = 0;
             try {

--- a/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/picasa.jsp
+++ b/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/picasa.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <link href="<c:url value="/main.css"/>" rel="stylesheet" type="text/css"/>

--- a/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
+++ b/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <link href="<c:url value="/main.css"/>" rel="stylesheet" type="text/css"/>

--- a/samples/oauth/tonr/src/main/webapp/index.jsp
+++ b/samples/oauth/tonr/src/main/webapp/index.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <link href="<c:url value="/main.css"/>" rel="stylesheet" type="text/css"/>
@@ -22,7 +22,7 @@
     <h1>Welcome to Tonr.com!</h1>
     
     <p>This is a website that will allow you to print your photos that you've uploaded to <a href="http://localhost:8080/sparklr/">sparklr.com</a>!
-      And since this site uses <a href="http://oauth.net">OAuth</a> to access your photos, we will never ask you
+      And since this site uses <a href="https://oauth.net">OAuth</a> to access your photos, we will never ask you
       for your Sparklr credentials.</p>
 
     <p>Tonr.com has only two users: "marissa" and "sam".  The password for "marissa" is password is "wombat" and for "sam" is password is "kangaroo".</p>
@@ -34,7 +34,7 @@
       <p><a href="<c:url value="/sparklr/photos"/>">View my Sparklr photos</a></p>
     </authz:authorize>
 
-    <p class="footer">Courtesy <a href="http://www.openwebdesign.org">Open Web Design</a> Thanks to <a href="http://www.dubaiapartments.biz/">Dubai Hotels</a></p>
+    <p class="footer">Courtesy <a href="https://www.openwebdesign.org">Open Web Design</a> Thanks to <a href="http://www.dubaiapartments.biz/">Dubai Hotels</a></p>
   </div>
 </div>
 </body>

--- a/samples/oauth/tonr/src/main/webapp/login.jsp
+++ b/samples/oauth/tonr/src/main/webapp/login.jsp
@@ -5,7 +5,7 @@
 <authz:authorize ifAllGranted="ROLE_USER">
   <c:redirect url="index.jsp"/>
 </authz:authorize>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <link href="<c:url value="/main.css"/>" rel="stylesheet" type="text/css"/>
@@ -42,7 +42,7 @@
       </form>
     </authz:authorize>
 
-    <p class="footer">Courtesy <a href="http://www.openwebdesign.org">Open Web Design</a> Thanks to <a href="http://www.dubaiapartments.biz/">Dubai Hotels</a></p>
+    <p class="footer">Courtesy <a href="https://www.openwebdesign.org">Open Web Design</a> Thanks to <a href="http://www.dubaiapartments.biz/">Dubai Hotels</a></p>
   </div>
 </div>
 </body>

--- a/samples/oauth/tonr/src/main/webapp/oauth_error.jsp
+++ b/samples/oauth/tonr/src/main/webapp/oauth_error.jsp
@@ -3,7 +3,7 @@
 <%@ page import="org.springframework.security.oauth.consumer.filter.OAuthConsumerContextFilter" %>
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <link href="<c:url value="/main.css"/>" rel="stylesheet" type="text/css"/>
@@ -42,7 +42,7 @@
         </c:if>
         <c:remove scope="session" var="OAUTH_FAILURE_KEY"/>
 
-        <p class="footer">Courtesy <a href="http://www.openwebdesign.org">Open Web Design</a> Thanks to <a
+        <p class="footer">Courtesy <a href="https://www.openwebdesign.org">Open Web Design</a> Thanks to <a
                 href="http://www.dubaiapartments.biz/">Dubai Hotels</a></p>
     </div>
 </div>

--- a/samples/oauth/tonr/src/main/webapp/template.html
+++ b/samples/oauth/tonr/src/main/webapp/template.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <link href="main.css" rel="stylesheet" type="text/css"/>
@@ -11,8 +11,8 @@
       <li><a href="#">home</a></li>
       <li><a href="#">about</a></li>
       <li><a href="#" class="selected">gallery pics</a></li>
-      <li><a href="http://www.naturaldesigngroup.co.uk">ndg</a></li>
-      <li><a href="http://www.planetphotoshop.com">planetphotoshop</a></li>
+      <li><a href="https://www.naturaldesigngroup.co.uk">ndg</a></li>
+      <li><a href="https://www.planetphotoshop.com">planetphotoshop</a></li>
     </ul>
 
   <div id="content">
@@ -25,7 +25,7 @@
       <li>a garden/jungle thing<a href="#"><img src="images/jungle.jpg" alt="a garden/jungle thing"/></a></li>
       <li>an oryx antelope in the desert<a href="#"><img src="images/antelope.jpg" alt="an oryx antelope in the desert"/></a></li>
       <li>mesas in the desert<a href="#"><img src="images/desert.jpg" alt="mesas in the desert"/><span class="main"><!--This theme is free for distriubtion,  so long as  link to openwebdesing.org and dubaiapartments.biz  stay on the theme--> Courtesy <a
-        href="http://www.openwebdesign.org" target="_blank">Open
+        href="https://www.openwebdesign.org" target="_blank">Open
         Web Design</a><a href="http://www.dubaiapartments.biz" target="_blank"><img src="spacer.gif" width="5" height="5" border="0"/></a>Thanks
 to <a href="http://www.dubaiapartments.biz/" target="_blank">Dubai Hotels</a></span></a></li>
     </ul>

--- a/samples/oauth2/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
+++ b/samples/oauth2/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
@@ -83,7 +83,7 @@
 
 		<div class="footer">
 			Sample application for <a
-				href="http://github.com/spring-projects/spring-security-oauth"
+				href="https://github.com/spring-projects/spring-security-oauth"
 				target="_blank">Spring Security OAuth</a>
 		</div>
 

--- a/samples/oauth2/sparklr/src/main/webapp/WEB-INF/jsp/oauth_error.jsp
+++ b/samples/oauth2/sparklr/src/main/webapp/WEB-INF/jsp/oauth_error.jsp
@@ -29,7 +29,7 @@
 
 		<div class="footer">
 			Sample application for <a
-				href="http://github.com/spring-projects/spring-security-oauth"
+				href="https://github.com/spring-projects/spring-security-oauth"
 				target="_blank">Spring Security OAuth</a>
 		</div>
 

--- a/samples/oauth2/sparklr/src/main/webapp/index.jsp
+++ b/samples/oauth2/sparklr/src/main/webapp/index.jsp
@@ -58,7 +58,7 @@
 
 		<div class="footer">
 			Sample application for <a
-				href="http://github.com/spring-projects/spring-security-oauth"
+				href="https://github.com/spring-projects/spring-security-oauth"
 				target="_blank">Spring Security OAuth</a>
 		</div>
 

--- a/samples/oauth2/sparklr/src/main/webapp/login.jsp
+++ b/samples/oauth2/sparklr/src/main/webapp/login.jsp
@@ -57,7 +57,7 @@
 
 		<div class="footer">
 			Sample application for <a
-				href="http://github.com/spring-projects/spring-security-oauth"
+				href="https://github.com/spring-projects/spring-security-oauth"
 				target="_blank">Spring Security OAuth</a>
 		</div>
 

--- a/samples/oauth2/sparklr/src/test/java/org/springframework/security/oauth2/provider/AuthorizationCodeProviderTests.java
+++ b/samples/oauth2/sparklr/src/test/java/org/springframework/security/oauth2/provider/AuthorizationCodeProviderTests.java
@@ -229,7 +229,7 @@ public class AuthorizationCodeProviderTests {
 		headers.setAccept(Arrays.asList(MediaType.TEXT_HTML));
 		headers.set("Cookie", cookie);
 
-		String authorizeUrl = getAuthorizeUrl("my-less-trusted-client", "http://anywhere.com", "read");
+		String authorizeUrl = getAuthorizeUrl("my-less-trusted-client", "https://anywhere.com", "read");
 		authorizeUrl = authorizeUrl + "&user_oauth_approval=true";
 		ResponseEntity<Void> response = serverRunning.postForStatus(authorizeUrl, headers,
 				new LinkedMultiValueMap<String, String>());

--- a/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/facebook.jsp
+++ b/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/facebook.jsp
@@ -1,7 +1,7 @@
 <%@ taglib prefix="authz"
 	uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
+++ b/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
@@ -1,7 +1,7 @@
 <%@ taglib prefix="authz"
 	uri="http://www.springframework.org/security/tags"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/samples/oauth2/tonr/src/main/webapp/demo.html
+++ b/samples/oauth2/tonr/src/main/webapp/demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Tonr JS Client Demo</title>

--- a/samples/oauth2/tonr/src/main/webapp/index.jsp
+++ b/samples/oauth2/tonr/src/main/webapp/index.jsp
@@ -46,7 +46,7 @@
 		<p>
 			This is a website that will allow you to print your photos that
 			you've uploaded to <a href="http://localhost:8080/sparklr2/">Sparklr</a>!
-			And since this site uses <a href="http://oauth.net">OAuth</a> to
+			And since this site uses <a href="https://oauth.net">OAuth</a> to
 			access your photos, we will never ask you for your Sparklr
 			credentials.
 		</p>

--- a/samples/oauth2/tonr/src/test/java/org/springframework/security/oauth/examples/tonr/AuthorizationCodeGrantTests.java
+++ b/samples/oauth2/tonr/src/test/java/org/springframework/security/oauth/examples/tonr/AuthorizationCodeGrantTests.java
@@ -50,7 +50,7 @@ public class AuthorizationCodeGrantTests {
 	public void testCannotConnectWithoutToken() throws Exception {
 
 		OAuth2RestTemplate template = new OAuth2RestTemplate(resource);
-		resource.setPreEstablishedRedirectUri("http://anywhere.com");
+		resource.setPreEstablishedRedirectUri("https://anywhere.com");
 		try {
 			template.getForObject(serverRunning.getUrl("/tonr2/photos"),
 					String.class);

--- a/spring-security-jwt/src/main/java/org/springframework/security/jwt/codec/Base64Codec.java
+++ b/spring-security-jwt/src/main/java/org/springframework/security/jwt/codec/Base64Codec.java
@@ -2,7 +2,7 @@ package org.springframework.security.jwt.codec;
 
 /**
  * Base64 encoder which is a reduced version of Robert Harder's public domain implementation (version 2.3.7).
- * See <a href="http://iharder.net/base64">http://iharder.net/base64</a> for more information.
+ * See <a href="http://iharder.sourceforge.net/current/java/base64/">http://iharder.sourceforge.net/current/java/base64/</a> for more information.
  *
  * @author Luke Taylor
  */

--- a/spring-security-jwt/src/test/java/org/springframework/security/jwt/JwtTests.java
+++ b/spring-security-jwt/src/test/java/org/springframework/security/jwt/JwtTests.java
@@ -35,7 +35,7 @@ public class JwtTests {
 	 * Sample from the JWT spec.
 	 */
 	static final String JOE_CLAIM_SEGMENT = "{\"iss\":\"joe\",\r\n" + " \"exp\":1300819380,\r\n"
-			+ " \"http://example.com/is_root\":true}";
+			+ " \"https://example.com/is_root\":true}";
 	static final String JOE_HEADER_HMAC = "{\"typ\":\"JWT\",\r\n" + " \"alg\":\"HS256\"}";
 	static final String JOE_HMAC_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
 			+ "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ."

--- a/spring-security-oauth/src/main/java/org/springframework/security/oauth/common/signature/SharedConsumerSecret.java
+++ b/spring-security-oauth/src/main/java/org/springframework/security/oauth/common/signature/SharedConsumerSecret.java
@@ -20,7 +20,7 @@ package org.springframework.security.oauth.common.signature;
  * A signature secret that consists of a consumer secret and a token secret.
  *
  * @author Ryan Heaton
- * @author <a href="http://autayeu.com/">Aliaksandr Autayeu</a>
+ * @author <a href="https://autayeu.com/">Aliaksandr Autayeu</a>
  */
 public interface SharedConsumerSecret extends SignatureSecret {
 

--- a/spring-security-oauth/src/main/java/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.java
+++ b/spring-security-oauth/src/main/java/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.java
@@ -53,7 +53,7 @@ public class HttpSessionBasedTokenServices implements OAuthConsumerTokenServices
     HttpSession session = getSession();
     session.setAttribute(KEY_PREFIX + "#" + resourceId, token);
 
-    //adding support for oauth session extension (http://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html)
+    //adding support for oauth session extension (https://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html)
     Long expiration = null;
     String expiresInValue = token.getAdditionalParameters() != null ? token.getAdditionalParameters().get("oauth_expires_in") : null;
     if (expiresInValue != null) {

--- a/spring-security-oauth/src/main/resources/org/springframework/security/oauth/spring-security-oauth-1.0.xsd
+++ b/spring-security-oauth/src/main/resources/org/springframework/security/oauth/spring-security-oauth-1.0.xsd
@@ -257,7 +257,7 @@
   <xs:element name="expression-handler">
     <xs:annotation>
       <xs:documentation>
-        Element for declaring and configuring an expression handler for oauth security expressions. See http://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/el-access.html
+        Element for declaring and configuring an expression handler for oauth security expressions. See https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/el-access.html
       </xs:documentation>
     </xs:annotation>
     <xs:complexType>

--- a/spring-security-oauth/src/test/java/net/oauth/signature/GoogleCodeCompatibilityTests.java
+++ b/spring-security-oauth/src/test/java/net/oauth/signature/GoogleCodeCompatibilityTests.java
@@ -87,13 +87,13 @@ public class GoogleCodeCompatibilityTests {
 			when(request.getParameterValues(param.getKey())).thenReturn(param.getValue());
 		}
 
-		String header = "OAuth realm=\"http://sp.example.com/\","
+		String header = "OAuth realm=\"https://sp.example.com/\","
 				+ "                oauth_consumer_key=\"0685bd9184jfhq22\","
 				+ "                oauth_token=\"ad180jjd733klru7\","
 				+ "                oauth_signature_method=\"HMAC-SHA1\","
 				+ "                oauth_signature=\"wOJIO9A2W5mFwDgiDvZbTSMK%2FPY%3D\","
 				+ "                oauth_timestamp=\"137131200\"," + "                oauth_callback=\""
-				+ OAuthCodec.oauthEncode("http://myhost.com/callback") + "\","
+				+ OAuthCodec.oauthEncode("https://myhost.com/callback") + "\","
 				+ "                oauth_nonce=\"4572616e48616d6d65724c61686176\","
 				+ "                oauth_version=\"1.0\"";
 		when(request.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList(header)));

--- a/spring-security-oauth/src/test/java/org/springframework/security/oauth/consumer/GoogleOAuthTests.java
+++ b/spring-security-oauth/src/test/java/org/springframework/security/oauth/consumer/GoogleOAuthTests.java
@@ -32,14 +32,14 @@ public class GoogleOAuthTests {
 		googleDetails.setSignatureMethod(HMAC_SHA1SignatureMethod.SIGNATURE_NAME);
 		googleDetails.setRequestTokenHttpMethod("GET");
 		HashMap<String, String> additional = new HashMap<String, String>();
-		additional.put("scope", "http://picasaweb.google.com/data");
+		additional.put("scope", "https://picasaweb.google.com/data");
 		googleDetails.setAdditionalParameters(additional);
 		detailsStore.put(googleDetails.getId(), googleDetails);
 		service.setResourceDetailsStore(detailsStore);
 		support.setProtectedResourceDetailsService(service);
 		// uncomment to see a request to google.
-		// see http://code.google.com/apis/accounts/docs/OAuth_ref.html
-		// and http://jira.codehaus.org/browse/OAUTHSS-37
+		// see https://code.google.com/apis/accounts/docs/OAuth_ref.html
+		// and https://jira.codehaus.org/browse/OAUTHSS-37
 		// OAuthConsumerToken token = support.getUnauthorizedRequestToken("google", "urn:mycallback");
 		// System.out.println(token.getValue());
 		// System.out.println(token.getSecret());

--- a/spring-security-oauth/src/test/java/org/springframework/security/oauth/consumer/client/CoreOAuthConsumerSupportTests.java
+++ b/spring-security-oauth/src/test/java/org/springframework/security/oauth/consumer/client/CoreOAuthConsumerSupportTests.java
@@ -93,7 +93,7 @@ public class CoreOAuthConsumerSupportTests {
 	public void testReadResouce() throws Exception {
 
 		OAuthConsumerToken token = new OAuthConsumerToken();
-		URL url = new URL("http://myhost.com/resource?with=some&query=params&too");
+		URL url = new URL("https://myhost.com/resource?with=some&query=params&too");
 		final ConnectionProps connectionProps = new ConnectionProps();
 		final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
 
@@ -446,7 +446,7 @@ public class CoreOAuthConsumerSupportTests {
 
 		CoreOAuthConsumerSupport support = new CoreOAuthConsumerSupport();
 
-		String baseString = support.getSignatureBaseString(oauthParams, new URL("http://photos.example.net/photos"),
+		String baseString = support.getSignatureBaseString(oauthParams, new URL("https://photos.example.net/photos"),
 				"geT");
 		assertEquals(
 				"GET&http%3A%2F%2Fphotos.example.net%2Fphotos&file%3Dvacation.jpg%26oauth_consumer_key%3Ddpf43f3p2l4k3l03%26oauth_nonce%3Dkllo9940pd9333jh%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1191242096%26oauth_token%3Dnnch734d00sl2jdk%26oauth_version%3D1.0%26size%3Doriginal",
@@ -461,7 +461,7 @@ public class CoreOAuthConsumerSupportTests {
 
 		CoreOAuthConsumerSupport support = new CoreOAuthConsumerSupport();
 
-		String baseString = support.getSignatureBaseString(oauthParams, new URL("http://photos.example.net/photos"),
+		String baseString = support.getSignatureBaseString(oauthParams, new URL("https://photos.example.net/photos"),
 				"get");
 		assertEquals("GET&http%3A%2F%2Fphotos.example.net%2Fphotos&bar%3D120%26bar%3D24%26foo%3Dbar", baseString);
 	}
@@ -475,7 +475,7 @@ public class CoreOAuthConsumerSupportTests {
 
 		CoreOAuthConsumerSupport support = new CoreOAuthConsumerSupport();
 
-		String baseString = support.getSignatureBaseString(oauthParams, new URL("http://photos.example.net/photos"),
+		String baseString = support.getSignatureBaseString(oauthParams, new URL("https://photos.example.net/photos"),
 				"get");
 		assertEquals("GET&http%3A%2F%2Fphotos.example.net%2Fphotos&foo%3Dbar%26pin%3D1%26pin%3D2", baseString);
 	}

--- a/spring-security-oauth/src/test/java/org/springframework/security/oauth/provider/CoreOAuthProviderSupportTests.java
+++ b/spring-security-oauth/src/test/java/org/springframework/security/oauth/provider/CoreOAuthProviderSupportTests.java
@@ -48,7 +48,7 @@ public class CoreOAuthProviderSupportTests {
 	public void testParseParameters() throws Exception {
 		CoreOAuthProviderSupport support = new CoreOAuthProviderSupport();
 		when(request.getHeaders("Authorization")).thenReturn(
-				Collections.enumeration(Arrays.asList("OAuth realm=\"http://sp.example.com/\",\n"
+				Collections.enumeration(Arrays.asList("OAuth realm=\"https://sp.example.com/\",\n"
 						+ "                oauth_consumer_key=\"0685bd9184jfhq22\",\n"
 						+ "                oauth_token=\"ad180jjd733klru7\",\n"
 						+ "                oauth_signature_method=\"HMAC-SHA1\",\n"
@@ -57,7 +57,7 @@ public class CoreOAuthProviderSupportTests {
 						+ "                oauth_nonce=\"4572616e48616d6d65724c61686176\",\n"
 						+ "                oauth_version=\"1.0\"")));
 		Map<String, String> params = support.parseParameters(request);
-		assertEquals("http://sp.example.com/", params.get("realm"));
+		assertEquals("https://sp.example.com/", params.get("realm"));
 		assertEquals("0685bd9184jfhq22", params.get(OAuthConsumerParameter.oauth_consumer_key.toString()));
 		assertEquals("ad180jjd733klru7", params.get(OAuthConsumerParameter.oauth_token.toString()));
 		assertEquals("HMAC-SHA1", params.get(OAuthConsumerParameter.oauth_signature_method.toString()));
@@ -82,7 +82,7 @@ public class CoreOAuthProviderSupportTests {
 		}
 
 		when(request.getHeaders("Authorization")).thenReturn(
-				Collections.enumeration(Arrays.asList("OAuth realm=\"http://sp.example.com/\",\n"
+				Collections.enumeration(Arrays.asList("OAuth realm=\"https://sp.example.com/\",\n"
 						+ "                oauth_consumer_key=\"dpf43f3p2l4k3l03\",\n"
 						+ "                oauth_token=\"nnch734d00sl2jdk\",\n"
 						+ "                oauth_signature_method=\"HMAC-SHA1\",\n"
@@ -93,7 +93,7 @@ public class CoreOAuthProviderSupportTests {
 
 		when(request.getMethod()).thenReturn("gEt");
 		CoreOAuthProviderSupport support = new CoreOAuthProviderSupport();
-		support.setBaseUrl("http://photos.example.net");
+		support.setBaseUrl("https://photos.example.net");
 		when(request.getRequestURI()).thenReturn("photos");
 
 		String baseString = support.getSignatureBaseString(request);

--- a/spring-security-oauth/src/test/java/org/springframework/security/oauth/provider/filter/UserAuthorizationSuccessfulAuthenticationHandlerTests.java
+++ b/spring-security-oauth/src/test/java/org/springframework/security/oauth/provider/filter/UserAuthorizationSuccessfulAuthenticationHandlerTests.java
@@ -53,19 +53,19 @@ public class UserAuthorizationSuccessfulAuthenticationHandlerTests {
 		handler.onAuthenticationSuccess(request, response, null);
 
 		verify(redirectStrategy).sendRedirect(request, response,
-				"http://my.host.com/my/context?oauth_token=mytok&oauth_verifier=myver");
+				"https://my.host.com/my/context?oauth_token=mytok&oauth_verifier=myver");
 
 		handler = new UserAuthorizationSuccessfulAuthenticationHandler();
 		handler.setRedirectStrategy(redirectStrategy);
 
 		when(request.getAttribute(UserAuthorizationProcessingFilter.CALLBACK_ATTRIBUTE)).thenReturn(
-				"http://my.hosting.com/my/context?with=some&query=parameter");
+				"https://my.hosting.com/my/context?with=some&query=parameter");
 		when(request.getAttribute(UserAuthorizationProcessingFilter.VERIFIER_ATTRIBUTE)).thenReturn("myvera");
 		when(request.getParameter("requestToken")).thenReturn("mytoka");
 
 		handler.onAuthenticationSuccess(request, response, null);
 
 		verify(redirectStrategy).sendRedirect(request, response,
-				"http://my.hosting.com/my/context?with=some&query=parameter&oauth_token=mytoka&oauth_verifier=myvera");
+				"https://my.hosting.com/my/context?with=some&query=parameter&oauth_token=mytoka&oauth_verifier=myvera");
 	}
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessToken.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessToken.java
@@ -38,7 +38,7 @@ public interface OAuth2AccessToken {
 
 	/**
 	 * The type of the token issued as described in <a
-	 * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-7.1">Section 7.1</a>. Value is case insensitive.
+	 * href="https://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-7.1">Section 7.1</a>. Value is case insensitive.
 	 * This value is REQUIRED.
 	 */
 	public static String TOKEN_TYPE = "token_type";
@@ -51,13 +51,13 @@ public interface OAuth2AccessToken {
 
 	/**
 	 * The refresh token which can be used to obtain new access tokens using the same authorization grant as described
-	 * in <a href="http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-6">Section 6</a>. This value is OPTIONAL.
+	 * in <a href="https://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-6">Section 6</a>. This value is OPTIONAL.
 	 */
 	public static String REFRESH_TOKEN = "refresh_token";
 
 	/**
 	 * The scope of the access token as described by <a
-	 * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-3.3">Section 3.3</a>
+	 * href="https://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-3.3">Section 3.3</a>
 	 */
 	public static String SCOPE = "scope";
 

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson1Deserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson1Deserializer.java
@@ -34,7 +34,7 @@ import org.springframework.security.oauth2.common.util.OAuth2Utils;
  * </p>
  * <p>
  * The expected format of the access token is defined by <a
- * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-5.1">Successful Response</a>.
+ * href="https://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-5.1">Successful Response</a>.
  * </p>
  *
  * @author Rob Winch

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson2Deserializer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/OAuth2AccessTokenJackson2Deserializer.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
  * </p>
  * <p>
  * The expected format of the access token is defined by <a
- * href="http://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-5.1">Successful Response</a>.
+ * href="https://tools.ietf.org/html/draft-ietf-oauth-v2-22#section-5.1">Successful Response</a>.
  * </p>
  *
  * @author Rob Winch

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/vote/ScopeVoter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/vote/ScopeVoter.java
@@ -49,7 +49,7 @@ import org.springframework.security.oauth2.provider.OAuth2Request;
  * <p>
  * All comparisons and prefixes are case insensitive so you can use (e.g.) <code>SCOPE_READ</code> for simple
  * Facebook-like scope names that might be lower case in the resource definition, or
- * <code>scope=http://my.company.com/scopes/read/</code> (<code>scopePrefix="scope="</code>) for Google-like URI scope
+ * <code>scope=https://my.company.com/scopes/read/</code> (<code>scopePrefix="scope="</code>) for Google-like URI scope
  * names.
  * </p>
  * 

--- a/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
+++ b/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-1.0.xsd
@@ -3,7 +3,7 @@
 	xmlns:beans="http://www.springframework.org/schema/beans" targetNamespace="http://www.springframework.org/schema/security/oauth2"
 	elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-	<xs:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.1.xsd" />
+	<xs:import namespace="http://www.springframework.org/schema/beans" schemaLocation="https://www.springframework.org/schema/beans/spring-beans-3.1.xsd" />
 
 	<xs:element name="rest-template">
 		<xs:annotation>
@@ -528,7 +528,7 @@
 				Element for declaring and configuring an expression
 				handler for oauth
 				security expressions. See
-				http://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html
+				https://docs.spring.io/spring-security/site/docs/3.0.x/reference/el-access.html
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
@@ -545,7 +545,7 @@
 				handler for oauth
 				security expressions in http
 				intercept urls. See
-				http://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html
+				https://docs.spring.io/spring-security/site/docs/3.0.x/reference/el-access.html
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>

--- a/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-2.0.xsd
+++ b/spring-security-oauth2/src/main/resources/org/springframework/security/oauth2/spring-security-oauth2-2.0.xsd
@@ -3,7 +3,7 @@
 	xmlns:beans="http://www.springframework.org/schema/beans" targetNamespace="http://www.springframework.org/schema/security/oauth2"
 	elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-	<xs:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.1.xsd" />
+	<xs:import namespace="http://www.springframework.org/schema/beans" schemaLocation="https://www.springframework.org/schema/beans/spring-beans-3.1.xsd" />
 
 	<xs:element name="rest-template">
 		<xs:annotation>
@@ -593,7 +593,7 @@
 				Element for declaring and configuring an expression
 				handler for oauth
 				security expressions. See
-				http://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html
+				https://docs.spring.io/spring-security/site/docs/3.0.x/reference/el-access.html
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
@@ -610,7 +610,7 @@
 				handler for oauth
 				security expressions in http
 				intercept urls. See
-				http://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html
+				https://docs.spring.io/spring-security/site/docs/3.0.x/reference/el-access.html
 			</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/OAuth2RestTemplateTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/OAuth2RestTemplateTests.java
@@ -209,7 +209,7 @@ public class OAuth2RestTemplateTests {
 			@Override
 			public OAuth2AccessToken obtainAccessToken(OAuth2ProtectedResourceDetails details,
 					AccessTokenRequest parameters) throws UserRedirectRequiredException, AccessDeniedException {
-				throw new UserRedirectRequiredException("http://foo.com", Collections.<String, String> emptyMap());
+				throw new UserRedirectRequiredException("http://www.foo.com/", Collections.<String, String> emptyMap());
 			}
 		});
 		try {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilterTests.java
@@ -21,7 +21,7 @@ public class OAuth2ClientContextFilterTests {
 
 	@Test
 	public void testVanillaRedirectUri() throws Exception {
-		String redirect = "http://example.com/authorize";
+		String redirect = "https://example.com/authorize";
 		Map<String, String> params = new LinkedHashMap<String, String>();
 		params.put("foo", "bar");
 		params.put("scope", "spam");
@@ -30,7 +30,7 @@ public class OAuth2ClientContextFilterTests {
 
 	@Test
 	public void testTwoScopesRedirectUri() throws Exception {
-		String redirect = "http://example.com/authorize";
+		String redirect = "https://example.com/authorize";
 		Map<String, String> params = new LinkedHashMap<String, String>();
 		params.put("foo", "bar");
 		params.put("scope", "spam scope2");
@@ -39,7 +39,7 @@ public class OAuth2ClientContextFilterTests {
 
 	@Test
 	public void testRedirectUriWithUrlInParams() throws Exception {
-		String redirect = "http://example.com/authorize";
+		String redirect = "https://example.com/authorize";
 		Map<String, String> params = Collections.singletonMap("redirect",
 				"http://foo/bar");
 		testRedirectUri(redirect, params, redirect + "?redirect=http://foo/bar");
@@ -47,7 +47,7 @@ public class OAuth2ClientContextFilterTests {
 
 	@Test
 	public void testRedirectUriWithQuery() throws Exception {
-		String redirect = "http://example.com/authorize?foo=bar";
+		String redirect = "https://example.com/authorize?foo=bar";
 		Map<String, String> params = Collections.singletonMap("spam",
 				"bucket");
 		testRedirectUri(redirect, params, redirect + "&spam=bucket");

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProviderTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProviderTests.java
@@ -99,12 +99,12 @@ public class AuthorizationCodeAccessTokenProviderTests {
 		request.setStateKey("bar");
 		request.setPreservedState(new Object());
 		resource.setAccessTokenUri("http://localhost/oauth/token");
-		resource.setPreEstablishedRedirectUri("http://anywhere.com");
+		resource.setPreEstablishedRedirectUri("https://anywhere.com");
 		assertEquals("FOO", provider.obtainAccessToken(resource, request).getValue());
 		// System.err.println(params);
 		assertEquals("authorization_code", params.getFirst("grant_type"));
 		assertEquals("foo", params.getFirst("code"));
-		assertEquals("http://anywhere.com", params.getFirst("redirect_uri"));
+		assertEquals("https://anywhere.com", params.getFirst("redirect_uri"));
 		// State is not set in token request
 		assertEquals(null, params.getFirst("state"));
 	}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProviderWithConversionTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeAccessTokenProviderWithConversionTests.java
@@ -92,7 +92,7 @@ public class AuthorizationCodeAccessTokenProviderWithConversionTests {
 
 		public URI getURI() {
 			try {
-				return new URI("http://foo.com");
+				return new URI("http://www.foo.com/");
 			}
 			catch (URISyntaxException e) {
 				throw new IllegalStateException(e);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeResourceDetailsTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/code/AuthorizationCodeResourceDetailsTests.java
@@ -29,7 +29,7 @@ public class AuthorizationCodeResourceDetailsTests {
 
 	@Test
 	public void testGetDefaultRedirectUri() {
-		details.setPreEstablishedRedirectUri("http://anywhere.com");
+		details.setPreEstablishedRedirectUri("https://anywhere.com");
 		DefaultAccessTokenRequest request = new DefaultAccessTokenRequest();
 		request.setCurrentUri("http://nowhere.com");
 		assertEquals("http://nowhere.com", details.getRedirectUri(request));
@@ -37,11 +37,11 @@ public class AuthorizationCodeResourceDetailsTests {
 
 	@Test
 	public void testGetOverrideRedirectUri() {
-		details.setPreEstablishedRedirectUri("http://anywhere.com");
+		details.setPreEstablishedRedirectUri("https://anywhere.com");
 		details.setUseCurrentUri(false);
 		DefaultAccessTokenRequest request = new DefaultAccessTokenRequest();
 		request.setCurrentUri("http://nowhere.com");
-		assertEquals("http://anywhere.com", details.getRedirectUri(request));
+		assertEquals("https://anywhere.com", details.getRedirectUri(request));
 	}
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/implicit/ImplicitAccessTokenProviderTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/grant/implicit/ImplicitAccessTokenProviderTests.java
@@ -59,11 +59,11 @@ public class ImplicitAccessTokenProviderTests {
 		AccessTokenRequest request = new DefaultAccessTokenRequest();
 		resource.setClientId("foo");
 		resource.setAccessTokenUri("http://localhost/oauth/authorize");
-		resource.setPreEstablishedRedirectUri("http://anywhere.com");
+		resource.setPreEstablishedRedirectUri("https://anywhere.com");
 		assertEquals("FOO", provider.obtainAccessToken(resource, request).getValue());
 		assertEquals("foo", params.getFirst("client_id"));
 		assertEquals("token", params.getFirst("response_type"));
-		assertEquals("http://anywhere.com", params.getFirst("redirect_uri"));
+		assertEquals("https://anywhere.com", params.getFirst("redirect_uri"));
 	}
 
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/ClientConfigurationTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/ClientConfigurationTests.java
@@ -58,7 +58,7 @@ public class ClientConfigurationTests {
 				.andExpect(MockMvcResultMatchers.status().isFound())
 				.andExpect(
 						MockMvcResultMatchers.header().string("Location",
-								CoreMatchers.startsWith("http://example.com/authorize")));
+								CoreMatchers.startsWith("https://example.com/authorize")));
 		context.close();
 	}
 
@@ -75,7 +75,7 @@ public class ClientConfigurationTests {
 		@RequestMapping("/photos")
 		@ResponseBody
 		public String photos() {
-			return restTemplate().getForObject("http://example.com/photos", String.class);
+			return restTemplate().getForObject("https://example.com/photos", String.class);
 		}
 
 		@Bean
@@ -84,8 +84,8 @@ public class ClientConfigurationTests {
 		public OAuth2RestOperations restTemplate() {
 			AuthorizationCodeResourceDetails resource = new AuthorizationCodeResourceDetails();
 			resource.setClientId("client");
-			resource.setAccessTokenUri("http://example.com/token");
-			resource.setUserAuthorizationUri("http://example.com/authorize");
+			resource.setAccessTokenUri("https://example.com/token");
+			resource.setUserAuthorizationUri("https://example.com/authorize");
 			return new OAuth2RestTemplate(resource, new DefaultOAuth2ClientContext(accessTokenRequest));
 		}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/Gh808EnableAuthorizationServerTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/annotation/Gh808EnableAuthorizationServerTests.java
@@ -81,7 +81,7 @@ public class Gh808EnableAuthorizationServerTests {
 	MockMvc mockMvc;
 
 	static {
-		client = new BaseClientDetails(CLIENT_ID, null, "read,write", "password,client_credentials", "ROLE_ADMIN", "http://example.com/oauth2callback");
+		client = new BaseClientDetails(CLIENT_ID, null, "read,write", "password,client_credentials", "ROLE_ADMIN", "https://example.com/oauth2callback");
 		client.setClientSecret(CLIENT_SECRET);
 		user = new User(USER_ID, USER_SECRET, Arrays.asList(new SimpleGrantedAuthority("ROLE_USER")));
 	}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/ClientDetailsServiceBeanDefinitionParserTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/ClientDetailsServiceBeanDefinitionParserTests.java
@@ -84,7 +84,7 @@ public class ClientDetailsServiceBeanDefinitionParserTests {
 		assertNotNull(clientDetailsService);
 		assertEquals("my-client-id-default-flow", clientDetails.getClientId());
 		assertEquals(1, clientDetails.getRegisteredRedirectUri().size());
-		assertEquals("http://mycompany.com", clientDetails.getRegisteredRedirectUri().iterator().next());
+		assertEquals("https://secure.mycompany.com", clientDetails.getRegisteredRedirectUri().iterator().next());
 
 		Set<String> grantTypes = clientDetails.getAuthorizedGrantTypes();
 		assertNotNull(grantTypes);

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/InvalidResourceBeanDefinitionParserTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/InvalidResourceBeanDefinitionParserTests.java
@@ -83,7 +83,7 @@ public class InvalidResourceBeanDefinitionParserTests {
 		context = new GenericXmlApplicationContext(new ByteArrayResource(config .getBytes()));
 	}
 
-	private static String HEADER = "<?xml version='1.0' encoding='UTF-8'?><beans xmlns='http://www.springframework.org/schema/beans' xmlns:oauth='http://www.springframework.org/schema/security/oauth2' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'	xsi:schemaLocation='http://www.springframework.org/schema/security/oauth2 http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd'>";
+	private static String HEADER = "<?xml version='1.0' encoding='UTF-8'?><beans xmlns='http://www.springframework.org/schema/beans' xmlns:oauth='http://www.springframework.org/schema/security/oauth2' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'	xsi:schemaLocation='http://www.springframework.org/schema/security/oauth2 https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd'>";
 	private static String FOOTER = "</beans>";
 	private static String TEMPLATE = "<oauth:resource id='resource' client-id='client' %s/>";
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/ResourceBeanDefinitionParserTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/config/xml/ResourceBeanDefinitionParserTests.java
@@ -68,7 +68,7 @@ public class ResourceBeanDefinitionParserTests {
 	public void testResourceFromPropertyFile() {
 		assertEquals("my-client-id-property-file", two.getClientId());
 		assertEquals("my-client-secret-property-file", two.getClientSecret());
-		assertEquals("http://myhost.com", two.getAccessTokenUri());
+		assertEquals("https://myhost.com", two.getAccessTokenUri());
 		assertEquals(2, two.getScope().size());
 		assertEquals("[none, all]", two.getScope().toString());
 	}
@@ -78,7 +78,7 @@ public class ResourceBeanDefinitionParserTests {
 		assertEquals("my-client-id", three.getClientId());
 		assertNull(three.getClientSecret());
 		assertEquals("http://somewhere.com", three.getAccessTokenUri());
-		assertEquals("http://anywhere.com", three.getPreEstablishedRedirectUri());
+		assertEquals("https://anywhere.com", three.getPreEstablishedRedirectUri());
 		assertFalse(three.isUseCurrentUri());
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/AuthorizationRequestTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/AuthorizationRequestTests.java
@@ -47,7 +47,7 @@ public class AuthorizationRequestTests {
 		parameters = new HashMap<String, String>();
 		parameters.put("client_id", "theClient");
 		parameters.put("state", "XYZ123");
-		parameters.put("redirect_uri", "http://www.callistaenterprise.se");
+		parameters.put("redirect_uri", "https://callistaenterprise.se/");
 	}
 	
 	@Test
@@ -153,8 +153,8 @@ public class AuthorizationRequestTests {
 
 		assertEquals("XYZ123", authorizationRequest.getState());
 		assertEquals("theClient", authorizationRequest.getClientId());
-		assertEquals("http://www.callistaenterprise.se", authorizationRequest.getRedirectUri());
-		assertEquals("http://www.callistaenterprise.se", authorizationRequest.getRequestParameters().get(OAuth2Utils.REDIRECT_URI));
+		assertEquals("https://callistaenterprise.se/", authorizationRequest.getRedirectUri());
+		assertEquals("https://callistaenterprise.se/", authorizationRequest.getRequestParameters().get(OAuth2Utils.REDIRECT_URI));
 		assertEquals("[one, two]", authorizationRequest.getScope().toString());
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/SubdomainRedirectResolverTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/SubdomainRedirectResolverTests.java
@@ -25,18 +25,18 @@ public class SubdomainRedirectResolverTests
 	@Test
 	public void testRedirectMatch() throws Exception
 	{
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://watchdox.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://watchdox.com"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.watchdox.com";
+		String requestedRedirect = "https://anywhere.watchdox.com";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	@Test(expected=RedirectMismatchException.class)
 	public void testRedirectNoMatch() throws Exception
 	{
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://watchdox.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://watchdox.com"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.google.com";
+		String requestedRedirect = "https://anywhere.google.com";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpointTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpointTests.java
@@ -101,7 +101,7 @@ public class AuthorizationEndpointTests {
 	@Before
 	public void init() throws Exception {
 		client = new BaseClientDetails();
-		client.setRegisteredRedirectUri(Collections.singleton("http://anywhere.com"));
+		client.setRegisteredRedirectUri(Collections.singleton("https://anywhere.com"));
 		client.setAuthorizedGrantTypes(Arrays.asList("authorization_code", "implicit"));
 		endpoint.setClientDetailsService(new ClientDetailsService() {
 			public ClientDetails loadClientByClientId(String clientId) throws OAuth2Exception {
@@ -155,59 +155,59 @@ public class AuthorizationEndpointTests {
 	@Test
 	public void testAuthorizationCodeWithFragment() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com#bar", null, null, Collections.singleton("code"));
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com#bar", null, null, Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
-		assertEquals("http://anywhere.com?code=thecode#bar", ((RedirectView) result).getUrl());
+		assertEquals("https://anywhere.com?code=thecode#bar", ((RedirectView) result).getUrl());
 	}
 
 	@Test
 	public void testAuthorizationCodeWithQueryParams() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com?foo=bar", null, null, Collections.singleton("code"));
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com?foo=bar", null, null, Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
-		assertEquals("http://anywhere.com?foo=bar&code=thecode", ((RedirectView) result).getUrl());
+		assertEquals("https://anywhere.com?foo=bar&code=thecode", ((RedirectView) result).getUrl());
 	}
 
 	@Test
 	public void testAuthorizationCodeWithTrickyState() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com", " =?s", null, Collections.singleton("code"));
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com", " =?s", null, Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
-		assertEquals("http://anywhere.com?code=thecode&state=%20%3D?s", ((RedirectView) result).getUrl());
+		assertEquals("https://anywhere.com?code=thecode&state=%20%3D?s", ((RedirectView) result).getUrl());
 	}
 
 	@Test
 	public void testAuthorizationCodeWithMultipleQueryParams() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com?foo=bar&bar=foo", null, null,
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com?foo=bar&bar=foo", null, null,
 				Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
-		assertEquals("http://anywhere.com?foo=bar&bar=foo&code=thecode", ((RedirectView) result).getUrl());
+		assertEquals("https://anywhere.com?foo=bar&bar=foo&code=thecode", ((RedirectView) result).getUrl());
 	}
 
 	@Test
 	public void testAuthorizationCodeWithTrickyQueryParams() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com?foo=b =&bar=f $", null, null,
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com?foo=b =&bar=f $", null, null,
 				Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
 		String url = ((RedirectView) result).getUrl();
-		assertEquals("http://anywhere.com?foo=b%20=&bar=f%20$&code=thecode", url);
+		assertEquals("https://anywhere.com?foo=b%20=&bar=f%20$&code=thecode", url);
 		MultiValueMap<String, String> params = UriComponentsBuilder.fromHttpUrl(url).build().getQueryParams();
 		assertEquals("[b%20=]", params.get("foo").toString());
 		assertEquals("[f%20$]", params.get("bar").toString());
@@ -217,24 +217,24 @@ public class AuthorizationEndpointTests {
 	public void testAuthorizationCodeWithTrickyEncodedQueryParams() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
 		AuthorizationRequest request = getAuthorizationRequest(
-				"foo", "http://anywhere.com/path?foo=b%20%3D&bar=f%20$", null, null, Collections.singleton("code"));
+				"foo", "https://anywhere.com/path?foo=b%20%3D&bar=f%20$", null, null, Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
-		assertEquals("http://anywhere.com/path?foo=b%20%3D&bar=f%20$&code=thecode", ((RedirectView) result).getUrl());
+		assertEquals("https://anywhere.com/path?foo=b%20%3D&bar=f%20$&code=thecode", ((RedirectView) result).getUrl());
 	}
 
 	@Test
 	public void testAuthorizationCodeWithMoreTrickyEncodedQueryParams() throws Exception {
 		endpoint.setAuthorizationCodeServices(new StubAuthorizationCodeServices());
 		AuthorizationRequest request = getAuthorizationRequest(
-				"foo", "http://anywhere?t=a%3Db%26ep%3Dtest%2540test.me", null, null, Collections.singleton("code"));
+				"foo", "https://anywhere?t=a%3Db%26ep%3Dtest%2540test.me", null, null, Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(Collections.singletonMap(OAuth2Utils.USER_OAUTH_APPROVAL, "true"), model,
 				sessionStatus, principal);
-		assertEquals("http://anywhere?t=a%3Db%26ep%3Dtest%2540test.me&code=thecode", ((RedirectView) result).getUrl());
+		assertEquals("https://anywhere?t=a%3Db%26ep%3Dtest%2540test.me&code=thecode", ((RedirectView) result).getUrl());
 	}
 
 	@Test
@@ -262,10 +262,10 @@ public class AuthorizationEndpointTests {
 		});
 		ModelAndView result = endpoint.authorize(
 				model,
-				getAuthorizationRequest("foo", "http://anywhere.com", "mystate", "myscope",
+				getAuthorizationRequest("foo", "https://anywhere.com", "mystate", "myscope",
 						Collections.singleton("code")).getRequestParameters(), sessionStatus, principal);
 		String url = ((RedirectView) result.getView()).getUrl();
-		assertTrue("Wrong view: " + result, url.startsWith("http://anywhere.com"));
+		assertTrue("Wrong view: " + result, url.startsWith("https://anywhere.com"));
 		assertTrue("No error: " + result, url.contains("?error="));
 		assertTrue("Wrong state: " + result, url.contains("&state=mystate"));
 
@@ -308,12 +308,12 @@ public class AuthorizationEndpointTests {
 				return true;
 			}
 		});
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				"myscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
 		String url = ((RedirectView) result.getView()).getUrl();
-		assertTrue("Wrong view: " + result, url.startsWith("http://anywhere.com"));
+		assertTrue("Wrong view: " + result, url.startsWith("https://anywhere.com"));
 		assertTrue("Wrong state: " + result, url.contains("&state=mystate"));
 		assertTrue("Wrong token: " + result, url.contains("access_token="));
 		assertTrue("Wrong token: " + result, url.contains("foo=bar"));
@@ -343,7 +343,7 @@ public class AuthorizationEndpointTests {
 				return true;
 			}
 		});
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				"myscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
@@ -364,7 +364,7 @@ public class AuthorizationEndpointTests {
 				return true;
 			}
 		});
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com?foo=bar",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com?foo=bar",
 				"mystate", "myscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
@@ -386,7 +386,7 @@ public class AuthorizationEndpointTests {
 				return true;
 			}
 		});
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				"myscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
@@ -419,7 +419,7 @@ public class AuthorizationEndpointTests {
 			}
 		});
 		client.setScope(Collections.singleton("read"));
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				null, Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
@@ -450,12 +450,12 @@ public class AuthorizationEndpointTests {
 			}
 		});
 		client.setScope(Collections.singleton("smallscope"));
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				"bigscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
 		String url = ((RedirectView) result.getView()).getUrl();
-		assertTrue("Wrong view: " + result, url.startsWith("http://anywhere.com"));
+		assertTrue("Wrong view: " + result, url.startsWith("https://anywhere.com"));
 	}
 
 	@Test
@@ -465,7 +465,7 @@ public class AuthorizationEndpointTests {
 				return null;
 			}
 		});
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				"myscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
@@ -494,13 +494,13 @@ public class AuthorizationEndpointTests {
 				return null;
 			}
 		});
-		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "http://anywhere.com", "mystate",
+		AuthorizationRequest authorizationRequest = getAuthorizationRequest("foo", "https://anywhere.com", "mystate",
 				"myscope", Collections.singleton("token"));
 		ModelAndView result = endpoint.authorize(model, authorizationRequest.getRequestParameters(), sessionStatus,
 				principal);
 
 		String url = ((RedirectView) result.getView()).getUrl();
-		assertTrue("Wrong view: " + result, url.startsWith("http://anywhere.com"));
+		assertTrue("Wrong view: " + result, url.startsWith("https://anywhere.com"));
 		assertTrue("No error: " + result, url.contains("#error="));
 		assertTrue("Wrong state: " + result, url.contains("&state=mystate"));
 
@@ -508,7 +508,7 @@ public class AuthorizationEndpointTests {
 
 	@Test
 	public void testApproveOrDeny() throws Exception {
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com", null, null,
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com", null, null,
 				Collections.singleton("code"));
 		request.setApproved(true);
 		Map<String, String> approvalParameters = new HashMap<String, String>();
@@ -516,26 +516,26 @@ public class AuthorizationEndpointTests {
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		View result = endpoint.approveOrDeny(approvalParameters, model, sessionStatus, principal);
-		assertTrue("Wrong view: " + result, ((RedirectView) result).getUrl().startsWith("http://anywhere.com"));
+		assertTrue("Wrong view: " + result, ((RedirectView) result).getUrl().startsWith("https://anywhere.com"));
 	}
 
 	@Test
 	public void testApprovalDenied() throws Exception {
-		AuthorizationRequest request = getAuthorizationRequest("foo", "http://anywhere.com", null, null, Collections.singleton("code"));
+		AuthorizationRequest request = getAuthorizationRequest("foo", "https://anywhere.com", null, null, Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, request);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(request));
 		Map<String, String> approvalParameters = new HashMap<String, String>();
 		approvalParameters.put("user_oauth_approval", "false");
 		View result = endpoint.approveOrDeny(approvalParameters, model, sessionStatus, principal);
 		String url = ((RedirectView) result).getUrl();
-		assertTrue("Wrong view: " + result, url.startsWith("http://anywhere.com"));
+		assertTrue("Wrong view: " + result, url.startsWith("https://anywhere.com"));
 		assertTrue("Wrong view: " + result, url.contains("error=access_denied"));
 	}
 
 	@Test
 	public void testDirectApproval() throws Exception {
 		ModelAndView result = endpoint.authorize(model,
-				getAuthorizationRequest("foo", "http://anywhere.com", null, "read", Collections.singleton("code"))
+				getAuthorizationRequest("foo", "https://anywhere.com", null, "read", Collections.singleton("code"))
 						.getRequestParameters(), sessionStatus, principal);
 		// Should go to approval page (SECOAUTH-191)
 		assertFalse(result.getView() instanceof RedirectView);
@@ -550,7 +550,7 @@ public class AuthorizationEndpointTests {
 		AuthorizationRequest authorizationRequest = (AuthorizationRequest) result.getModelMap().get(
 				AUTHORIZATION_REQUEST_ATTR_NAME);
 		assertNull(authorizationRequest.getRequestParameters().get(OAuth2Utils.REDIRECT_URI));
-		assertEquals("http://anywhere.com", authorizationRequest.getRedirectUri());
+		assertEquals("https://anywhere.com", authorizationRequest.getRedirectUri());
 	}
 
 	/**
@@ -572,7 +572,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedClientId() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setClientId("bar");		// Modify authorization request
@@ -584,7 +584,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedState() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setState("state-5678");		// Modify authorization request
@@ -596,7 +596,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedRedirectUri() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setRedirectUri("http://somewhere.com");		// Modify authorization request
@@ -608,7 +608,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedResponseTypes() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setResponseTypes(Collections.singleton("implicit"));		// Modify authorization request
@@ -620,7 +620,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedScope() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setScope(Arrays.asList("read", "write"));		// Modify authorization request
@@ -632,7 +632,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedApproved() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		authorizationRequest.setApproved(false);
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
@@ -645,7 +645,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedResourceIds() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setResourceIds(Collections.singleton("resource-other"));		// Modify authorization request
@@ -657,7 +657,7 @@ public class AuthorizationEndpointTests {
 	@Test(expected = InvalidRequestException.class)
 	public void testApproveWithModifiedAuthorities() throws Exception {
 		AuthorizationRequest authorizationRequest = getAuthorizationRequest(
-				"foo", "http://anywhere.com", "state-1234", "read", Collections.singleton("code"));
+				"foo", "https://anywhere.com", "state-1234", "read", Collections.singleton("code"));
 		model.put(AUTHORIZATION_REQUEST_ATTR_NAME, authorizationRequest);
 		model.put(ORIGINAL_AUTHORIZATION_REQUEST_ATTR_NAME, endpoint.unmodifiableMap(authorizationRequest));
 		authorizationRequest.setAuthorities(AuthorityUtils.commaSeparatedStringToAuthorityList("authority-other"));		// Modify authorization request

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolverTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/DefaultRedirectResolverTests.java
@@ -47,22 +47,22 @@ public class DefaultRedirectResolverTests {
 
 	@Test
 	public void testRedirectMatchesRegisteredValue() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com";
+		String requestedRedirect = "https://anywhere.com";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	@Test(expected = InvalidRequestException.class)
 	public void testRedirectWithNoRegisteredValue() throws Exception {
-		String requestedRedirect = "http://anywhere.com/myendpoint";
+		String requestedRedirect = "https://anywhere.com/myendpoint";
 		resolver.resolveRedirect(requestedRedirect, client);
 	}
 
 	// If only one redirect has been registered, then we should use it
 	@Test
 	public void testRedirectWithNoRequestedValue() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
 		resolver.resolveRedirect(null, client);
 	}
@@ -70,14 +70,14 @@ public class DefaultRedirectResolverTests {
 	// If multiple redirects registered, then we should get an exception
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectWithNoRequestedValueAndMultipleRegistered() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com", "http://nowhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com", "http://nowhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
 		resolver.resolveRedirect(null, client);
 	}
 
 	@Test(expected = InvalidGrantException.class)
 	public void testNoGrantType() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com", "http://nowhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com", "http://nowhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
 		client.setAuthorizedGrantTypes(Collections.<String>emptyList());
 		resolver.resolveRedirect(null, client);
@@ -85,7 +85,7 @@ public class DefaultRedirectResolverTests {
 
 	@Test(expected = InvalidGrantException.class)
 	public void testWrongGrantType() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com", "http://nowhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com", "http://nowhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
 		client.setAuthorizedGrantTypes(Collections.singleton("client_credentials"));
 		resolver.resolveRedirect(null, client);
@@ -94,7 +94,7 @@ public class DefaultRedirectResolverTests {
 	@Test(expected = InvalidGrantException.class)
 	public void testWrongCustomGrantType() throws Exception {
 		resolver.setRedirectGrantTypes(Collections.singleton("foo"));
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com", "http://nowhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com", "http://nowhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
 		resolver.resolveRedirect(null, client);
 	}
@@ -102,15 +102,15 @@ public class DefaultRedirectResolverTests {
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectNotMatching() throws Exception {
 		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://nowhere.com"));
-		String requestedRedirect = "http://anywhere.com/myendpoint";
+		String requestedRedirect = "https://anywhere.com/myendpoint";
 		client.setRegisteredRedirectUri(redirectUris);
 		assertEquals(redirectUris.iterator().next(), resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectNotMatchingWithTraversal() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/foo"));
-		String requestedRedirect = "http://anywhere.com/foo/../bar";
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/foo"));
+		String requestedRedirect = "https://anywhere.com/foo/../bar";
 		client.setRegisteredRedirectUri(redirectUris);
 		assertEquals(redirectUris.iterator().next(), resolver.resolveRedirect(requestedRedirect, client));
 	}
@@ -118,16 +118,16 @@ public class DefaultRedirectResolverTests {
 	// gh-1331
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectNotMatchingWithHexEncodedTraversal() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/foo"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/foo"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com/foo/%2E%2E";	// hexadecimal encoding of '..' represents '%2E%2E'
+		String requestedRedirect = "https://anywhere.com/foo/%2E%2E";	// hexadecimal encoding of '..' represents '%2E%2E'
 		resolver.resolveRedirect(requestedRedirect, client);
 	}
 
 	// gh-747
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectNotMatchingSubdomain() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/foo"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/foo"));
 		client.setRegisteredRedirectUri(redirectUris);
 		resolver.resolveRedirect("http://2anywhere.com/foo", client);
 	}
@@ -135,8 +135,8 @@ public class DefaultRedirectResolverTests {
 	// gh-747
 	@Test
 	public void testRedirectMatchingSubdomain() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/foo"));
-		String requestedRedirect = "http://2.anywhere.com/foo";
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/foo"));
+		String requestedRedirect = "https://2.anywhere.com/foo";
 		client.setRegisteredRedirectUri(redirectUris);
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
@@ -144,26 +144,26 @@ public class DefaultRedirectResolverTests {
 	// gh-746
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectNotMatchingPort() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com:90"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com:90"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://anywhere.com:91/foo", client);
+		resolver.resolveRedirect("https://anywhere.com:91/foo", client);
 	}
 
 	// gh-746
 	@Test
 	public void testRedirectMatchingPort() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com:90"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com:90"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com:90";
+		String requestedRedirect = "https://anywhere.com:90";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-746
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectRegisteredPortSetRequestedPortNotSet() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com:90"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com:90"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://anywhere.com/foo", client);
+		resolver.resolveRedirect("https://anywhere.com/foo", client);
 	}
 
 	// gh-746
@@ -178,112 +178,112 @@ public class DefaultRedirectResolverTests {
 	@Test
 	public void testRedirectMatchPortsFalse() throws Exception {
 		resolver.setMatchPorts(false);
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com:90"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com:90"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com:91";
+		String requestedRedirect = "https://anywhere.com:91";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-1566
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectRegisteredUserInfoNotMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://userinfo@anywhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://userinfo@anywhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://otheruserinfo@anywhere.com", client);
+		resolver.resolveRedirect("https://otheruserinfo@anywhere.com", client);
 	}
 
 	// gh-1566
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectRegisteredNoUserInfoNotMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://userinfo@anywhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://userinfo@anywhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://anywhere.com", client);
+		resolver.resolveRedirect("https://anywhere.com", client);
 	}
 
 	// gh-1566
 	@Test()
 	public void testRedirectRegisteredUserInfoMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://userinfo@anywhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://userinfo@anywhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://userinfo@anywhere.com";
+		String requestedRedirect = "https://userinfo@anywhere.com";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-1566
 	@Test()
 	public void testRedirectRegisteredFragmentIgnoredAndStripped() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://userinfo@anywhere.com/foo/bar#baz"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://userinfo@anywhere.com/foo/bar#baz"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://userinfo@anywhere.com/foo/bar";
+		String requestedRedirect = "https://userinfo@anywhere.com/foo/bar";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect + "#bar", client));
 	}
 
 	// gh-1566
 	@Test()
 	public void testRedirectRegisteredQueryParamsMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v1&p2=v2"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com/?p1=v1&p2=v2";
+		String requestedRedirect = "https://anywhere.com/?p1=v1&p2=v2";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-1566
 	@Test()
 	public void testRedirectRegisteredQueryParamsMatchingIgnoringAdditionalParams() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v1&p2=v2"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com/?p1=v1&p2=v2&p3=v3";
+		String requestedRedirect = "https://anywhere.com/?p1=v1&p2=v2&p3=v3";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-1566
 	@Test()
 	public void testRedirectRegisteredQueryParamsMatchingDifferentOrder() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v1&p2=v2"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com/?p2=v2&p1=v1";
+		String requestedRedirect = "https://anywhere.com/?p2=v2&p1=v1";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-1566
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectRegisteredQueryParamsWithDifferentValues() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v1&p2=v2"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://anywhere.com/?p1=v1&p2=v3", client);
+		resolver.resolveRedirect("https://anywhere.com/?p1=v1&p2=v3", client);
 	}
 
 	// gh-1566
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectRegisteredQueryParamsNotMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v1"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v1"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://anywhere.com/?p2=v2", client);
+		resolver.resolveRedirect("https://anywhere.com/?p2=v2", client);
 	}
 
 	// gh-1566
 	@Test(expected = RedirectMismatchException.class)
 	public void testRedirectRegisteredQueryParamsPartiallyMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v1&p2=v2"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
-		resolver.resolveRedirect("http://anywhere.com/?p2=v2&p3=v3", client);
+		resolver.resolveRedirect("https://anywhere.com/?p2=v2&p3=v3", client);
 	}
 
 	// gh-1566
 	@Test
 	public void testRedirectRegisteredQueryParamsMatchingWithMultipleValuesInRegistered() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1=v11&p1=v12"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1=v11&p1=v12"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com/?p1=v11&p1=v12";
+		String requestedRedirect = "https://anywhere.com/?p1=v11&p1=v12";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	// gh-1566
 	@Test
 	public void testRedirectRegisteredQueryParamsMatchingWithParamWithNoValue() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com/?p1&p2=v2"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com/?p1&p2=v2"));
 		client.setRegisteredRedirectUri(redirectUris);
-		String requestedRedirect = "http://anywhere.com/?p1&p2=v2";
+		String requestedRedirect = "https://anywhere.com/?p1&p2=v2";
 		assertEquals(requestedRedirect, resolver.resolveRedirect(requestedRedirect, client));
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/ExactMatchRedirectResolverTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/endpoint/ExactMatchRedirectResolverTests.java
@@ -40,15 +40,15 @@ public class ExactMatchRedirectResolverTests {
 
 	@Test ( expected = RedirectMismatchException.class )
 	public void testRedirectNotMatching() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com"));
-		String requestedRedirect = "http://anywhere.com/myendpoint";
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com"));
+		String requestedRedirect = "https://anywhere.com/myendpoint";
 		client.setRegisteredRedirectUri(redirectUris);
 		assertEquals(redirectUris.iterator().next(), resolver.resolveRedirect(requestedRedirect, client));
 	}
 
 	@Test(expected = InvalidRequestException.class)
 	public void testRedirectWithNoRegisteredValue() throws Exception {
-		String requestedRedirect = "http://anywhere.com/myendpoint";
+		String requestedRedirect = "https://anywhere.com/myendpoint";
 		resolver.resolveRedirect(requestedRedirect, client);
 	}
 
@@ -56,7 +56,7 @@ public class ExactMatchRedirectResolverTests {
 	// If not we should expect a Oauth2Exception.
 	@Test ( expected = OAuth2Exception.class )
 	public void testRedirectWithNoRequestedValue() throws Exception {
-		Set<String> redirectUris = new HashSet<String>(Arrays.asList("http://anywhere.com", "http://nowhere.com"));
+		Set<String> redirectUris = new HashSet<String>(Arrays.asList("https://anywhere.com", "http://nowhere.com"));
 		client.setRegisteredRedirectUri(redirectUris);
 		resolver.resolveRedirect(null, client);
 	}

--- a/tests/annotation/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
+++ b/tests/annotation/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
@@ -130,7 +130,7 @@ public abstract class AbstractAuthorizationCodeProviderTests extends AbstractEmp
 
 		HttpHeaders headers = getAuthenticatedHeaders();
 
-		String authorizeUrl = getAuthorizeUrl("my-trusted-client", "http://anywhere.com", "read");
+		String authorizeUrl = getAuthorizeUrl("my-trusted-client", "https://anywhere.com", "read");
 		authorizeUrl = authorizeUrl + "&user_oauth_approval=true";
 		ResponseEntity<String> response = http.postForStatus(authorizeUrl, headers,
 				new LinkedMultiValueMap<String, String>());

--- a/tests/annotation/ssl/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/ssl/src/test/java/demo/ImplicitProviderTests.java
@@ -57,7 +57,7 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 	private void getToken() {
 		Map<String, String> form = new LinkedHashMap<String, String>();
 		form.put("client_id", "my-trusted-client");
-		form.put("redirect_uri", "http://foo.com");
+		form.put("redirect_uri", "http://www.foo.com/");
 		form.put("response_type", "token");
 		form.put("scope", "read");
 		ResponseEntity<Void> response = new TestRestTemplate("user", "password")

--- a/tests/xml/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
+++ b/tests/xml/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
@@ -200,7 +200,7 @@ public abstract class AbstractAuthorizationCodeProviderTests extends AbstractInt
 
 		HttpHeaders headers = getAuthenticatedHeaders();
 
-		String authorizeUrl = getAuthorizeUrl("my-trusted-client", "http://anywhere.com", "read");
+		String authorizeUrl = getAuthorizeUrl("my-trusted-client", "https://anywhere.com", "read");
 		authorizeUrl = authorizeUrl + "&user_oauth_approval=true";
 		ResponseEntity<Void> response = http.postForStatus(authorizeUrl, headers,
 				new LinkedMultiValueMap<String, String>());


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://nowhere.com (200) with 12 occurrences could not be migrated:  
   ([https](https://nowhere.com) result AnnotatedConnectException).
* [ ] http://www.dubaiapartments.biz (200) with 1 occurrences could not be migrated:  
   ([https](https://www.dubaiapartments.biz) result NativeIoException).
* [ ] http://www.dubaiapartments.biz/ (200) with 4 occurrences could not be migrated:  
   ([https](https://www.dubaiapartments.biz/) result NativeIoException).
* [ ] http://www.faqs.org/qa/rfcc-1940.html (200) with 4 occurrences could not be migrated:  
   ([https](https://www.faqs.org/qa/rfcc-1940.html) result AnnotatedConnectException).
* [ ] http://www.faqs.org/rfcs/rfc3548.html (200) with 4 occurrences could not be migrated:  
   ([https](https://www.faqs.org/rfcs/rfc3548.html) result AnnotatedConnectException).
* [ ] http://www.pyserwebdesigns.com (200) with 4 occurrences could not be migrated:  
   ([https](https://www.pyserwebdesigns.com) result SSLHandshakeException).
* [ ] http://foo.com (301) with 3 occurrences could not be migrated:  
   ([https](https://foo.com) result SSLHandshakeException).
* [ ] http://2anywhere.com/foo (302) with 1 occurrences could not be migrated:  
   ([https](https://2anywhere.com/foo) result ConnectTimeoutException).
* [ ] http://iharder.net/base64 (303) with 2 occurrences could not be migrated:  
   ([https](https://iharder.net/base64) result AnnotatedConnectException).
* [ ] http://somewhere.com (403) with 9 occurrences could not be migrated:  
   ([https](https://somewhere.com) result ConnectTimeoutException).
* [ ] http://my.host.com/my/context (404) with 1 occurrences could not be migrated:  
   ([https](https://my.host.com/my/context) result ReadTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.callistaenterprise.se (301) with 3 occurrences migrated to:  
  https://callistaenterprise.se/ ([https](https://www.callistaenterprise.se) result SSLHandshakeException).
* [ ] http://my.hosting.com/my/context?with=some&query=parameter (301) with 1 occurrences migrated to:  
  https://my.hosting.com/my/context?with=some&query=parameter ([https](https://my.hosting.com/my/context?with=some&query=parameter) result SSLHandshakeException).
* [ ] http://my.hosting.com/my/context?with=some&query=parameter&oauth_token=mytoka&oauth_verifier=myvera (301) with 1 occurrences migrated to:  
  https://my.hosting.com/my/context?with=some&query=parameter&oauth_token=mytoka&oauth_verifier=myvera ([https](https://my.hosting.com/my/context?with=some&query=parameter&oauth_token=mytoka&oauth_verifier=myvera) result SSLHandshakeException).
* [ ] http://mycompany.com (302) with 1 occurrences migrated to:  
  https://secure.mycompany.com ([https](https://mycompany.com) result ConnectTimeoutException).
* [ ] http://tools.ietf.org/html/draft-ietf-oauth-v2 (301) with 3 occurrences migrated to:  
  https://tools.ietf.org/html/draft-ietf-oauth-v2 ([https](https://tools.ietf.org/html/draft-ietf-oauth-v2) result ReadTimeoutException).
* [ ] http://anywhere.com:90 (ConnectTimeoutException) with 5 occurrences migrated to:  
  https://anywhere.com:90 ([https](https://anywhere.com:90) result ConnectTimeoutException).
* [ ] http://anywhere.com:91 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://anywhere.com:91 ([https](https://anywhere.com:91) result ConnectTimeoutException).
* [ ] http://anywhere.com:91/foo (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://anywhere.com:91/foo ([https](https://anywhere.com:91/foo) result ConnectTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 13 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* [ ] http://2.anywhere.com/foo (UnknownHostException) with 1 occurrences migrated to:  
  https://2.anywhere.com/foo ([https](https://2.anywhere.com/foo) result UnknownHostException).
* [ ] http://anywhere.google.com (UnknownHostException) with 1 occurrences migrated to:  
  https://anywhere.google.com ([https](https://anywhere.google.com) result UnknownHostException).
* [ ] http://anywhere?t=a%3Db%26ep%3Dtest%2540test.me (UnknownHostException) with 1 occurrences migrated to:  
  https://anywhere?t=a%3Db%26ep%3Dtest%2540test.me ([https](https://anywhere?t=a%3Db%26ep%3Dtest%2540test.me) result UnknownHostException).
* [ ] http://anywhere?t=a%3Db%26ep%3Dtest%2540test.me&code=thecode (UnknownHostException) with 1 occurrences migrated to:  
  https://anywhere?t=a%3Db%26ep%3Dtest%2540test.me&code=thecode ([https](https://anywhere?t=a%3Db%26ep%3Dtest%2540test.me&code=thecode) result UnknownHostException).
* [ ] http://jira.codehaus.org/browse/OAUTHSS-37 (UnknownHostException) with 1 occurrences migrated to:  
  https://jira.codehaus.org/browse/OAUTHSS-37 ([https](https://jira.codehaus.org/browse/OAUTHSS-37) result UnknownHostException).
* [ ] http://my.company.com/scopes/read/ (UnknownHostException) with 1 occurrences migrated to:  
  https://my.company.com/scopes/read/ ([https](https://my.company.com/scopes/read/) result UnknownHostException).
* [ ] http://otheruserinfo@anywhere.com (UnknownHostException) with 1 occurrences migrated to:  
  https://otheruserinfo@anywhere.com ([https](https://otheruserinfo@anywhere.com) result UnknownHostException).
* [ ] http://photos.example.net (UnknownHostException) with 1 occurrences migrated to:  
  https://photos.example.net ([https](https://photos.example.net) result UnknownHostException).
* [ ] http://photos.example.net/photos (UnknownHostException) with 3 occurrences migrated to:  
  https://photos.example.net/photos ([https](https://photos.example.net/photos) result UnknownHostException).
* [ ] http://sp.example.com/ (UnknownHostException) with 4 occurrences migrated to:  
  https://sp.example.com/ ([https](https://sp.example.com/) result UnknownHostException).
* [ ] http://userinfo@anywhere.com (UnknownHostException) with 4 occurrences migrated to:  
  https://userinfo@anywhere.com ([https](https://userinfo@anywhere.com) result UnknownHostException).
* [ ] http://userinfo@anywhere.com/foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://userinfo@anywhere.com/foo/bar ([https](https://userinfo@anywhere.com/foo/bar) result UnknownHostException).
* [ ] http://www.naturaldesigngroup.co.uk (UnknownHostException) with 1 occurrences migrated to:  
  https://www.naturaldesigngroup.co.uk ([https](https://www.naturaldesigngroup.co.uk) result UnknownHostException).
* [ ] http://picasaweb.google.com/data (400) with 1 occurrences migrated to:  
  https://picasaweb.google.com/data ([https](https://picasaweb.google.com/data) result 400).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerContextFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerContextFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerContextFilter.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerProcessingFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerProcessingFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthConsumerProcessingFilter.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthRestTemplate.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthRestTemplate.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/OAuthRestTemplate.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/AccessTokenProcessingFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/AccessTokenProcessingFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/AccessTokenProcessingFilter.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ProtectedResourceProcessingFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ProtectedResourceProcessingFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ProtectedResourceProcessingFilter.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UnauthenticatedRequestTokenProcessingFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UnauthenticatedRequestTokenProcessingFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UnauthenticatedRequestTokenProcessingFilter.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UserAuthorizationProcessingFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UserAuthorizationProcessingFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/UserAuthorizationProcessingFilter.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/InMemoryCallbackServices.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/InMemoryCallbackServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/InMemoryCallbackServices.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/OAuthCallbackServices.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/OAuthCallbackServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/callback/OAuthCallbackServices.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/RandomValueInMemoryVerifierServices.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/RandomValueInMemoryVerifierServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/RandomValueInMemoryVerifierServices.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/BaseClientDetails.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/BaseClientDetails.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/BaseClientDetails.html) result 404).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/InMemoryClientDetailsService.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/InMemoryClientDetailsService.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/InMemoryClientDetailsService.html) result 404).
* [ ] http://example.com/authorize (404) with 5 occurrences migrated to:  
  https://example.com/authorize ([https](https://example.com/authorize) result 404).
* [ ] http://example.com/authorize?foo=bar (404) with 1 occurrences migrated to:  
  https://example.com/authorize?foo=bar ([https](https://example.com/authorize?foo=bar) result 404).
* [ ] http://example.com/is_root (404) with 1 occurrences migrated to:  
  https://example.com/is_root ([https](https://example.com/is_root) result 404).
* [ ] http://example.com/oauth2callback (404) with 1 occurrences migrated to:  
  https://example.com/oauth2callback ([https](https://example.com/oauth2callback) result 404).
* [ ] http://example.com/photos (404) with 1 occurrences migrated to:  
  https://example.com/photos ([https](https://example.com/photos) result 404).
* [ ] http://example.com/token (404) with 1 occurrences migrated to:  
  https://example.com/token ([https](https://example.com/token) result 404).
* [ ] http://my.host.com/my/context?oauth_token=mytok&oauth_verifier=myver (404) with 1 occurrences migrated to:  
  https://my.host.com/my/context?oauth_token=mytok&oauth_verifier=myver ([https](https://my.host.com/my/context?oauth_token=mytok&oauth_verifier=myver) result 404).
* [ ] http://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html (404) with 1 occurrences migrated to:  
  https://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html ([https](https://oauth.googlecode.com/svn/spec/ext/session/1.0/drafts/1/spec.html) result 404).
* [ ] http://shrub.appspot.com/maven.springframework.org/release/org/springframework/security/oauth/spring-security-oauth/ (404) with 1 occurrences migrated to:  
  https://shrub.appspot.com/maven.springframework.org/release/org/springframework/security/oauth/spring-security-oauth/ ([https](https://shrub.appspot.com/maven.springframework.org/release/org/springframework/security/oauth/spring-security-oauth/) result 404).
* [ ] http://myhost.com/callback (500) with 1 occurrences migrated to:  
  https://myhost.com/callback ([https](https://myhost.com/callback) result 500).
* [ ] http://myhost.com/resource?with=some&query=params&too (500) with 1 occurrences migrated to:  
  https://myhost.com/resource?with=some&query=params&too ([https](https://myhost.com/resource?with=some&query=params&too) result 500).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://autayeu.com/ with 1 occurrences migrated to:  
  https://autayeu.com/ ([https](https://autayeu.com/) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/BaseProtectedResourceDetails.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/BaseProtectedResourceDetails.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/BaseProtectedResourceDetails.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/InMemoryProtectedResourceDetailsService.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/InMemoryProtectedResourceDetailsService.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/InMemoryProtectedResourceDetailsService.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/ProtectedResourceDetailsService.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/ProtectedResourceDetailsService.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/ProtectedResourceDetailsService.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/HttpSessionBasedTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/OAuthConsumerTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/OAuthConsumerTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/consumer/token/OAuthConsumerTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/BaseConsumerDetails.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/BaseConsumerDetails.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/BaseConsumerDetails.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetails.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ConsumerDetailsService.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/ExtraTrustConsumerDetails.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/InMemoryConsumerDetailsService.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/InMemoryConsumerDetailsService.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/InMemoryConsumerDetailsService.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityConfig.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityConfig.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityConfig.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityVoter.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityVoter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/ConsumerSecurityVoter.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/package-summary.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/package-summary.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/attributes/package-summary.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/ExpiringTimestampNonceServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/ExpiringTimestampNonceServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/ExpiringTimestampNonceServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/InMemoryNonceServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/InMemoryNonceServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/InMemoryNonceServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/OAuthNonceServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/OAuthNonceServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/nonce/OAuthNonceServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/InMemoryProviderTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/InMemoryProviderTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/InMemoryProviderTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/OAuthProviderTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/OAuthProviderTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/OAuthProviderTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/RandomValueProviderTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/RandomValueProviderTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/token/RandomValueProviderTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/OAuthVerifierServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/OAuthVerifierServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth/provider/verifier/OAuthVerifierServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetails.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetails.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetails.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetailsService.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetailsService.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/ClientDetailsService.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationProcessingFilter.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationProcessingFilter.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/authentication/OAuth2AuthenticationProcessingFilter.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/endpoint/TokenEndpoint.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/AuthorizationServerTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/AuthorizationServerTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/AuthorizationServerTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/DefaultTokenServices.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/DefaultTokenServices.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/DefaultTokenServices.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/InMemoryTokenStore.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/InMemoryTokenStore.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/InMemoryTokenStore.html) result 200).
* [ ] http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.html ([https](https://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.html) result 200).
* [ ] http://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html (301) with 5 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/3.0.x/reference/el-access.html ([https](https://static.springsource.org/spring-security/site/docs/3.0.x/reference/el-access.html) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/3.2.5.RELEASE/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/3.2.5.RELEASE/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/3.2.5.RELEASE/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/el-access.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/el-access.html ([https](https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/el-access.html) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/ns-config.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/ns-config.html ([https](https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/ns-config.html) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html) result 200).
* [ ] http://github.com/spring-projects/spring-security-oauth with 5 occurrences migrated to:  
  https://github.com/spring-projects/spring-security-oauth ([https](https://github.com/spring-projects/spring-security-oauth) result 200).
* [ ] http://maven.apache.org/ with 1 occurrences migrated to:  
  https://maven.apache.org/ ([https](https://maven.apache.org/) result 200).
* [ ] http://myhost.com with 1 occurrences migrated to:  
  https://myhost.com ([https](https://myhost.com) result 200).
* [ ] http://oauth.net with 6 occurrences migrated to:  
  https://oauth.net ([https](https://oauth.net) result 200).
* [ ] http://gopivotal.com (302) with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://gopivotal.com) result 200).
* [ ] http://projects.spring.io/spring-security-oauth/docs/Home.html with 1 occurrences migrated to:  
  https://projects.spring.io/spring-security-oauth/docs/Home.html ([https](https://projects.spring.io/spring-security-oauth/docs/Home.html) result 200).
* [ ] http://projects.spring.io/spring-security/ with 4 occurrences migrated to:  
  https://projects.spring.io/spring-security/ ([https](https://projects.spring.io/spring-security/) result 200).
* [ ] http://repo1.maven.org/maven2/org/springframework/security/oauth/spring-security-oauth/ with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2/org/springframework/security/oauth/spring-security-oauth/ ([https](https://repo1.maven.org/maven2/org/springframework/security/oauth/spring-security-oauth/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-security+spring+oauth with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-security+spring+oauth ([https](https://stackoverflow.com/questions/tagged/spring-security+spring+oauth) result 200).
* [ ] http://tools.ietf.org/html/draft-ietf-oauth-v2-22 with 5 occurrences migrated to:  
  https://tools.ietf.org/html/draft-ietf-oauth-v2-22 ([https](https://tools.ietf.org/html/draft-ietf-oauth-v2-22) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.openwebdesign.org with 4 occurrences migrated to:  
  https://www.openwebdesign.org ([https](https://www.openwebdesign.org) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* [ ] http://www.springframework.org/schema/security/spring-security-oauth.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-oauth.xsd ([https](https://www.springframework.org/schema/security/spring-security-oauth.xsd) result 200).
* [ ] http://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd ([https](https://www.springframework.org/schema/security/spring-security-oauth2-1.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/security/spring-security-oauth2.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-oauth2.xsd ([https](https://www.springframework.org/schema/security/spring-security-oauth2.xsd) result 200).
* [ ] http://www.webcohesion.com with 2 occurrences migrated to:  
  https://www.webcohesion.com ([https](https://www.webcohesion.com) result 200).
* [ ] http://anywhere.com with 51 occurrences migrated to:  
  https://anywhere.com ([https](https://anywhere.com) result 301).
* [ ] http://anywhere.com/?p1&p2=v2 with 2 occurrences migrated to:  
  https://anywhere.com/?p1&p2=v2 ([https](https://anywhere.com/?p1&p2=v2) result 301).
* [ ] http://anywhere.com/?p1=v1 with 1 occurrences migrated to:  
  https://anywhere.com/?p1=v1 ([https](https://anywhere.com/?p1=v1) result 301).
* [ ] http://anywhere.com/?p1=v1&p2=v2 with 6 occurrences migrated to:  
  https://anywhere.com/?p1=v1&p2=v2 ([https](https://anywhere.com/?p1=v1&p2=v2) result 301).
* [ ] http://anywhere.com/?p1=v1&p2=v2&p3=v3 with 1 occurrences migrated to:  
  https://anywhere.com/?p1=v1&p2=v2&p3=v3 ([https](https://anywhere.com/?p1=v1&p2=v2&p3=v3) result 301).
* [ ] http://anywhere.com/?p1=v1&p2=v3 with 1 occurrences migrated to:  
  https://anywhere.com/?p1=v1&p2=v3 ([https](https://anywhere.com/?p1=v1&p2=v3) result 301).
* [ ] http://anywhere.com/?p1=v11&p1=v12 with 2 occurrences migrated to:  
  https://anywhere.com/?p1=v11&p1=v12 ([https](https://anywhere.com/?p1=v11&p1=v12) result 301).
* [ ] http://anywhere.com/?p2=v2 with 1 occurrences migrated to:  
  https://anywhere.com/?p2=v2 ([https](https://anywhere.com/?p2=v2) result 301).
* [ ] http://anywhere.com/?p2=v2&p1=v1 with 1 occurrences migrated to:  
  https://anywhere.com/?p2=v2&p1=v1 ([https](https://anywhere.com/?p2=v2&p1=v1) result 301).
* [ ] http://anywhere.com/?p2=v2&p3=v3 with 1 occurrences migrated to:  
  https://anywhere.com/?p2=v2&p3=v3 ([https](https://anywhere.com/?p2=v2&p3=v3) result 301).
* [ ] http://anywhere.com/foo with 5 occurrences migrated to:  
  https://anywhere.com/foo ([https](https://anywhere.com/foo) result 301).
* [ ] http://anywhere.com/foo/%2E%2E with 1 occurrences migrated to:  
  https://anywhere.com/foo/%2E%2E ([https](https://anywhere.com/foo/%2E%2E) result 301).
* [ ] http://anywhere.com/foo/../bar with 1 occurrences migrated to:  
  https://anywhere.com/foo/../bar ([https](https://anywhere.com/foo/../bar) result 301).
* [ ] http://anywhere.com/myendpoint with 4 occurrences migrated to:  
  https://anywhere.com/myendpoint ([https](https://anywhere.com/myendpoint) result 301).
* [ ] http://anywhere.com/path?foo=b%20%3D&bar=f%20 with 2 occurrences migrated to:  
  https://anywhere.com/path?foo=b%20%3D&bar=f%20 ([https](https://anywhere.com/path?foo=b%20%3D&bar=f%20) result 301).
* [ ] http://anywhere.com?code=thecode with 1 occurrences migrated to:  
  https://anywhere.com?code=thecode ([https](https://anywhere.com?code=thecode) result 301).
* [ ] http://anywhere.com?code=thecode&state=%20%3D?s with 1 occurrences migrated to:  
  https://anywhere.com?code=thecode&state=%20%3D?s ([https](https://anywhere.com?code=thecode&state=%20%3D?s) result 301).
* [ ] http://anywhere.com?foo=b with 1 occurrences migrated to:  
  https://anywhere.com?foo=b ([https](https://anywhere.com?foo=b) result 301).
* [ ] http://anywhere.com?foo=b%20=&bar=f%20 with 1 occurrences migrated to:  
  https://anywhere.com?foo=b%20=&bar=f%20 ([https](https://anywhere.com?foo=b%20=&bar=f%20) result 301).
* [ ] http://anywhere.com?foo=bar with 2 occurrences migrated to:  
  https://anywhere.com?foo=bar ([https](https://anywhere.com?foo=bar) result 301).
* [ ] http://anywhere.com?foo=bar&bar=foo with 1 occurrences migrated to:  
  https://anywhere.com?foo=bar&bar=foo ([https](https://anywhere.com?foo=bar&bar=foo) result 301).
* [ ] http://anywhere.com?foo=bar&bar=foo&code=thecode with 1 occurrences migrated to:  
  https://anywhere.com?foo=bar&bar=foo&code=thecode ([https](https://anywhere.com?foo=bar&bar=foo&code=thecode) result 301).
* [ ] http://anywhere.com?foo=bar&code=thecode with 1 occurrences migrated to:  
  https://anywhere.com?foo=bar&code=thecode ([https](https://anywhere.com?foo=bar&code=thecode) result 301).
* [ ] http://anywhere.watchdox.com with 1 occurrences migrated to:  
  https://anywhere.watchdox.com ([https](https://anywhere.watchdox.com) result 301).
* [ ] http://code.google.com/apis/accounts/docs/OAuth_ref.html with 1 occurrences migrated to:  
  https://code.google.com/apis/accounts/docs/OAuth_ref.html ([https](https://code.google.com/apis/accounts/docs/OAuth_ref.html) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://developers.facebook.com/docs/authentication with 1 occurrences migrated to:  
  https://developers.facebook.com/docs/authentication ([https](https://developers.facebook.com/docs/authentication) result 301).
* [ ] http://download.eclipse.org/technology/m2e/releases with 1 occurrences migrated to:  
  https://download.eclipse.org/technology/m2e/releases ([https](https://download.eclipse.org/technology/m2e/releases) result 301).
* [ ] http://forum.springsource.org/forumdisplay.php?f=79 (301) with 2 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=79 ([https](https://forum.springsource.org/forumdisplay.php?f=79) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://springframework.org/ with 1 occurrences migrated to:  
  https://springframework.org/ ([https](https://springframework.org/) result 301).
* [ ] http://watchdox.com with 2 occurrences migrated to:  
  https://watchdox.com ([https](https://watchdox.com) result 301).
* [ ] http://www.opensocial.org/ with 1 occurrences migrated to:  
  https://www.opensocial.org/ ([https](https://www.opensocial.org/) result 301).
* [ ] http://www.planetphotoshop.com with 1 occurrences migrated to:  
  https://www.planetphotoshop.com ([https](https://www.planetphotoshop.com) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* [ ] http://maven.springframework.org/snapshot with 1 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* [ ] http://search.yahoo.com/mrss/ with 1 occurrences migrated to:  
  https://search.yahoo.com/mrss/ ([https](https://search.yahoo.com/mrss/) result 302).
* [ ] http://www.hueniverse.com/hueniverse/2007/10/beginners-gui-1.html with 1 occurrences migrated to:  
  https://www.hueniverse.com/hueniverse/2007/10/beginners-gui-1.html ([https](https://www.hueniverse.com/hueniverse/2007/10/beginners-gui-1.html) result 302).
* [ ] http://www.springsource.org/node/feed with 1 occurrences migrated to:  
  https://www.springsource.org/node/feed ([https](https://www.springsource.org/node/feed) result 302).

# Ignored
These URLs were intentionally ignored.

* http://anywhere with 59 occurrences
* http://anywhere?key=value with 29 occurrences
* http://foo with 2 occurrences
* http://foo/bar with 2 occurrences
* http://java.sun.com/jsp/jstl/core with 8 occurrences
* http://java.sun.com/jstl/core with 10 occurrences
* http://localhost with 3 occurrences
* http://localhost/login with 2 occurrences
* http://localhost/oauth/authorize with 4 occurrences
* http://localhost/oauth/token with 10 occurrences
* http://localhost:8080 with 7 occurrences
* http://localhost:8080,http://localhost:9090 with 1 occurrences
* http://localhost:8080/oauth/authorize with 3 occurrences
* http://localhost:8080/oauth/token with 3 occurrences
* http://localhost:8080/sparklr with 2 occurrences
* http://localhost:8080/sparklr/ with 1 occurrences
* http://localhost:8080/sparklr/photos/%s with 1 occurrences
* http://localhost:8080/sparklr/photos?format=xml with 1 occurrences
* http://localhost:8080/sparklr2/ with 1 occurrences
* http://localhost:8080/sparklr2/oauth/authorize with 2 occurrences
* http://localhost:8080/sparklr2/oauth/token with 1 occurrences
* http://localhost:8080/sparklr2/photos/%s with 1 occurrences
* http://localhost:8080/sparklr2/photos/trusted/message with 1 occurrences
* http://localhost:8080/sparklr2/photos?format=json with 1 occurrences
* http://localhost:8080/sparklr2/photos?format=xml with 1 occurrences
* http://localhost:8080/tonr with 2 occurrences
* http://localhost:8080/tonr2 with 3 occurrences
* http://localhost:8080/tonr2/ with 2 occurrences
* http://localhost:8080/tonr2/demo.html with 1 occurrences
* http://localhost:8080/tonr2/sparklr/redirect with 1 occurrences
* http://localhost:8081/client with 2 occurrences
* http://localhost:8888/tonr/ with 1 occurrences
* http://localhost:9090 with 1 occurrences
* http://localhost?foo=bar with 3 occurrences
* http://localhost?foo=bar%20spam with 1 occurrences
* http://localhost?foo=bar+spam with 1 occurrences
* http://myserver/resource with 1 occurrences
* http://nowhere with 6 occurrences
* http://nowhere/token with 1 occurrences
* http://user-auth/context?with=some&queryParams with 2 occurrences
* http://user-auth/context?with=some&queryParams&oauth_token=mytoken with 1 occurrences
* http://user-auth/context?with=some&queryParams&oauth_token=mytoken&oauth_callback=urn%3A%2F%2Fcallback%3Fwith%3Dsome%26query%3Dparams with 1 occurrences
* http://www.springframework.org/schema/beans with 8 occurrences
* http://www.springframework.org/schema/security/ with 1 occurrences
* http://www.springframework.org/schema/security/oauth with 4 occurrences
* http://www.springframework.org/schema/security/oauth2 with 7 occurrences
* http://www.springframework.org/security/tags with 15 occurrences
* http://www.w3.org/1999/xhtml with 13 occurrences
* http://www.w3.org/2001/XMLSchema with 3 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences