### PR TITLE
Set cache control headers for implicit grant response

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/AuthorizationEndpoint.java
@@ -12,6 +12,7 @@
  */
 package org.springframework.security.oauth2.provider.endpoint;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -46,6 +47,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.HttpSessionRequiredException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -69,6 +71,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * <p>
@@ -638,4 +641,10 @@ public class AuthorizationEndpoint extends AbstractEndpoint {
 		}
 
 	}
+	
+	@ModelAttribute
+	public void addAdditionalResponseHeader(HttpServletResponse response) {
+	    response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+	    response.setHeader(HttpHeaders.PRAGMA, "no-cache");
+	} 
 }

--- a/tests/annotation/common/src/main/java/sparklr/common/AbstractResourceOwnerPasswordProviderTests.java
+++ b/tests/annotation/common/src/main/java/sparklr/common/AbstractResourceOwnerPasswordProviderTests.java
@@ -196,6 +196,8 @@ public abstract class AbstractResourceOwnerPasswordProviderTests extends
 		assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
 		assertTrue("Wrong body: " + result.getBody(),
 				result.getBody().toLowerCase().contains("unauthorized"));
+		assertTrue(result.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(result.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	@Test

--- a/tests/annotation/custom-grant/src/test/java/demo/CustomProviderTests.java
+++ b/tests/annotation/custom-grant/src/test/java/demo/CustomProviderTests.java
@@ -1,7 +1,7 @@
 package demo;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertTrue;
 import java.util.Map;
 
 import org.junit.Test;
@@ -27,6 +27,8 @@ public class CustomProviderTests extends AbstractIntegrationTests {
 		@SuppressWarnings("rawtypes")
 		ResponseEntity<Map> response = http.postForMap("/oauth/token", headers, form);
 		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	@Test
@@ -38,6 +40,8 @@ public class CustomProviderTests extends AbstractIntegrationTests {
 		@SuppressWarnings("rawtypes")
 		ResponseEntity<Map> response = http.postForMap("/oauth/token", headers, form);
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 }

--- a/tests/annotation/custom-grant/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/custom-grant/src/test/java/demo/ImplicitProviderTests.java
@@ -57,6 +57,8 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 						Void.class, form);
 		assertEquals(HttpStatus.FOUND, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	protected static class ResourceOwner extends ResourceOwnerPasswordResourceDetails {

--- a/tests/annotation/jaxb/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/jaxb/src/test/java/demo/ImplicitProviderTests.java
@@ -63,6 +63,8 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 						Void.class, form);
 		assertEquals(HttpStatus.FOUND, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	protected static class ResourceOwner extends ResourceOwnerPasswordResourceDetails {

--- a/tests/annotation/jpa/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/jpa/src/test/java/demo/ImplicitProviderTests.java
@@ -63,6 +63,8 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 						Void.class, form);
 		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.FOUND, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	protected static class ResourceOwner extends ResourceOwnerPasswordResourceDetails {

--- a/tests/annotation/ssl/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/ssl/src/test/java/demo/ImplicitProviderTests.java
@@ -65,6 +65,8 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 						Void.class, form);
 		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.FOUND, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	protected static class ResourceOwner extends ResourceOwnerPasswordResourceDetails {

--- a/tests/annotation/vanilla/src/test/java/demo/ImplicitProviderTests.java
+++ b/tests/annotation/vanilla/src/test/java/demo/ImplicitProviderTests.java
@@ -63,6 +63,8 @@ public class ImplicitProviderTests extends AbstractImplicitProviderTests {
 						Void.class, form);
 		assertEquals("Wrong status: " + response.getHeaders(), HttpStatus.FOUND, response.getStatusCode());
 		assertTrue(response.getHeaders().getLocation().toString().contains("access_token"));
+		assertTrue(response.getHeaders().get("Cache-Control").toString().contains("no-store"));
+		assertTrue(response.getHeaders().get("Pragma").toString().contains("no-cache"));
 	}
 
 	protected static class ResourceOwner extends ResourceOwnerPasswordResourceDetails {


### PR DESCRIPTION
Fixes #1725

1. Have added response headers Pragma and Cache-Control for AuthorizationEndpoint.java Controller
2. Modified test cases to confirm the inclusion of headers