### PR TITLE
Add support for custom user claim name

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
@@ -49,6 +49,11 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 		this.userDetailsService = userDetailsService;
 	}
 
+	/**
+	 * Set the name of the user claim to use when extracting an {@link Authentication} from the incoming map
+	 * or when converting an {@link Authentication} to a map.
+	 * @param claimName the claim name to use (default {@link UserAuthenticationConverter#USERNAME})
+	 */
 	public void setUserClaimName(String claimName) {
 		this.userClaimName = claimName;
 	}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverter.java
@@ -38,6 +38,8 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 
 	private UserDetailsService userDetailsService;
 
+	private String userClaimName = USERNAME;
+
 	/**
 	 * Optional {@link UserDetailsService} to use when extracting an {@link Authentication} from the incoming map.
 	 * 
@@ -45,6 +47,10 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 	 */
 	public void setUserDetailsService(UserDetailsService userDetailsService) {
 		this.userDetailsService = userDetailsService;
+	}
+
+	public void setUserClaimName(String claimName) {
+		this.userClaimName = claimName;
 	}
 
 	/**
@@ -61,7 +67,7 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 
 	public Map<String, ?> convertUserAuthentication(Authentication authentication) {
 		Map<String, Object> response = new LinkedHashMap<String, Object>();
-		response.put(USERNAME, authentication.getName());
+		response.put(userClaimName, authentication.getName());
 		if (authentication.getAuthorities() != null && !authentication.getAuthorities().isEmpty()) {
 			response.put(AUTHORITIES, AuthorityUtils.authorityListToSet(authentication.getAuthorities()));
 		}
@@ -69,11 +75,11 @@ public class DefaultUserAuthenticationConverter implements UserAuthenticationCon
 	}
 
 	public Authentication extractAuthentication(Map<String, ?> map) {
-		if (map.containsKey(USERNAME)) {
-			Object principal = map.get(USERNAME);
+		if (map.containsKey(userClaimName)) {
+			Object principal = map.get(userClaimName);
 			Collection<? extends GrantedAuthority> authorities = getAuthorities(map);
 			if (userDetailsService != null) {
-				UserDetails user = userDetailsService.loadUserByUsername((String) map.get(USERNAME));
+				UserDetails user = userDetailsService.loadUserByUsername((String) map.get(userClaimName));
 				authorities = user.getAuthorities();
 				principal = user;
 			}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultUserAuthenticationConverterTests.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.User;
@@ -58,5 +59,51 @@ public class DefaultUserAuthenticationConverterTests {
 		Authentication authentication = converter.extractAuthentication(map);
 
 		assertEquals("ROLE_SPAM", authentication.getAuthorities().iterator().next().toString());
+	}
+
+	@Test
+	public void shouldExtractWithDefaultUsernameClaimWhenNotSet() throws Exception {
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(UserAuthenticationConverter.USERNAME, "test_user");
+
+		Authentication authentication = converter.extractAuthentication(map);
+
+		assertEquals("test_user", authentication.getPrincipal());
+	}
+
+	@Test
+	public void shouldConvertUserWithDefaultUsernameClaimWhenNotSet() throws Exception {
+		Authentication authentication = new UsernamePasswordAuthenticationToken("test_user", "");
+
+		Map<String, ?> map = converter.convertUserAuthentication(authentication);
+
+		assertEquals("test_user", map.get(UserAuthenticationConverter.USERNAME));
+	}
+
+	@Test
+	public void shouldExtractWithCustomUsernameClaimWhenSet() throws Exception {
+		String customUserClaim = "custom_user_name";
+		DefaultUserAuthenticationConverter converter = new DefaultUserAuthenticationConverter();
+		converter.setUserClaimName(customUserClaim);
+
+		Map<String, Object> map = new HashMap<String, Object>();
+		map.put(customUserClaim, "test_user");
+
+		Authentication authentication = converter.extractAuthentication(map);
+
+		assertEquals("test_user", authentication.getPrincipal());
+	}
+
+	@Test
+	public void shouldConvertUserWithCustomUsernameClaimWhenSet() throws Exception {
+		String customUserClaim = "custom_user_name";
+		DefaultUserAuthenticationConverter converter = new DefaultUserAuthenticationConverter();
+		converter.setUserClaimName(customUserClaim);
+
+		Authentication authentication = new UsernamePasswordAuthenticationToken("test_user", "");
+
+		Map<String, ?> map = converter.convertUserAuthentication(authentication);
+
+		assertEquals("test_user", map.get(customUserClaim));
 	}
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

This adds support for setting a custom user claim name. The default remains `user_name`.
