### PR TITLE
Fix reuse refresh token flow

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -168,16 +168,17 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 
 		authentication = createRefreshedAuthentication(authentication, tokenRequest);
 
+		tokenStore.removeRefreshToken(refreshToken);
+
 		if (!reuseRefreshToken) {
-			tokenStore.removeRefreshToken(refreshToken);
 			refreshToken = createRefreshToken(authentication);
 		}
 
 		OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken);
 		tokenStore.storeAccessToken(accessToken, authentication);
-		if (!reuseRefreshToken) {
-			tokenStore.storeRefreshToken(accessToken.getRefreshToken(), authentication);
-		}
+
+		tokenStore.storeRefreshToken(accessToken.getRefreshToken(), authentication);
+
 		return accessToken;
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJwtTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesWithJwtTests.java
@@ -1,8 +1,5 @@
 package org.springframework.security.oauth2.provider.token;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -10,12 +7,16 @@ import org.junit.Test;
 import org.springframework.security.jwt.JwtHelper;
 import org.springframework.security.oauth2.common.ExpiringOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.common.util.JsonParser;
 import org.springframework.security.oauth2.common.util.JsonParserFactory;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.TokenRequest;
+import org.springframework.security.oauth2.provider.token.store.InMemoryTokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Ryan Heaton
@@ -61,6 +62,47 @@ public class DefaultTokenServicesWithJwtTests extends AbstractDefaultTokenServic
 				refreshTokenInfo.get(AccessTokenConverter.ATI));
 		assertNotSame("Refresh token re-used", expectedExpiringRefreshToken.getValue(),
 				refreshedAccessToken.getRefreshToken().getValue());
+	}
+
+	@Test
+	public void testReusedRefreshedTokenIsStored() throws Exception {
+
+		InMemoryTokenStore tokenStore = new InMemoryTokenStore();
+
+		getTokenServices().setSupportRefreshToken(true);
+		getTokenServices().setReuseRefreshToken(true);
+		getTokenServices().setTokenStore(tokenStore);
+
+		OAuth2Authentication authentication = createAuthentication();
+
+		OAuth2AccessToken initialToken = getTokenServices().createAccessToken(
+				authentication);
+		ExpiringOAuth2RefreshToken expectedExpiringRefreshToken = (ExpiringOAuth2RefreshToken) initialToken
+				.getRefreshToken();
+
+		OAuth2AccessToken testStoredAccessToken = tokenStore.readAccessToken(initialToken.getValue());
+		assertNotNull("Access token was not stored", testStoredAccessToken);
+		assertNotNull("Access token was not stored", testStoredAccessToken.getValue());
+
+		OAuth2RefreshToken testStoredRefreshAccessToken = tokenStore.readRefreshToken(expectedExpiringRefreshToken.getValue());
+		assertNotNull("Refresh token was not stored", testStoredRefreshAccessToken);
+		assertNotNull("Refresh token was not stored", testStoredRefreshAccessToken.getValue());
+
+		TokenRequest tokenRequest = new TokenRequest(Collections.singletonMap(
+				"client_id", "id"), "id", null, null);
+
+		OAuth2AccessToken refreshedAccessToken = getTokenServices().refreshAccessToken(
+				expectedExpiringRefreshToken.getValue(), tokenRequest);
+		ExpiringOAuth2RefreshToken refreshedExpectedExpiringRefreshToken = (ExpiringOAuth2RefreshToken) refreshedAccessToken
+				.getRefreshToken();
+
+		OAuth2AccessToken testStoredRefreshedAccessToken = tokenStore.readAccessToken(refreshedAccessToken.getValue());
+		assertNotNull("Refreshed access token was not stored", testStoredRefreshedAccessToken);
+		assertNotNull("Refreshed access token was not stored", testStoredRefreshedAccessToken.getValue());
+
+		OAuth2RefreshToken testStoredRefreshedRefreshAccessToken = tokenStore.readRefreshToken(refreshedExpectedExpiringRefreshToken.getValue());
+		assertNotNull("Refreshed refresh token was not stored", testStoredRefreshedRefreshAccessToken);
+		assertNotNull("Refreshed refresh token was not stored", testStoredRefreshedRefreshAccessToken.getValue());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes: #1193 #1109 

This update fixes an issue with the refresh token flow when the 'reuseRefreshToken' flag is true.

Description of issue:
If the 'reuseRefreshToken' flag is true, and 'supportRefreshToken' flag is true, when refreshing the access token the refresh token changes also(it updates the 'ati' property with the id of the new access token). This new refresh token is referenced against the access token when stored, but the new refresh token itself is not stored, and the original refresh token not being linked to an existing access token. This results in refresh tokens being single use, and being orphaned after use. More information on the issue present in #1193 

Fix:
The fix removes the existing refresh token, and stores the new refresh token. 