### PR TITLE
Add volatile keyword for double check locking

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/OAuth2AccessTokenSupport.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/OAuth2AccessTokenSupport.java
@@ -49,7 +49,7 @@ public abstract class OAuth2AccessTokenSupport {
 
 	private static final FormHttpMessageConverter FORM_MESSAGE_CONVERTER = new FormHttpMessageConverter();
 
-	private RestOperations restTemplate;
+	private volatile RestOperations restTemplate;
 
 	private List<HttpMessageConverter<?>> messageConverters;
 


### PR DESCRIPTION
This PR provides additional volatile keyword in order to prevent potential instructions reordering. For more info see: http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html

