### PR TITLE
Replace UUID with SecureRandom in `createAccessToken` (DefaultTokenSe…

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -16,6 +16,9 @@ package org.springframework.security.oauth2.provider.token;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
+import java.security.SecureRandom;
+
+import org.apache.commons.codec.binary.Base64;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -290,7 +293,12 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 	}
 
 	private OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken) {
-		DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken(UUID.randomUUID().toString());
+		SecureRandom random = new SecureRandom();
+		byte[] accessTokenBuffer = new byte[20];
+		random.nextBytes(accessTokenBuffer);
+		String accessTokenString = new String(Base64.encodeBase64(accessTokenBuffer));
+	
+		DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken(accessTokenString);
 		int validitySeconds = getAccessTokenValiditySeconds(authentication.getOAuth2Request());
 		if (validitySeconds > 0) {
 			token.setExpiration(new Date(System.currentTimeMillis() + (validitySeconds * 1000L)));


### PR DESCRIPTION
**Problem**
Usage of UUID for access tokens is unacceptable. 

**Why**
Accoding to [RFC 6749](https://tools.ietf.org/html/rfc6749#section-10.10) (OAuth 2.0 Authorization Framework Specs):

> The probability of an attacker guessing generated tokens (and other credentials not intended for handling by end-users) MUST be less than or equal to 2^(-128) and SHOULD be less than or equal to 2^(-160).

128 bits in a random-generated UUID v.4, there are 6 bits which are fixed variant and version bits leaving **only 122 bits of actual random which does not comply with RFC specifications.**

**Solution**
Using a secure source of random `SecureRandom`, we're generating base64 out of 160-bit random value. 