### PR TITLE
Fixed hard-coded clientCredentialsTokenEndpointFilter method in AuthorizationServerSecurityConfigurer

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
@@ -208,10 +208,7 @@ public final class AuthorizationServerSecurityConfigurer extends
 				frameworkEndpointHandlerMapping().getServletPath("/oauth/token"));
 		clientCredentialsTokenEndpointFilter
 				.setAuthenticationManager(http.getSharedObject(AuthenticationManager.class));
-		OAuth2AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
-		authenticationEntryPoint.setTypeName("Form");
-		authenticationEntryPoint.setRealmName(realm);
-		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(authenticationEntryPoint);
+		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(this.authenticationEntryPoint);
 		clientCredentialsTokenEndpointFilter = postProcess(clientCredentialsTokenEndpointFilter);
 		http.addFilterBefore(clientCredentialsTokenEndpointFilter, BasicAuthenticationFilter.class);
 		return clientCredentialsTokenEndpointFilter;


### PR DESCRIPTION
When I configure the `AuthorizationServer`, enable `allowFormAuthenticationForClients` and customize the `AuthenticationEntryPoint`, then the `AuthenticationEntryPoint` will not work.

```
    @Configuration
    @EnableAuthorizationServer
    protected static class AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
        ...
        @Override
        public void configure(AuthorizationServerSecurityConfigurer oauthServer) {
            MyAuthenticationEntryPoint myAuthenticationEntryPoint = new MyAuthenticationEntryPoint();
            myAuthenticationEntryPoint.setRealmName("oauth2/client");
            myAuthenticationEntryPoint.setExceptionTranslator(new MyWebResponseExceptionTranslator());
            oauthServer.authenticationEntryPoint(myAuthenticationEntryPoint).allowFormAuthenticationForClients();
        }
        ...
    }
```

The reason is that hard-coded processing is used in `AuthorizationServerSecurityConfigurer`:

```
	@Override
	public void configure(HttpSecurity http) throws Exception {
		
		// ensure this is initialized
		...
		if (allowFormAuthenticationForClients) {
			clientCredentialsTokenEndpointFilter(http);
		}
		...
	}
	...
	private ClientCredentialsTokenEndpointFilter clientCredentialsTokenEndpointFilter(HttpSecurity http) {
		ClientCredentialsTokenEndpointFilter clientCredentialsTokenEndpointFilter = new ClientCredentialsTokenEndpointFilter(
				frameworkEndpointHandlerMapping().getServletPath("/oauth/token"));
		...
		OAuth2AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
		...
		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(authenticationEntryPoint);
		...
	}
```
