### PR TITLE
Adds support for fragments in userAuthorizationUri

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilter.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilter.java
@@ -95,8 +95,14 @@ public class OAuth2ClientContextFilter implements Filter, InitializingBean {
 			throws IOException {
 
 		String redirectUri = e.getRedirectUri();
-		UriComponentsBuilder builder = UriComponentsBuilder
-				.fromHttpUrl(redirectUri);
+		UriComponentsBuilder builder;
+		if (e.containsFragment()) {
+			builder = UriComponentsBuilder
+					.fromUriString(redirectUri);
+		} else {
+			builder = UriComponentsBuilder
+					.fromHttpUrl(redirectUri);
+		}
 		Map<String, String> requestParams = e.getRequestParams();
 		for (Map.Entry<String, String> param : requestParams.entrySet()) {
 			builder.queryParam(param.getKey(), param.getValue());

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/resource/UserRedirectRequiredException.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/resource/UserRedirectRequiredException.java
@@ -77,4 +77,11 @@ public class UserRedirectRequiredException extends RuntimeException {
 	public void setStateToPreserve(Object stateToPreserve) {
 		this.stateToPreserve = stateToPreserve;
 	}
+
+	/**
+	 * Returns {@code true} if the redirectUri contains a fragment, otherwise {@code false}.
+	 */
+	public boolean containsFragment() {
+		return this.redirectUri.indexOf('#') >- 0;
+	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilterTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/filter/OAuth2ClientContextFilterTests.java
@@ -53,6 +53,16 @@ public class OAuth2ClientContextFilterTests {
 		testRedirectUri(redirect, params, redirect + "&spam=bucket");
 	}
 
+	@Test
+	public void testRedirectUriWithFragment() throws Exception {
+		String base = "https://example.com/authorize";
+		String fragment = "fragment";
+		String redirect = base + '#' + fragment;
+		Map<String, String> params = Collections.singletonMap("spam",
+				"bucket");
+		testRedirectUri(redirect, params, base + "?spam=bucket#" + fragment);
+	}
+
 	public void testRedirectUri(String redirect, Map<String, String> params,
 			String result) throws Exception {
 		OAuth2ClientContextFilter filter = new OAuth2ClientContextFilter();


### PR DESCRIPTION
Fixes [#959](https://github.com/spring-projects/spring-security-oauth/issues/959)
Adds support for fragments in `userAuthorizationUri` in `OAuth2ClientContextFilter `

