### PR TITLE
clear jwk definitions *after* retrieving new ones

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
@@ -96,10 +96,12 @@ class JwkDefinitionSource {
 			if (result != null) {
 				return result;
 			}
-			this.jwkDefinitions.clear();
+			Map newJwkDefinitions = new LinkedHashMap<String, JwkDefinitionHolder>();
 			for (URL jwkSetUrl : jwkSetUrls) {
-				this.jwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
+				newJwkDefinitions.putAll(loadJwkDefinitions(jwkSetUrl));
 			}
+			this.jwkDefinitions.clear();
+			this.jwkDefinitions.putAll(newJwkDefinitions);
 			return this.getDefinition(keyId);
 		}
 	}


### PR DESCRIPTION
An unknown jwk id triggers the retrieval of the key definitions as it usually means the keys rotated.

When this call executes the definition map was cleared before reading the current definitions
from the remote `jwkSetUrl`. 
During this retrieval subsequent requests can not be
verified, which is fine in case of a key rotation. But if someone intentionally changes the kid, other requests still have a valid key but are forced to block until the call completes.  

 Moving the clear and put after the retrieval of the new jwk
definitions mitigates this.

Closes gh-1722

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
