### PR TITLE
Safer deserialization in RedisTokenStore

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/JdkSerializationStrategy.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/JdkSerializationStrategy.java
@@ -1,26 +1,83 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.oauth2.provider.token.store.redis;
 
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.core.serializer.support.SerializationFailedException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Serializes objects using {@link JdkSerializationRedisSerializer}
+ * Serializes and objects using {@link ObjectOutputStream},
+ * and deserializes only allowed objects using {@link SaferObjectInputStream}.
  *
  * @author efenderbosch
- *
+ * @author Artem Smotrakov
  */
 public class JdkSerializationStrategy extends StandardStringSerializationStrategy {
 
-	private static final JdkSerializationRedisSerializer OBJECT_SERIALIZER = new JdkSerializationRedisSerializer();
+    private static final byte[] EMPTY_ARRAY = new byte[0];
 
-	@Override
-	@SuppressWarnings("unchecked")
-	protected <T> T deserializeInternal(byte[] bytes, Class<T> clazz) {
-		return (T) OBJECT_SERIALIZER.deserialize(bytes);
-	}
+    /**
+     * A list of classes which are allowed to deserialize.
+     */
+    private static final List<String> ALLOWED_CLASSES;
 
-	@Override
-	protected byte[] serializeInternal(Object object) {
-		return OBJECT_SERIALIZER.serialize(object);
-	}
+    static {
+        List<String> classes = new ArrayList<String>();
+        classes.add("java.lang.");
+        classes.add("java.util.");
+        classes.add("org.springframework.security");
+        ALLOWED_CLASSES = Collections.unmodifiableList(classes);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> T deserializeInternal(byte[] bytes, Class<T> clazz) {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        try {
+            SaferObjectInputStream saferObjectInputStream = new SaferObjectInputStream(
+                    new ByteArrayInputStream(bytes), ALLOWED_CLASSES);
+            return (T) saferObjectInputStream.readObject();
+        } catch (Exception e) {
+            throw new SerializationFailedException("Failed to deserialize payload", e);
+        }
+    }
+
+    @Override
+    protected byte[] serializeInternal(Object object) {
+        if (object == null) {
+            return EMPTY_ARRAY;
+        }
+        try {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+            objectOutputStream.writeObject(object);
+            objectOutputStream.flush();
+            return byteArrayOutputStream.toByteArray();
+        } catch (Exception e) {
+            throw new SerializationFailedException("Failed to serialize object", e);
+        }
+    }
 
 }

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/SaferObjectInputStream.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/SaferObjectInputStream.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.provider.token.store.redis;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Special ObjectInputStream subclass that checks if classes are allowed to deserialize.
+ * The class should be configured with a whitelist of only allowed (safe) classes to deserialize.
+ *
+ * @author Artem Smotrakov
+ */
+public class SaferObjectInputStream extends ObjectInputStream {
+
+    /**
+     * The whitelist of classes which are allowed for deserialization.
+     */
+    private final List<String> allowedClasses;
+
+    /**
+     * Create a new SaferObjectInputStream for the given InputStream and allowed class names.
+     *
+     * @param in             the InputStream to read from
+     * @param allowedClasses the list of allowed classes for deserialization
+     * @see ObjectInputStream#ObjectInputStream(InputStream)
+     */
+    public SaferObjectInputStream(InputStream in, List<String> allowedClasses) throws IOException {
+        super(in);
+        this.allowedClasses = Collections.unmodifiableList(allowedClasses);
+    }
+
+    /**
+     * Resolve the class only if it's allowed to deserialize.
+     *
+     * @see ObjectInputStream#resolveClass(ObjectStreamClass)
+     */
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass classDesc) throws IOException, ClassNotFoundException {
+        if (isProhibited(classDesc.getName())) {
+            throw new NotSerializableException("Not allowed to deserialize " + classDesc.getName());
+        }
+        return super.resolveClass(classDesc);
+    }
+
+    /**
+     * Check if the class is allowed to be deserialized.
+     *
+     * @param className the class to check
+     * @return true if the class is not allowed to be deserialized, false otherwise
+     */
+    private boolean isProhibited(String className) {
+        for (String allowedClass : this.allowedClasses) {
+            if (className.startsWith(allowedClass)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/JdkSerializationStrategyTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/JdkSerializationStrategyTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.provider.token.store.redis;
+
+import org.junit.Test;
+import org.springframework.core.serializer.support.SerializationFailedException;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Artem Smotrakov
+ */
+public class JdkSerializationStrategyTests {
+
+    @Test
+    public void deserializeAllowedClasses() {
+        deserializeAllowedClasses(new DefaultOAuth2AccessToken("access-token-" + UUID.randomUUID()));
+        deserializeAllowedClasses("xyz");
+        deserializeAllowedClasses(new HashMap<String, String>());
+    }
+
+    private void deserializeAllowedClasses(Object object) {
+        JdkSerializationStrategy serializationStrategy = new JdkSerializationStrategy();
+
+        byte[] bytes = serializationStrategy.serialize(object);
+
+        Object clone = serializationStrategy.deserialize(bytes, Object.class);
+        assertEquals(object, clone);
+    }
+
+    @Test(expected = SerializationFailedException.class)
+    public void deserializeProhibitedClasses() throws UnknownHostException {
+        JdkSerializationStrategy serializationStrategy = new JdkSerializationStrategy();
+
+        byte[] bytes = serializationStrategy.serializeInternal(InetAddress.getLocalHost());
+        serializationStrategy.deserializeInternal(bytes, Object.class);
+    }
+
+    @Test
+    public void deserializeEmpty() {
+        JdkSerializationStrategy jdkSerializationStrategy = new JdkSerializationStrategy();
+        assertNull(jdkSerializationStrategy.deserialize(null, Object.class));
+        assertNull(jdkSerializationStrategy.deserialize(new byte[0], Object.class));
+    }
+
+    @Test
+    public void serializeNull() {
+        assertArrayEquals(new byte[0], new JdkSerializationStrategy().serialize(null));
+    }
+}


### PR DESCRIPTION
Please review the following patch which fixes #1682 

- Added `SaferObjectInputStream` which checks if classes are allowed to deserialize.
- Updated `JdkSerializationStrategy` to use `SaferObjectInputStream` instead of `JdkSerializationRedisSerializer`.
- Updated `JdkSerializationStrategy` with a list of classes allowed to deserialize.
- Added a couple of tests for `JdkSerializationStrategy`