### PR TITLE
Issue #1416: Token refresh with empty scopes

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/request/DefaultOAuth2RequestValidator.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/request/DefaultOAuth2RequestValidator.java
@@ -17,7 +17,13 @@ import org.springframework.security.oauth2.provider.TokenRequest;
 public class DefaultOAuth2RequestValidator implements OAuth2RequestValidator {
 
 	public void validateScope(AuthorizationRequest authorizationRequest, ClientDetails client) throws InvalidScopeException {
-		validateScope(authorizationRequest.getScope(), client.getScope());
+		Set<String> requestScopes = authorizationRequest.getScope();
+
+		validateScope(requestScopes, client.getScope());
+
+		if (requestScopes.isEmpty()) {
+			throw new InvalidScopeException("Empty scope (either the client or the user is not allowed the requested scopes)");
+		}
 	}
 
 	public void validateScope(TokenRequest tokenRequest, ClientDetails client) throws InvalidScopeException {
@@ -32,10 +38,6 @@ public class DefaultOAuth2RequestValidator implements OAuth2RequestValidator {
 					throw new InvalidScopeException("Invalid scope: " + scope, clientScopes);
 				}
 			}
-		}
-		
-		if (requestScopes.isEmpty()) {
-			throw new InvalidScopeException("Empty scope (either the client or the user is not allowed the requested scopes)");
 		}
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/request/DefaultOAuth2RequestValidatorTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/request/DefaultOAuth2RequestValidatorTests.java
@@ -54,26 +54,49 @@ public class DefaultOAuth2RequestValidatorTests {
 		params.put("scope", "foo");
 	}
 
-	@Test(expected=InvalidScopeException.class)
-	public void testNotPermittedForEmpty() {
+	@Test
+	public void testPermittedForAuthorizationAndValidScope() {
 		AuthorizationRequest request = factory.createAuthorizationRequest(params);
-		request.setScope(Collections.<String>emptySet());
-		validator.validateScope(request, client);;
-	}
-
-	@Test(expected=InvalidScopeException.class)
-	public void testNotPermittedForAuthorization() {
-		AuthorizationRequest request = factory.createAuthorizationRequest(params );
-		request.setScope(Collections.singleton("foo"));
+		request.setScope(Collections.singleton("bar"));
 		validator.validateScope(request, client);
 	}
 
 	@Test(expected=InvalidScopeException.class)
-	public void testNotPermittedForScope() {
-		AuthorizationRequest request = factory.createAuthorizationRequest(params );
+	public void testNotPermittedForAuthorizationAndEmptyScope() {
+		AuthorizationRequest request = factory.createAuthorizationRequest(params);
+		request.setScope(Collections.<String>emptySet());
+		validator.validateScope(request, client);
+	}
+
+	@Test(expected=InvalidScopeException.class)
+	public void testNotPermittedForAuthorizationAndInvalidScope() {
+		AuthorizationRequest request = factory.createAuthorizationRequest(params);
+		request.setScope(Collections.singleton("foo"));
+		validator.validateScope(request, client);
+	}
+
+	@Test
+	public void testPermittedForTokenAndValidScope() {
+		AuthorizationRequest request = factory.createAuthorizationRequest(params);
+		TokenRequest tokenRequest = factory.createTokenRequest(request, "authorization_code");
+		tokenRequest.setScope(Collections.singleton("bar"));
+		validator.validateScope(tokenRequest, client);
+	}
+
+	@Test
+	public void testPermittedForTokenAndEmptyScope() {
+		AuthorizationRequest request = factory.createAuthorizationRequest(params);
+		TokenRequest tokenRequest = factory.createTokenRequest(request, "authorization_code");
+		tokenRequest.setScope(Collections.<String>emptySet());
+		validator.validateScope(tokenRequest, client);
+	}
+
+	@Test(expected=InvalidScopeException.class)
+	public void testNotPermittedForTokenAndInvalidScope() {
+		AuthorizationRequest request = factory.createAuthorizationRequest(params);
 		TokenRequest tokenRequest = factory.createTokenRequest(request, "authorization_code");
 		tokenRequest.setScope(Collections.singleton("foo"));
-		validator.validateScope(tokenRequest, client);;
+		validator.validateScope(tokenRequest, client);
 	}
 
 }

--- a/tests/annotation/approval/src/main/java/demo/Application.java
+++ b/tests/annotation/approval/src/main/java/demo/Application.java
@@ -80,7 +80,10 @@ public class Application {
 		            .authorities("ROLE_CLIENT")
 		            .scopes("read")
 		            .resourceIds("oauth2-resource")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/annotation/custom-grant/src/main/java/demo/Application.java
+++ b/tests/annotation/custom-grant/src/main/java/demo/Application.java
@@ -87,7 +87,10 @@ public class Application {
 		            .authorities("ROLE_CLIENT")
 		            .scopes("read")
 		            .resourceIds("oauth2-resource")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/annotation/form/src/main/java/demo/Application.java
+++ b/tests/annotation/form/src/main/java/demo/Application.java
@@ -69,7 +69,10 @@ public class Application {
 		            .authorities("ROLE_CLIENT")
 		            .scopes("read")
 		            .resourceIds("oauth2-resource")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/annotation/jaxb/src/main/java/demo/Application.java
+++ b/tests/annotation/jaxb/src/main/java/demo/Application.java
@@ -106,7 +106,10 @@ public class Application extends WebMvcConfigurerAdapter {
 		            .authorities("ROLE_CLIENT")
 		            .scopes("read")
 		            .resourceIds("oauth2-resource")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/annotation/jdbc/src/main/java/demo/Application.java
+++ b/tests/annotation/jdbc/src/main/java/demo/Application.java
@@ -120,7 +120,9 @@ public class Application {
 				.withClient("my-client-with-secret")
 					.authorizedGrantTypes("client_credentials", "password")
 					.authorities("ROLE_CLIENT").scopes("read")
-					.resourceIds("oauth2-resource").secret("secret");
+					.resourceIds("oauth2-resource").secret("secret").and()
+				.withClient("my-client-with-empty-scopes")
+					.authorizedGrantTypes("password", "refresh_token");
 			// @formatter:on
 		}
 

--- a/tests/annotation/jpa/src/main/java/demo/Application.java
+++ b/tests/annotation/jpa/src/main/java/demo/Application.java
@@ -86,7 +86,10 @@ public class Application {
 					.authorities("ROLE_CLIENT").scopes("read", "trust").resourceIds("oauth2-resource")
 					.redirectUris("https://anywhere?key=value").and().withClient("my-client-with-secret")
 					.authorizedGrantTypes("client_credentials", "password").authorities("ROLE_CLIENT").scopes("read")
-					.resourceIds("oauth2-resource").secret("secret");
+					.resourceIds("oauth2-resource").secret("secret")
+					.and()
+						.withClient("my-client-with-empty-scopes")
+							.authorizedGrantTypes("password", "refresh_token");
 			// @formatter:on
 		}
 

--- a/tests/annotation/jwt/src/main/java/demo/Application.java
+++ b/tests/annotation/jwt/src/main/java/demo/Application.java
@@ -75,7 +75,12 @@ public class Application {
 		            .authorizedGrantTypes("client_credentials", "password")
 		            .authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT")
 		            .scopes("read", "write")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token")
+		            .accessTokenValiditySeconds(60)
+		            .refreshTokenValiditySeconds(160);
 		// @formatter:on
 		}
 

--- a/tests/annotation/mappings/src/main/java/demo/Application.java
+++ b/tests/annotation/mappings/src/main/java/demo/Application.java
@@ -123,7 +123,10 @@ public class Application {
 		            .authorities("ROLE_CLIENT", "ROLE_TRUSTED_CLIENT")
 		            .scopes("read")
 		            .resourceIds("sparklr")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/annotation/multi/src/main/java/demo/Application.java
+++ b/tests/annotation/multi/src/main/java/demo/Application.java
@@ -137,7 +137,10 @@ public class Application {
 		            .authorities("ROLE_CLIENT")
 		            .scopes("read", "trust")
 		            .resourceIds("oauth2/other")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/annotation/vanilla/src/main/java/demo/Application.java
+++ b/tests/annotation/vanilla/src/main/java/demo/Application.java
@@ -80,7 +80,10 @@ public class Application {
 		            .authorities("ROLE_CLIENT")
 		            .scopes("read")
 		            .resourceIds("oauth2-resource")
-		            .secret("secret");
+		            .secret("secret")
+		    .and()
+		        .withClient("my-client-with-empty-scopes")
+		            .authorizedGrantTypes("password", "refresh_token");
 		// @formatter:on
 		}
 

--- a/tests/xml/approval/src/main/resources/context.xml
+++ b/tests/xml/approval/src/main/resources/context.xml
@@ -30,6 +30,8 @@
 			authorized-grant-types="password,client_credentials" scope="read"
 			resource-ids="oauth2-resource" access-token-validity="60"
 			authorities="ROLE_CLIENT" />
+		<oauth2:client client-id="my-client-with-empty-scopes"
+			authorized-grant-types="password,refresh_token" />
 	</client-details-service>
 
 </beans>

--- a/tests/xml/common/src/main/java/sparklr/common/AbstractRefreshTokenSupportTests.java
+++ b/tests/xml/common/src/main/java/sparklr/common/AbstractRefreshTokenSupportTests.java
@@ -32,10 +32,33 @@ public abstract class AbstractRefreshTokenSupportTests extends AbstractIntegrati
 
 		// now use the refresh token to get a new access token.
 		assertNotNull(accessToken.getRefreshToken());
-		OAuth2AccessToken newAccessToken = refreshAccessToken(accessToken.getRefreshToken().getValue());
+		OAuth2AccessToken newAccessToken = refreshAccessToken(accessToken.getRefreshToken().getValue(),
+			"my-trusted-client", "read");
 		assertFalse(newAccessToken.getValue().equals(accessToken.getValue()));
 
 		verifyAccessTokens(accessToken, newAccessToken);
+
+	}
+
+	/**
+	 * Tests that refreshing an access token specifying no scopes for a client
+	 * with unlimited scopes returns an access token with the originally
+	 * granted scopes.
+	 */
+	@Test
+	public void testGrantedScope() throws Exception {
+
+		OAuth2AccessToken accessToken = getAccessToken("read write", "my-client-with-empty-scopes");
+
+		// now use the refresh token to get a new access token.
+		assertNotNull(accessToken.getRefreshToken());
+		OAuth2AccessToken newAccessToken = refreshAccessToken(accessToken.getRefreshToken().getValue(),
+			"my-client-with-empty-scopes", null);
+		assertFalse(newAccessToken.getValue().equals(accessToken.getValue()));
+
+		verifyAccessTokens(accessToken, newAccessToken);
+		assertTrue(newAccessToken.getScope().contains("read"));
+		assertTrue(newAccessToken.getScope().contains("write"));
 
 	}
 
@@ -52,14 +75,16 @@ public abstract class AbstractRefreshTokenSupportTests extends AbstractIntegrati
 		assertEquals(status, http.getStatusCode("/admin/beans", headers));
 	}
 
-	private OAuth2AccessToken refreshAccessToken(String refreshToken) {
+	private OAuth2AccessToken refreshAccessToken(String refreshToken, String clientId, String scope) {
 
 		MultiValueMap<String, String> formData = new LinkedMultiValueMap<String, String>();
 		formData.add("grant_type", "refresh_token");
-		formData.add("client_id", "my-trusted-client");
+		formData.add("client_id", clientId);
 		formData.add("refresh_token", refreshToken);
-		formData.add("scope", "read");
-		HttpHeaders headers = getTokenHeaders("my-trusted-client");
+		if (scope != null) {
+			formData.add("scope", scope);
+		}
+		HttpHeaders headers = getTokenHeaders(clientId);
 
 		@SuppressWarnings("rawtypes")
 		ResponseEntity<Map> response = http.postForMap(tokenPath(), headers, formData);

--- a/tests/xml/form/src/main/resources/context.xml
+++ b/tests/xml/form/src/main/resources/context.xml
@@ -30,6 +30,8 @@
 			authorized-grant-types="password,client_credentials" scope="read"
 			resource-ids="oauth2-resource" access-token-validity="60"
 			authorities="ROLE_CLIENT" />
+		<oauth2:client client-id="my-client-with-empty-scopes"
+			authorized-grant-types="password,refresh_token" />
 	</client-details-service>
 
 </beans>

--- a/tests/xml/jdbc/src/main/resources/schema.sql
+++ b/tests/xml/jdbc/src/main/resources/schema.sql
@@ -60,3 +60,6 @@ insert into oauth_client_details (client_id, resource_ids, scope, authorized_gra
 insert into oauth_client_details (client_id, client_secret, resource_ids, scope, authorized_grant_types, authorities) 
 	values ('my-client-with-secret', 'secret', 'oauth2-resource', 'read', 'password,client_credentials', 'ROLE_CLIENT');
 
+insert into oauth_client_details (client_id, client_secret, resource_ids, scope, authorized_grant_types, authorities)
+	values ('my-client-with-empty-scopes', null, null, null, 'password,refresh_token', null);
+

--- a/tests/xml/jwt/src/main/resources/context.xml
+++ b/tests/xml/jwt/src/main/resources/context.xml
@@ -30,6 +30,8 @@
 			authorized-grant-types="password,client_credentials" scope="read"
 			resource-ids="oauth2-resource" access-token-validity="60"
 			authorities="ROLE_CLIENT" />
+		<oauth2:client client-id="my-client-with-empty-scopes"
+			authorized-grant-types="password,refresh_token" />
 	</client-details-service>
 
 </beans>

--- a/tests/xml/mappings/src/main/resources/context.xml
+++ b/tests/xml/mappings/src/main/resources/context.xml
@@ -33,6 +33,8 @@
 			authorized-grant-types="password,client_credentials" scope="read"
 			resource-ids="oauth2-resource" access-token-validity="60"
 			authorities="ROLE_CLIENT" />
+		<oauth2:client client-id="my-client-with-empty-scopes"
+			authorized-grant-types="password,refresh_token" />
 	</client-details-service>
 
 </beans>

--- a/tests/xml/vanilla/src/main/resources/context.xml
+++ b/tests/xml/vanilla/src/main/resources/context.xml
@@ -30,6 +30,8 @@
 			authorized-grant-types="password,client_credentials" scope="read"
 			resource-ids="oauth2-resource" access-token-validity="60"
 			authorities="ROLE_CLIENT" />
+		<oauth2:client client-id="my-client-with-empty-scopes"
+			authorized-grant-types="password,refresh_token" />
 	</client-details-service>
 
 </beans>


### PR DESCRIPTION
As per the spec, refreshing an access token with no scopes specified
should create a new access token with the originally granted scopes.

This was actually the implemented behaviour once the
`DefaultOAuth2RequestValidator` allows empty scopes.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
