### PR TITLE
Restricting OAuth to allow only POST method in check_token endpoint

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/CheckTokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/CheckTokenEndpoint.java
@@ -29,6 +29,7 @@ import org.springframework.security.oauth2.provider.token.DefaultAccessTokenConv
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -69,7 +70,7 @@ public class CheckTokenEndpoint {
 		this.accessTokenConverter = accessTokenConverter;
 	}
 
-	@RequestMapping(value = "/oauth/check_token")
+	@RequestMapping(value = "/oauth/check_token", method = RequestMethod.POST)
 	@ResponseBody
 	public Map<String, ?> checkToken(@RequestParam("token") String value) {
 

--- a/tests/annotation/jpa/src/test/java/demo/ResourceOwnerPasswordProviderTests.java
+++ b/tests/annotation/jpa/src/test/java/demo/ResourceOwnerPasswordProviderTests.java
@@ -1,13 +1,16 @@
 package demo;
 
 import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.test.OAuth2ContextConfiguration;
-
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import sparklr.common.AbstractResourceOwnerPasswordProviderTests;
 
 /**
@@ -20,7 +23,25 @@ public class ResourceOwnerPasswordProviderTests extends AbstractResourceOwnerPas
 	public void testCheckToken() throws Exception {
 		TestRestTemplate template = new TestRestTemplate("my-trusted-client", "");
 		ResponseEntity<String> response = template.getForEntity(http.getUrl("/oauth/check_token?token={token}"), String.class, context.getAccessToken().getValue());
-		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals(HttpStatus.METHOD_NOT_ALLOWED, response.getStatusCode());
 	}
 
+	/**
+	 * Note: This test is to check the POST request call to CheckTokenEndpoint. 
+	 * The main intension is to avoid passing parameters as part of the URL /oauth/check_token. Example: /oauth/check_token?token={token}
+	 * Instead making sure that the URL /oauth/check_token accepts only POST request calls so that parameters can be part of request body.
+	*/	
+	@Test
+	@OAuth2ContextConfiguration(ResourceOwner.class)
+	public void testCheckTokenPostRequestCall() throws Exception {
+		TestRestTemplate template = new TestRestTemplate("my-trusted-client", "");
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
+		map.add("token", context.getAccessToken().getValue());
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
+		ResponseEntity<String> response = template.postForEntity(http.getUrl("/oauth/check_token"), request, String.class);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+	
 }

--- a/tests/annotation/vanilla/src/test/java/demo/ResourceOwnerPasswordProviderTests.java
+++ b/tests/annotation/vanilla/src/test/java/demo/ResourceOwnerPasswordProviderTests.java
@@ -1,13 +1,16 @@
 package demo;
 
 import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.test.OAuth2ContextConfiguration;
-
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import sparklr.common.AbstractResourceOwnerPasswordProviderTests;
 
 /**
@@ -20,6 +23,24 @@ public class ResourceOwnerPasswordProviderTests extends AbstractResourceOwnerPas
 	public void testCheckToken() throws Exception {
 		TestRestTemplate template = new TestRestTemplate("my-trusted-client", "");
 		ResponseEntity<String> response = template.getForEntity(http.getUrl("/oauth/check_token?token={token}"), String.class, context.getAccessToken().getValue());
+		assertEquals(HttpStatus.METHOD_NOT_ALLOWED, response.getStatusCode());
+	}
+
+	/**
+	 * Note: This test is to check the POST request call to CheckTokenEndpoint. 
+	 * The main intension is to avoid passing parameters as part of the URL /oauth/check_token. Example: /oauth/check_token?token={token}
+	 * Instead making sure that the URL /oauth/check_token accepts only POST request calls so that parameters can be part of request body.
+	*/	
+	@Test
+	@OAuth2ContextConfiguration(ResourceOwner.class)
+	public void testCheckTokenPostRequestCall() throws Exception {
+		TestRestTemplate template = new TestRestTemplate("my-trusted-client", "");
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
+		map.add("token", context.getAccessToken().getValue());
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
+		ResponseEntity<String> response = template.postForEntity(http.getUrl("/oauth/check_token"), request, String.class);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}
 


### PR DESCRIPTION
Fixes: #1710

- Restricting `/oauth/check_token` in `CheckTokenEndpoint` to allow only `POST` requests
- Writing some unit testcases to make sure that the endpoint functionality does not cause regression issues