### PR TITLE
Remove use of deprecated APIs in samples

### DIFF
--- a/samples/oauth/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
@@ -1,5 +1,5 @@
 <%@ page import="org.springframework.security.core.AuthenticationException" %>
-<%@ page import="org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter" %>
+<%@ page import="org.springframework.security.web.WebAttributes" %>
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -20,12 +20,12 @@
       <div class="error">
         <h2>Woops!</h2>
 
-        <p>Access could not be granted. (<%= ((AuthenticationException) session.getAttribute(AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY)).getMessage() %>)</p>
+        <p>Access could not be granted. (<%= ((AuthenticationException) session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION)).getMessage() %>)</p>
       </div>
     </c:if>
     <c:remove scope="session" var="SPRING_SECURITY_LAST_EXCEPTION"/>
 
-    <authz:authorize ifAllGranted="ROLE_USER">
+    <authz:authorize access="hasRole('ROLE_USER')">
       <h2>Please Confirm</h2>
 
       <p>You hereby authorize "<c:out value="${consumer.consumerName}"/>" to access the following resource:</p>

--- a/samples/oauth/sparklr/src/main/webapp/index.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/index.jsp
@@ -7,7 +7,7 @@
   <title>Sparklr</title>
   <link type="text/css" rel="stylesheet" href="<c:url value="/style.css"/>"/>
 
-  <authz:authorize ifAllGranted="ROLE_USER">
+  <authz:authorize access="hasRole('ROLE_USER')">
     <script type='text/javascript'>
       function pictureDisplay(json) {
         for (var i = 0; i < json.photos.length; i++) {
@@ -28,7 +28,7 @@
     <p>This is a great site to store and view your photos. Unfortunately, we don't have any services
     for printing your photos.  For that, you'll have to go to <a href="http://localhost:8888/tonr/">Tonr.com</a>.</p>
 
-    <authz:authorize ifNotGranted="ROLE_USER">
+    <authz:authorize access="!hasRole('ROLE_USER')">
       <h2>Login</h2>
       <form action="<c:url value="/login.do"/>" method="post">
         <p><label>Username: <input type='text' name='j_username' value="marissa"></label></p>
@@ -37,7 +37,7 @@
         <p><input name="login" value="Login" type="submit"></p>
       </form>
     </authz:authorize>
-    <authz:authorize ifAllGranted="ROLE_USER">
+    <authz:authorize access="hasRole('ROLE_USER')">
       <div style="text-align: center"><form action="<c:url value="/logout.do"/>"><input type="submit" value="Logout"></form></div>
       
       <h2>Your Photos</h2>

--- a/samples/oauth/sparklr/src/main/webapp/login.jsp
+++ b/samples/oauth/sparklr/src/main/webapp/login.jsp
@@ -1,8 +1,8 @@
 <%@ page import="org.springframework.security.core.AuthenticationException" %>
-<%@ page import="org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter" %>
+<%@ page import="org.springframework.security.web.WebAttributes" %>
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<authz:authorize ifAllGranted="ROLE_USER">
+<authz:authorize access="hasRole('ROLE_USER')">
   <c:redirect url="index.jsp"/>
 </authz:authorize>
 
@@ -23,12 +23,12 @@
       <div class="error">
 		<h2>Woops!</h2>
 
-      	<p>Your login attempt was not successful. (<%= ((AuthenticationException) session.getAttribute(AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY)).getMessage() %>)</p>
+      	<p>Your login attempt was not successful. (<%= ((AuthenticationException) session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION)).getMessage() %>)</p>
       </div>
     </c:if>
     <c:remove scope="session" var="SPRING_SECURITY_LAST_EXCEPTION"/>
 
-    <authz:authorize ifNotGranted="ROLE_USER">
+    <authz:authorize access="!hasRole('ROLE_USER')">
       <h2>Login</h2>
 
       <p>We've got a grand total of 2 users: marissa and paul. Go ahead and log in. Marissa's password is "koala" and Paul's password is "emu".</p>

--- a/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/picasa.jsp
+++ b/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/picasa.jsp
@@ -11,7 +11,7 @@
 
     <ul id="mainlinks">
       <li><a href="<c:url value="/index.jsp"/>">home</a></li>
-      <authz:authorize ifNotGranted="ROLE_USER">
+      <authz:authorize access="!hasRole('ROLE_USER')">
         <li><a href="<c:url value="/login.jsp"/>">login</a></li>
       </authz:authorize>
       <li><a href="<c:url value="/sparklr/photos"/>">sparklr pics</a></li>

--- a/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
+++ b/samples/oauth/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
@@ -11,7 +11,7 @@
 
     <ul id="mainlinks">
       <li><a href="<c:url value="/index.jsp"/>">home</a></li>
-      <authz:authorize ifNotGranted="ROLE_USER">
+      <authz:authorize access="!hasRole('ROLE_USER')">
         <li><a href="<c:url value="/login.jsp"/>">login</a></li>
       </authz:authorize>
       <li><a href="<c:url value="/sparklr/photos"/>" class="selected">sparklr pics</a></li>

--- a/samples/oauth/tonr/src/main/webapp/index.jsp
+++ b/samples/oauth/tonr/src/main/webapp/index.jsp
@@ -11,7 +11,7 @@
 
     <ul id="mainlinks">
       <li><a href="<c:url value="/index.jsp"/>" class="selected">home</a></li>
-      <authz:authorize ifNotGranted="ROLE_USER">
+      <authz:authorize access="!hasRole('ROLE_USER')">
         <li><a href="<c:url value="/login.jsp"/>">login</a></li>
       </authz:authorize>
       <li><a href="<c:url value="/sparklr/photos"/>">sparklr pics</a></li>
@@ -27,10 +27,10 @@
 
     <p>Tonr.com has only two users: "marissa" and "sam".  The password for "marissa" is password is "wombat" and for "sam" is password is "kangaroo".</p>
 
-    <authz:authorize ifNotGranted="ROLE_USER">
+    <authz:authorize access="!hasRole('ROLE_USER')">
       <p><a href="<c:url value="login.jsp"/>">Login to Tonr</a></p>
     </authz:authorize>
-    <authz:authorize ifAllGranted="ROLE_USER">
+    <authz:authorize access="hasRole('ROLE_USER')">
       <p><a href="<c:url value="/sparklr/photos"/>">View my Sparklr photos</a></p>
     </authz:authorize>
 

--- a/samples/oauth/tonr/src/main/webapp/login.jsp
+++ b/samples/oauth/tonr/src/main/webapp/login.jsp
@@ -1,8 +1,8 @@
-<%@ page import="org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter" %>
+<%@ page import="org.springframework.security.web.WebAttributes" %>
 <%@ page import="org.springframework.security.core.AuthenticationException" %>
 <%@ taglib prefix="authz" uri="http://www.springframework.org/security/tags" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
-<authz:authorize ifAllGranted="ROLE_USER">
+<authz:authorize access="hasRole('ROLE_USER')">
   <c:redirect url="index.jsp"/>
 </authz:authorize>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -25,11 +25,11 @@
     <c:if test="${!empty sessionScope.SPRING_SECURITY_LAST_EXCEPTION}">
       <h1>Woops!</h1>
 
-      <p class="error">Your login attempt was not successful. (<%= ((AuthenticationException) session.getAttribute(AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY)).getMessage() %>)</p>
+      <p class="error">Your login attempt was not successful. (<%= ((AuthenticationException) session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION)).getMessage() %>)</p>
     </c:if>
     <c:remove scope="session" var="SPRING_SECURITY_LAST_EXCEPTION"/>
 
-    <authz:authorize ifNotGranted="ROLE_USER">
+    <authz:authorize access="!hasRole('ROLE_USER')">
       <h1>Login</h1>
 
       <p>Tonr.com has only two users: "marissa" and "sam".  The password for "marissa" is password is "wombat" and for "sam" is password is "kangaroo".</p>

--- a/samples/oauth/tonr/src/main/webapp/oauth_error.jsp
+++ b/samples/oauth/tonr/src/main/webapp/oauth_error.jsp
@@ -14,7 +14,7 @@
 
     <ul id="mainlinks">
         <li><a href="<c:url value="/index.jsp"/>">home</a></li>
-        <authz:authorize ifNotGranted="ROLE_USER">
+        <authz:authorize access="!hasRole('ROLE_USER')">
             <li><a href="<c:url value="/login.jsp"/>">login</a></li>
         </authz:authorize>
         <li><a href="<c:url value="/sparklr/photos"/>">sparklr pics</a></li>

--- a/samples/oauth2/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
+++ b/samples/oauth2/sparklr/src/main/webapp/WEB-INF/jsp/access_confirmation.jsp
@@ -1,7 +1,7 @@
 <%@ page
 	import="org.springframework.security.core.AuthenticationException"%>
 <%@ page
-	import="org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter"%>
+    import="org.springframework.security.web.WebAttributes" %>
 <%@ page
 	import="org.springframework.security.oauth2.common.exceptions.UnapprovedClientAuthenticationException"%>
 <%@ taglib prefix="authz"
@@ -27,16 +27,16 @@
 		<h1>Sparklr</h1>
 
 		<%
-			if (session.getAttribute(AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY) != null
+			if (session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION) != null
 					&& !(session
-							.getAttribute(AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY) instanceof UnapprovedClientAuthenticationException)) {
+							.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION) instanceof UnapprovedClientAuthenticationException)) {
 		%>
 		<div class="error">
 			<h2>Woops!</h2>
 
 			<p>
 				Access could not be granted. (<%=((AuthenticationException) session
-						.getAttribute(AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY))
+						.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION))
 						.getMessage()%>)
 			</p>
 		</div>
@@ -45,7 +45,7 @@
 		%>
 		<c:remove scope="session" var="SPRING_SECURITY_LAST_EXCEPTION" />
 
-		<authz:authorize ifAllGranted="ROLE_USER">
+		<authz:authorize access="hasRole('ROLE_USER')">
 			<h2>Please Confirm</h2>
 
 			<p>

--- a/samples/oauth2/sparklr/src/main/webapp/index.jsp
+++ b/samples/oauth2/sparklr/src/main/webapp/index.jsp
@@ -26,7 +26,7 @@
 			Unfortunately, we don't have any services for printing your photos.
 			For that, you'll have to go to Tonr.</p>
 
-		<authz:authorize ifAllGranted="ROLE_USER">
+		<authz:authorize access="hasRole('ROLE_USER')">
 			<div class="form-horizontal">
 				<form action="<c:url value="/logout"/>" role="form" method="post">
 					<input type="hidden" name="${_csrf.parameterName}"

--- a/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/facebook.jsp
+++ b/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/facebook.jsp
@@ -30,7 +30,7 @@
 		<div class="navbar-collapse collapse">
 			<ul class="nav navbar-nav">
 				<li><a href="${base}index.jsp">home</a></li>
-				<authz:authorize ifNotGranted="ROLE_USER">
+				<authz:authorize access="!hasRole('ROLE_USER')">
 					<li><a href="${base}login.jsp">login</a></li>
 				</authz:authorize>
 				<li><a href="${base}sparklr/photos">sparklr pics</a></li>

--- a/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
+++ b/samples/oauth2/tonr/src/main/webapp/WEB-INF/jsp/sparklr.jsp
@@ -30,7 +30,7 @@
 		<div class="navbar-collapse collapse">
 			<ul class="nav navbar-nav">
 				<li><a href="${base}index.jsp">home</a></li>
-				<authz:authorize ifNotGranted="ROLE_USER">
+				<authz:authorize access="!hasRole('ROLE_USER')">
 					<li><a href="${base}login.jsp">login</a></li>
 				</authz:authorize>
 				<li><a href="${base}sparklr/photos" class="selected">sparklr

--- a/samples/oauth2/tonr/src/main/webapp/index.jsp
+++ b/samples/oauth2/tonr/src/main/webapp/index.jsp
@@ -30,7 +30,7 @@
 		<div class="navbar-collapse collapse">
 			<ul class="nav navbar-nav">
 				<li><a href="${base}index.jsp" class="selected">home</a></li>
-				<authz:authorize ifNotGranted="ROLE_USER">
+				<authz:authorize access="!hasRole('ROLE_USER')">
 					<li><a href="${base}login.jsp">login</a></li>
 				</authz:authorize>
 				<li><a href="${base}sparklr/photos">sparklr pics</a></li>
@@ -55,12 +55,12 @@
 			for "marissa" is password is "wombat" and for "sam" is password is
 			"kangaroo".</p>
 
-		<authz:authorize ifNotGranted="ROLE_USER">
+		<authz:authorize access="!hasRole('ROLE_USER')">
 			<p>
 				<a href="<c:url value="login.jsp"/>">Login to Tonr</a>
 			</p>
 		</authz:authorize>
-		<authz:authorize ifAllGranted="ROLE_USER">
+		<authz:authorize access="hasRole('ROLE_USER')">
 			<p>
 				<a href="<c:url value="/sparklr/photos"/>">View my Sparklr
 					photos</a>


### PR DESCRIPTION
I wanted to play with the sample application but looks like they don't work:

* Fixed #1672 by replacing `ifAllGranted="..."` with `access="hasRole(...)"`
* `AbstractAuthenticationProcessingFilter.SPRING_SECURITY_LAST_EXCEPTION_KEY` has been [deprecated](https://docs.spring.io/spring-security/site/docs/3.1.x/apidocs/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.html#SPRING_SECURITY_LAST_EXCEPTION_KEY), replaced it with `WebAttributes.AUTHENTICATION_EXCEPTION`.