### PR TITLE
Redirect HTTP response code is set to 303 for Authorization Endpoint

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -12,6 +12,7 @@
  */
 package org.springframework.security.oauth2.provider.endpoint;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -260,9 +261,11 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 			}
 
 			if (!authorizationRequest.isApproved()) {
-				return new RedirectView(getUnsuccessfulRedirect(authorizationRequest,
+				RedirectView redirectView = new RedirectView(getUnsuccessfulRedirect(authorizationRequest,
 						new UserDeniedAuthorizationException("User denied access"), responseTypes.contains("token")),
 						false, true, false);
+				redirectView.setStatusCode(HttpStatus.SEE_OTHER);
+				return redirectView;
 			}
 
 			if (responseTypes.contains("token")) {
@@ -342,12 +345,16 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 			if (accessToken == null) {
 				throw new UnsupportedResponseTypeException("Unsupported response type: token");
 			}
-			return new ModelAndView(new RedirectView(appendAccessToken(authorizationRequest, accessToken), false, true,
-					false));
+				RedirectView redirectView = new RedirectView(appendAccessToken(authorizationRequest, accessToken), false, true,
+					false);
+				redirectView.setStatusCode(HttpStatus.SEE_OTHER);
+				return new ModelAndView(redirectView);
 		}
 		catch (OAuth2Exception e) {
-			return new ModelAndView(new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, true), false,
-					true, false));
+				RedirectView redirectView = new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, true), false,
+					true, false);
+				redirectView.setStatusCode(HttpStatus.SEE_OTHER);
+				return new ModelAndView(redirectView);
 		}
 	}
 
@@ -365,11 +372,15 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 
 	private View getAuthorizationCodeResponse(AuthorizationRequest authorizationRequest, Authentication authUser) {
 		try {
-			return new RedirectView(getSuccessfulRedirect(authorizationRequest,
+				RedirectView redirectView = new RedirectView(getSuccessfulRedirect(authorizationRequest,
 					generateCode(authorizationRequest, authUser)), false, true, false);
+				redirectView.setStatusCode(HttpStatus.SEE_OTHER);
+				return redirectView;
 		}
 		catch (OAuth2Exception e) {
-			return new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, false), false, true, false);
+				RedirectView redirectView = new RedirectView(getUnsuccessfulRedirect(authorizationRequest, e, false), false, true, false);
+				redirectView.setStatusCode(HttpStatus.SEE_OTHER);
+				return redirectView;
 		}
 	}
 
@@ -601,7 +612,9 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 			authorizationRequest.setRedirectUri(requestedRedirect);
 			String redirect = getUnsuccessfulRedirect(authorizationRequest, translate.getBody(), authorizationRequest
 					.getResponseTypes().contains("token"));
-			return new ModelAndView(new RedirectView(redirect, false, true, false));
+			RedirectView redirectView = new RedirectView(redirect, false, true, false);
+			redirectView.setStatusCode(HttpStatus.SEE_OTHER);
+			return new ModelAndView(redirectView);
 		}
 		catch (OAuth2Exception ex) {
 			// If an AuthorizationRequest cannot be created from the incoming parameters it must be

--- a/tests/annotation/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
+++ b/tests/annotation/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
@@ -112,7 +112,7 @@ public abstract class AbstractAuthorizationCodeProviderTests extends AbstractEmp
 		assertTrue(location.startsWith("https://anywhere"));
 		assertTrue(location.substring(location.indexOf('?')).contains("error=access_denied"));
 		// It was a redirect that triggered our client redirect exception:
-		assertEquals(HttpStatus.FOUND, getTokenEndpointResponse().getStatusCode());
+		assertEquals(HttpStatus.SEE_OTHER, getTokenEndpointResponse().getStatusCode());
 	}
 
 	@Test
@@ -172,7 +172,7 @@ public abstract class AbstractAuthorizationCodeProviderTests extends AbstractEmp
 			uri.queryParam("redirect_uri", redirectUri);
 		}
 		ResponseEntity<String> response = http.getForString(uri.pattern(), headers, uri.params());
-		assertEquals(HttpStatus.FOUND, response.getStatusCode());
+		assertEquals(HttpStatus.SEE_OTHER, response.getStatusCode());
 		String location = response.getHeaders().getLocation().toString();
 		assertTrue(location.startsWith("https://anywhere"));
 		assertTrue(location.contains("error=invalid_scope"));

--- a/tests/annotation/custom-grant/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/custom-grant/src/test/java/demo/ImplicitProviderTests.java
@@ -55,7 +55,7 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 				.getForEntity(
 						http.getUrl("/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&scope={scope}"),
 						Void.class, form);
-		assertEquals(HttpStatus.FOUND, response.getStatusCode());
+		assertEquals(HttpStatus.SEE_OTHER, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
 	}
 

--- a/tests/annotation/jaxb/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/jaxb/src/test/java/demo/ImplicitProviderTests.java
@@ -61,7 +61,7 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 				.getForEntity(
 						http.getUrl("/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&scope={scope}"),
 						Void.class, form);
-		assertEquals(HttpStatus.FOUND, response.getStatusCode());
+		assertEquals(HttpStatus.SEE_OTHER, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
 	}
 

--- a/tests/annotation/jpa/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/jpa/src/test/java/demo/ImplicitProviderTests.java
@@ -61,7 +61,7 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 				.getForEntity(
 						http.getUrl("/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&scope={scope}"),
 						Void.class, form);
-		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.FOUND, response.getStatusCode());
+		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.SEE_OTHER, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
 	}
 

--- a/tests/annotation/vanilla/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/vanilla/src/test/java/demo/ImplicitProviderTests.java
@@ -61,7 +61,7 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 				.getForEntity(
 						http.getUrl("/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&response_type={response_type}&scope={scope}"),
 						Void.class, form);
-		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.FOUND, response.getStatusCode());
+		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.SEE_OTHER, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
 	}
 

--- a/tests/xml/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
+++ b/tests/xml/common/src/main/java/sparklr/common/AbstractAuthorizationCodeProviderTests.java
@@ -182,7 +182,7 @@ public abstract class AbstractAuthorizationCodeProviderTests extends AbstractInt
 		assertTrue(location.startsWith("https://anywhere"));
 		assertTrue(location.substring(location.indexOf('?')).contains("error=access_denied"));
 		// It was a redirect that triggered our client redirect exception:
-		assertEquals(HttpStatus.FOUND, tokenEndpointResponse.getStatusCode());
+		assertEquals(HttpStatus.SEE_OTHER, tokenEndpointResponse.getStatusCode());
 	}
 
 	@Test
@@ -242,7 +242,7 @@ public abstract class AbstractAuthorizationCodeProviderTests extends AbstractInt
 			uri.queryParam("redirect_uri", redirectUri);
 		}
 		ResponseEntity<String> response = http.getForString(uri.pattern(), headers, uri.params());
-		assertEquals(HttpStatus.FOUND, response.getStatusCode());
+		assertEquals(HttpStatus.SEE_OTHER, response.getStatusCode());
 		String location = response.getHeaders().getLocation().toString();
 		assertTrue(location.startsWith("https://anywhere"));
 		assertTrue(location.contains("error=invalid_scope"));


### PR DESCRIPTION
Fixes #900 

- Default Redirect Strategy is set to HTTP Response Status Code 303. As per below-given conditions:
    * The Endpoint is receiving a POST request
    * The POST request is expecting a redirect
    * Handling every RedirectView present in AuthorizationEndpoint.java
- Modifying tests to handle regression issues
