### PR TITLE
OAuth 2 Autoconfiguration 401 Error for preflight request #1749

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configuration/AuthorizationServerSecurityConfiguration.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configuration/AuthorizationServerSecurityConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -86,9 +87,10 @@ public class AuthorizationServerSecurityConfiguration extends WebSecurityConfigu
 		// @formatter:off
 		http
         	.authorizeRequests()
-            	.antMatchers(tokenEndpointPath).fullyAuthenticated()
-            	.antMatchers(tokenKeyPath).access(configurer.getTokenKeyAccess())
-            	.antMatchers(checkTokenPath).access(configurer.getCheckTokenAccess())
+				.antMatchers(HttpMethod.OPTIONS, tokenEndpointPath).permitAll()
+				.antMatchers(tokenEndpointPath).fullyAuthenticated()
+				.antMatchers(tokenKeyPath).access(configurer.getTokenKeyAccess())
+				.antMatchers(checkTokenPath).access(configurer.getCheckTokenAccess())
         .and()
         	.requestMatchers()
             	.antMatchers(tokenEndpointPath, tokenKeyPath, checkTokenPath)


### PR DESCRIPTION
When sending requests from the browser with one of some combinations of method and headers, browsers tend to send a special _preflight_ request, which is a kind of Cors request.

These requests are sent with the method _OPTIONS_, containing headers like _Access-Control-Request-*_.

# An example
when using OAuth2 authentication, we send a POST request to _/oauth/token_, with HTTP's Basic authorization header. This kind of request is handled correctly by the autoconfiguration.

But when a browser sends a _preflight_ request, it doesn't tend to send the _Authorization_ header needed to access the given resource, because the configuration expects _fullyAuthenticated_ clients on that, which causes the request to fail, resulting in a CORS error from the browser side.

My pull request allows all clients to access _/oauth/token_ in case of an incoming OPTIONS request. 
Based on my testing, the change solves the original problem, while not raising new ones.

Original issue: https://github.com/spring-projects/spring-security-oauth/issues/1749