### PR TITLE
Safer deserialization in JDBC services

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/SerializationUtils.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/SerializationUtils.java
@@ -3,12 +3,31 @@ package org.springframework.security.oauth2.common.util;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import org.springframework.core.ConfigurableObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.util.ClassUtils;
 
 public class SerializationUtils {
+
+	/**
+	 * A list of classes which are allowed to deserialize.
+	 */
+	private static final List<String> ALLOWED_CLASSES;
+
+	static {
+		List<String> classes = new ArrayList<String>();
+		classes.add("java.lang.");
+		classes.add("java.util.");
+		classes.add("org.springframework.security.");
+		ALLOWED_CLASSES = Collections.unmodifiableList(classes);
+	}
 
 	public static byte[] serialize(Object state) {
 		ObjectOutputStream oos = null;
@@ -37,8 +56,8 @@ public class SerializationUtils {
 	public static <T> T deserialize(byte[] byteArray) {
 		ObjectInputStream oip = null;
 		try {
-			oip = new ConfigurableObjectInputStream(new ByteArrayInputStream(byteArray),
-					Thread.currentThread().getContextClassLoader());
+			oip = new SaferObjectInputStream(new ByteArrayInputStream(byteArray),
+					Thread.currentThread().getContextClassLoader(), ALLOWED_CLASSES);
 			@SuppressWarnings("unchecked")
 			T result = (T) oip.readObject();
 			return result;
@@ -58,6 +77,72 @@ public class SerializationUtils {
 					// eat it
 				}
 			}
+		}
+	}
+
+	/**
+	 * Special ObjectInputStream subclass that checks if classes are allowed to deserialize.
+	 * The class should be configured with a whitelist of only allowed (safe) classes to deserialize.
+	 *
+	 * @author Artem Smotrakov
+	 */
+	private static class SaferObjectInputStream extends ObjectInputStream {
+
+		/**
+		 * The whitelist of classes which are allowed for deserialization.
+		 */
+		private final List<String> allowedClasses;
+
+		/**
+		 * The class loader to use for loading local classes.
+		 */
+		private final ClassLoader classLoader;
+
+		/**
+		 * Create a new SaferObjectInputStream for the given InputStream, class loader and  allowed class names.
+		 *
+		 * @param in             the InputStream to read from
+		 * @param classLoader    the ClassLoader to use for loading local classes
+		 * @param allowedClasses the list of allowed classes for deserialization
+		 * @throws IOException
+		 */
+		SaferObjectInputStream(InputStream in, ClassLoader classLoader, List<String> allowedClasses)
+				throws IOException {
+
+			super(in);
+			this.classLoader = classLoader;
+			this.allowedClasses = Collections.unmodifiableList(allowedClasses);
+		}
+
+		/**
+		 * Resolve the class only if it's allowed to deserialize.
+		 *
+		 * @see ObjectInputStream#resolveClass(ObjectStreamClass)
+		 */
+		@Override
+		protected Class<?> resolveClass(ObjectStreamClass classDesc) throws IOException, ClassNotFoundException {
+			if (isProhibited(classDesc.getName())) {
+				throw new NotSerializableException("Not allowed to deserialize " + classDesc.getName());
+			}
+			if (this.classLoader != null) {
+				return ClassUtils.forName(classDesc.getName(), this.classLoader);
+			}
+			return super.resolveClass(classDesc);
+		}
+
+		/**
+		 * Check if the class is allowed to be deserialized.
+		 *
+		 * @param className the class to check
+		 * @return true if the class is not allowed to be deserialized, false otherwise
+		 */
+		private boolean isProhibited(String className) {
+			for (String allowedClass : this.allowedClasses) {
+				if (className.startsWith(allowedClass)) {
+					return false;
+				}
+			}
+			return true;
 		}
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/SerializationUtilsTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/SerializationUtilsTest.java
@@ -1,0 +1,61 @@
+package org.springframework.security.oauth2.common.util;
+
+import static org.junit.Assert.*;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.UUID;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.common.DefaultExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+
+/**
+ * @author Artem Smotrakov
+ */
+public class SerializationUtilsTest {
+
+  @Test
+  public void deserializeAllowedClasses() {
+    deserializeAllowedClasses(new DefaultOAuth2AccessToken("access-token-" + UUID.randomUUID()));
+
+    deserializeAllowedClasses(new OAuth2Authentication(
+        new OAuth2Request(Collections.<String, String>emptyMap(), "clientId", Collections.<GrantedAuthority>emptyList(),
+            false, Collections.<String>emptySet(),
+            new HashSet<String>(Arrays.asList("resourceId-1", "resourceId-2")), "redirectUri",
+            Collections.<String>emptySet(), Collections.<String, Serializable>emptyMap()),
+        new UsernamePasswordAuthenticationToken("test", "N/A")));
+
+    deserializeAllowedClasses(new DefaultExpiringOAuth2RefreshToken(
+        "access-token-" + UUID.randomUUID(), new Date()));
+
+    deserializeAllowedClasses("xyz");
+    deserializeAllowedClasses(new HashMap<String, String>());
+  }
+
+  private void deserializeAllowedClasses(Object object) {
+    byte[] bytes = SerializationUtils.serialize(object);
+    assertNotNull(bytes);
+    assertTrue(bytes.length > 0);
+
+    Object clone = SerializationUtils.deserialize(bytes);
+    assertNotNull(clone);
+    assertEquals(object, clone);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void deserializeProhibitedClasses() throws UnknownHostException {
+    byte[] bytes = SerializationUtils.serialize(InetAddress.getLocalHost());
+    SerializationUtils.deserialize(bytes);
+  }
+
+}


### PR DESCRIPTION
Please review the following patch which fixes gh-1759 (similar to #1703)

- Updated `SerializationUtils` to use `SaferObjectInputStream` with a list of allowed classes.
- Added `SerializationUtilsTest`.