### PR TITLE
Update to bouncycastle:bcpkix-jdk15on:1.62

### DIFF
--- a/spring-security-jwt/pom.xml
+++ b/spring-security-jwt/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.60</version>
+			<version>1.62</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Upgrade the bouncy castle version to latest available, which is 1.62.