### PR TITLE
Allow specifying allowed classes for deserialization

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/DefaultSerializationStrategy.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/DefaultSerializationStrategy.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.common.util;
+
+import org.springframework.core.ConfigurableObjectInputStream;
+
+import java.io.*;
+
+/**
+ * This is a default {@link SerializationStrategy} which uses the build-it Java serialization mechanism.
+ * <br/>
+ * Note that this class should not be used if data for deserialization comes from an untrusted source.
+ * Instead, please use {@link WhitelistedSerializationStrategy} with a list of allowed classes for deserialization.
+ *
+ * @author Artem Smotrakov
+ * @since 2.4
+ */
+public class DefaultSerializationStrategy implements SerializationStrategy {
+
+    public byte[] serialize(Object state) {
+        ObjectOutputStream oos = null;
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream(512);
+            oos = new ObjectOutputStream(bos);
+            oos.writeObject(state);
+            oos.flush();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        } finally {
+            if (oos != null) {
+                try {
+                    oos.close();
+                } catch (IOException e) {
+                    // eat it
+                }
+            }
+        }
+    }
+
+    public <T> T deserialize(byte[] byteArray) {
+        ObjectInputStream oip = null;
+        try {
+            oip = createObjectInputStream(byteArray);
+            @SuppressWarnings("unchecked")
+            T result = (T) oip.readObject();
+            return result;
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(e);
+        } finally {
+            if (oip != null) {
+                try {
+                    oip.close();
+                } catch (IOException e) {
+                    // eat it
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates an {@link ObjectInputStream} for deserialization.
+     *
+     * @param byteArray Data to be deserialized.
+     * @return An instance of {@link ObjectInputStream} which should be used for deserialization.
+     * @throws IOException If something went wrong.
+     */
+    protected ObjectInputStream createObjectInputStream(byte[] byteArray) throws IOException {
+        return new ConfigurableObjectInputStream(new ByteArrayInputStream(byteArray),
+                Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/SerializationStrategy.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/SerializationStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.common.util;
+
+/**
+ * Defines how objects are serialized an deserialized.
+ *
+ * @author Artem Smotrakov
+ * @since 2.4
+ */
+public interface SerializationStrategy {
+
+    /**
+     * Serializes an object.
+     *
+     * @param object The object to be serialized.
+     * @return A byte array.
+     */
+    byte[] serialize(Object object);
+
+    /**
+     * Deserializes an object from a byte array.
+     *
+     * @param byteArray The byte array.
+     * @param <T>       The type of the object.
+     * @return The deserialized object.
+     */
+    <T> T deserialize(byte[] byteArray);
+
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/WhitelistedSerializationStrategy.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/util/WhitelistedSerializationStrategy.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.common.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * This is a {@link SerializationStrategy} which uses a whitelist of allowed classes for deserialization.
+ *
+ * @author Artem Smotrakov
+ * @since 2.4
+ */
+public class WhitelistedSerializationStrategy extends DefaultSerializationStrategy {
+
+    /**
+     * A list of classes which are allowed to deserialize by default.
+     */
+    private static final List<String> DEFAULT_ALLOWED_CLASSES;
+
+    static {
+        List<String> classes = new ArrayList<String>();
+        classes.add("java.lang.");
+        classes.add("java.util.");
+        classes.add("org.springframework.security.");
+        DEFAULT_ALLOWED_CLASSES = Collections.unmodifiableList(classes);
+    }
+
+    /**
+     * A list of classes which allowed to deserialize.
+     */
+    private final List<String> allowedClasses;
+
+    /**
+     * Initializes {@link WhitelistedSerializationStrategy} with the list of classes
+     * which are allowed to deserialize by default.
+     */
+    public WhitelistedSerializationStrategy() {
+        this(DEFAULT_ALLOWED_CLASSES);
+    }
+
+    /**
+     * Initializes {@link WhitelistedSerializationStrategy} with specified allowed classes.
+     *
+     * @param allowedClasses The allowed classes for deserialization.
+     */
+    public WhitelistedSerializationStrategy(List<String> allowedClasses) {
+        this.allowedClasses = Collections.unmodifiableList(allowedClasses);
+    }
+
+    protected ObjectInputStream createObjectInputStream(byte[] byteArray) throws IOException {
+        return new WhitelistedObjectInputStream(new ByteArrayInputStream(byteArray),
+                Thread.currentThread().getContextClassLoader(), allowedClasses);
+    }
+
+    /**
+     * Special ObjectInputStream subclass that checks if classes are allowed to deserialize. The class
+     * should be configured with a whitelist of only allowed (safe) classes to deserialize.
+     */
+    private static class WhitelistedObjectInputStream extends ObjectInputStream {
+
+        /**
+         * The list of classes which are allowed for deserialization.
+         */
+        private final List<String> allowedClasses;
+
+        /**
+         * The class loader to use for loading local classes.
+         */
+        private final ClassLoader classLoader;
+
+        /**
+         * Create a new WhitelistedObjectInputStream for the given InputStream, class loader and
+         * allowed class names.
+         *
+         * @param in             The InputStream to read from.
+         * @param classLoader    The ClassLoader to use for loading local classes.
+         * @param allowedClasses The list of allowed classes for deserialization.
+         * @throws IOException If something went wrong.
+         */
+        private WhitelistedObjectInputStream(InputStream in, ClassLoader classLoader, List<String> allowedClasses)
+                throws IOException {
+            super(in);
+            this.classLoader = classLoader;
+            this.allowedClasses = Collections.unmodifiableList(allowedClasses);
+        }
+
+        /**
+         * Resolve the class only if it's allowed to deserialize.
+         *
+         * @see ObjectInputStream#resolveClass(ObjectStreamClass)
+         */
+        @Override
+        protected Class<?> resolveClass(ObjectStreamClass classDesc)
+                throws IOException, ClassNotFoundException {
+            if (isProhibited(classDesc.getName())) {
+                throw new NotSerializableException("Not allowed to deserialize " + classDesc.getName());
+            }
+            if (this.classLoader != null) {
+                return ClassUtils.forName(classDesc.getName(), this.classLoader);
+            }
+            return super.resolveClass(classDesc);
+        }
+
+        /**
+         * Check if the class is allowed to be deserialized.
+         *
+         * @param className The class to check.
+         * @return True if the class is not allowed to be deserialized, false otherwise.
+         */
+        private boolean isProhibited(String className) {
+            for (String allowedClass : this.allowedClasses) {
+                if (className.startsWith(allowedClass)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/JdkSerializationStrategy.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/redis/JdkSerializationStrategy.java
@@ -1,26 +1,50 @@
 package org.springframework.security.oauth2.provider.token.store.redis;
 
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.core.serializer.support.SerializationFailedException;
+
+import java.io.Serializable;
+
+import org.springframework.security.oauth2.common.util.SerializationUtils;
 
 /**
- * Serializes objects using {@link JdkSerializationRedisSerializer}
+ * Serializes and deserializes allowed objects using {@link SerializationUtils}.
  *
  * @author efenderbosch
- *
+ * @author Artem Smotrakov
  */
 public class JdkSerializationStrategy extends StandardStringSerializationStrategy {
 
-	private static final JdkSerializationRedisSerializer OBJECT_SERIALIZER = new JdkSerializationRedisSerializer();
+    private static final byte[] EMPTY_ARRAY = new byte[0];
 
-	@Override
-	@SuppressWarnings("unchecked")
-	protected <T> T deserializeInternal(byte[] bytes, Class<T> clazz) {
-		return (T) OBJECT_SERIALIZER.deserialize(bytes);
-	}
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T> T deserializeInternal(byte[] bytes, Class<T> clazz) {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        try {
+            return (T) SerializationUtils.deserialize(bytes);
+        } catch (Exception e) {
+            throw new SerializationFailedException("Failed to deserialize payload", e);
+        }
+    }
 
-	@Override
-	protected byte[] serializeInternal(Object object) {
-		return OBJECT_SERIALIZER.serialize(object);
-	}
+    @Override
+    protected byte[] serializeInternal(Object object) {
+        if (object == null) {
+            return EMPTY_ARRAY;
+        }
+        if (!(object instanceof Serializable)) {
+            throw new IllegalArgumentException(this.getClass().getSimpleName()
+                + " requires a Serializable payload but received an object of type ["
+                + object.getClass().getName() + "]");
+        }
+
+        try {
+            return SerializationUtils.serialize(object);
+        } catch (Exception e) {
+            throw new SerializationFailedException("Failed to serialize object", e);
+        }
+    }
 
 }

--- a/spring-security-oauth2/src/test/java/org/company/oauth2/CustomAuthentication.java
+++ b/spring-security-oauth2/src/test/java/org/company/oauth2/CustomAuthentication.java
@@ -1,0 +1,24 @@
+package org.company.oauth2;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class CustomAuthentication extends AbstractAuthenticationToken  {
+
+    private static final long serialVersionUID = 1L;
+
+    private String principal;
+
+    public CustomAuthentication(String name, boolean authenticated) {
+        super(null);
+        setAuthenticated(authenticated);
+        this.principal = name;
+    }
+
+    public Object getCredentials() {
+        return null;
+    }
+
+    public Object getPrincipal() {
+        return this.principal;
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/company/oauth2/CustomOAuth2AccessToken.java
+++ b/spring-security-oauth2/src/test/java/org/company/oauth2/CustomOAuth2AccessToken.java
@@ -1,0 +1,10 @@
+package org.company.oauth2;
+
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+
+public class CustomOAuth2AccessToken extends DefaultOAuth2AccessToken {
+
+    public CustomOAuth2AccessToken(String value) {
+        super(value);
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/company/oauth2/CustomOAuth2Authentication.java
+++ b/spring-security-oauth2/src/test/java/org/company/oauth2/CustomOAuth2Authentication.java
@@ -1,0 +1,14 @@
+package org.company.oauth2;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+
+public class CustomOAuth2Authentication extends OAuth2Authentication {
+
+    public CustomOAuth2Authentication(
+            OAuth2Request storedRequest,
+            Authentication userAuthentication) {
+        super(storedRequest, userAuthentication);
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/JdbcClientTokenServicesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/JdbcClientTokenServicesTests.java
@@ -1,10 +1,10 @@
 package org.springframework.security.oauth2.client.token;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
+import org.company.oauth2.CustomOAuth2AccessToken;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,10 +15,15 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.util.SerializationStrategy;
+import org.springframework.security.oauth2.common.util.SerializationUtils;
+import org.springframework.security.oauth2.common.util.WhitelistedSerializationStrategy;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Dave Syer
- * 
+ * @author Artem Smotrakov
  */
 public class JdbcClientTokenServicesTests {
 
@@ -79,4 +84,58 @@ public class JdbcClientTokenServicesTests {
 		assertNull(result);
 	}
 
+	@Test
+	public void testSaveAndRetrieveCustomToken() {
+		OAuth2AccessToken accessToken = new CustomOAuth2AccessToken("FOO");
+		Authentication authentication = new UsernamePasswordAuthenticationToken("marissa", "koala");
+		AuthorizationCodeResourceDetails resource = new AuthorizationCodeResourceDetails();
+		resource.setClientId("client");
+		resource.setScope(Arrays.asList("foo", "bar"));
+		tokenStore.saveAccessToken(resource, authentication, accessToken);
+		OAuth2AccessToken result = tokenStore.getAccessToken(resource, authentication);
+		assertNotNull(result);
+		assertEquals(accessToken, result);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSaveAndRetrieveNotAllowedCustomToken() {
+		OAuth2AccessToken accessToken = new CustomOAuth2AccessToken("FOO");
+		Authentication authentication = new UsernamePasswordAuthenticationToken("marissa", "koala");
+		AuthorizationCodeResourceDetails resource = new AuthorizationCodeResourceDetails();
+		resource.setClientId("client");
+		resource.setScope(Arrays.asList("foo", "bar"));
+		WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy();
+		SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+		try {
+			SerializationUtils.setSerializationStrategy(newStrategy);
+			tokenStore.saveAccessToken(resource, authentication, accessToken);
+			tokenStore.getAccessToken(resource, authentication);
+		} finally {
+			SerializationUtils.setSerializationStrategy(oldStrategy);
+		}
+	}
+
+	@Test
+	public void testSaveAndRetrieveCustomTokenWithCustomSerializationStrategy() {
+		List<String> allowedClasses = new ArrayList<String>();
+		allowedClasses.add("java.util.");
+		allowedClasses.add("org.springframework.security.");
+		allowedClasses.add("org.company.oauth2.CustomOAuth2AccessToken");
+		WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy(allowedClasses);
+		SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+		try {
+			SerializationUtils.setSerializationStrategy(newStrategy);
+			OAuth2AccessToken accessToken = new CustomOAuth2AccessToken("FOO");
+			Authentication authentication = new UsernamePasswordAuthenticationToken("marissa", "koala");
+			AuthorizationCodeResourceDetails resource = new AuthorizationCodeResourceDetails();
+			resource.setClientId("client");
+			resource.setScope(Arrays.asList("foo", "bar"));
+			tokenStore.saveAccessToken(resource, authentication, accessToken);
+			OAuth2AccessToken result = tokenStore.getAccessToken(resource, authentication);
+			assertNotNull(result);
+			assertEquals(accessToken, result);
+		} finally {
+			SerializationUtils.setSerializationStrategy(oldStrategy);
+		}
+	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/CustomSerializationStrategyTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/CustomSerializationStrategyTest.java
@@ -1,0 +1,87 @@
+package org.springframework.security.oauth2.common.util;
+
+
+import org.company.oauth2.CustomAuthentication;
+import org.company.oauth2.CustomOAuth2AccessToken;
+import org.company.oauth2.CustomOAuth2Authentication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.common.DefaultExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.RequestTokenFactory;
+
+import java.io.Serializable;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ SpringFactoriesLoader.class })
+public class CustomSerializationStrategyTest {
+
+    @Test
+    public void loadCustomSerializationStrategy() {
+        spy(SpringFactoriesLoader.class);
+        when(SpringFactoriesLoader
+                .loadFactories(SerializationStrategy.class, SerializationUtils.class.getClassLoader()))
+                .thenReturn(Arrays.<SerializationStrategy>asList(new CustomSerializationStrategy()));
+
+        deserialize(new DefaultOAuth2AccessToken("access-token-" + UUID.randomUUID()));
+
+        deserialize(new OAuth2Authentication(
+                new OAuth2Request(Collections.<String, String>emptyMap(), "clientId", Collections.<GrantedAuthority>emptyList(),
+                        false, Collections.<String>emptySet(),
+                        new HashSet<String>(Arrays.asList("resourceId-1", "resourceId-2")), "redirectUri",
+                        Collections.<String>emptySet(), Collections.<String, Serializable>emptyMap()),
+                new UsernamePasswordAuthenticationToken("test", "N/A")));
+
+        deserialize(new DefaultExpiringOAuth2RefreshToken(
+                "access-token-" + UUID.randomUUID(), new Date()));
+
+        deserialize("xyz");
+        deserialize(new HashMap<String, String>());
+
+        deserialize(new CustomOAuth2AccessToken("xyz"));
+
+        deserialize(
+                new CustomOAuth2Authentication(
+                        RequestTokenFactory.createOAuth2Request("id", false),
+                        new CustomAuthentication("test", false)));
+    }
+
+    private void deserialize(Object object) {
+        byte[] bytes = SerializationUtils.serialize(object);
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 0);
+
+        Object clone = SerializationUtils.deserialize(bytes);
+        assertNotNull(clone);
+        assertEquals(object, clone);
+    }
+
+    private static class CustomSerializationStrategy extends WhitelistedSerializationStrategy {
+
+        private static final List<String> ALLOWED_CLASSES = new ArrayList<String>();
+        static {
+            ALLOWED_CLASSES.add("java.lang.");
+            ALLOWED_CLASSES.add("java.util.");
+            ALLOWED_CLASSES.add("org.springframework.security.");
+            ALLOWED_CLASSES.add("org.company.oauth2.");
+        }
+
+        CustomSerializationStrategy() {
+            super(ALLOWED_CLASSES);
+        }
+
+    }
+
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/SerializationUtilsTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/common/util/SerializationUtilsTest.java
@@ -1,0 +1,82 @@
+package org.springframework.security.oauth2.common.util;
+
+import org.company.oauth2.CustomOAuth2AccessToken;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.common.DefaultExpiringOAuth2RefreshToken;
+import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Artem Smotrakov
+ */
+public class SerializationUtilsTest {
+
+    @Test
+    public void deserializeAllowedClasses() {
+        deserializeAllowedClasses(new DefaultOAuth2AccessToken("access-token-" + UUID.randomUUID()));
+
+        deserializeAllowedClasses(new OAuth2Authentication(
+                new OAuth2Request(Collections.<String, String>emptyMap(), "clientId", Collections.<GrantedAuthority>emptyList(),
+                        false, Collections.<String>emptySet(),
+                        new HashSet<String>(Arrays.asList("resourceId-1", "resourceId-2")), "redirectUri",
+                        Collections.<String>emptySet(), Collections.<String, Serializable>emptyMap()),
+                new UsernamePasswordAuthenticationToken("test", "N/A")));
+
+        deserializeAllowedClasses(new DefaultExpiringOAuth2RefreshToken(
+                "access-token-" + UUID.randomUUID(), new Date()));
+
+        deserializeAllowedClasses("xyz");
+        deserializeAllowedClasses(new HashMap<String, String>());
+    }
+
+    private void deserializeAllowedClasses(Object object) {
+        byte[] bytes = SerializationUtils.serialize(object);
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 0);
+
+        Object clone = SerializationUtils.deserialize(bytes);
+        assertNotNull(clone);
+        assertEquals(object, clone);
+    }
+
+    @Test
+    public void deserializeCustomClasses() {
+        OAuth2AccessToken accessToken = new CustomOAuth2AccessToken("FOO");
+        byte[] bytes = SerializationUtils.serialize(accessToken);
+        OAuth2AccessToken clone = SerializationUtils.deserialize(bytes);
+        assertNotNull(clone);
+        assertEquals(accessToken, clone);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void deserializeNotAllowedCustomClasses() {
+        OAuth2AccessToken accessToken = new CustomOAuth2AccessToken("FOO");
+        WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy();
+        SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+        try {
+            SerializationUtils.setSerializationStrategy(newStrategy);
+            byte[] bytes = SerializationUtils.serialize(accessToken);
+            OAuth2AccessToken clone = SerializationUtils.deserialize(bytes);
+            assertNotNull(clone);
+            assertEquals(accessToken, clone);
+        } finally {
+            SerializationUtils.setSerializationStrategy(oldStrategy);
+        }
+    }
+}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/AuthorizationRequestTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/AuthorizationRequestTests.java
@@ -30,7 +30,7 @@ import java.util.SortedSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
-import org.springframework.util.SerializationUtils;
+import org.springframework.security.oauth2.common.util.SerializationUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -161,8 +161,8 @@ public class AuthorizationRequestTests {
 	@Test
 	public void testSerialization() {
 		AuthorizationRequest authorizationRequest = createFromParameters(parameters);
-		AuthorizationRequest other = (AuthorizationRequest) SerializationUtils.deserialize(SerializationUtils
-				.serialize(authorizationRequest));
+		AuthorizationRequest other = SerializationUtils.deserialize(
+				SerializationUtils.serialize(authorizationRequest));
 		assertEquals(authorizationRequest, other);
 	}
 

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/JdbcAuthorizationCodeServicesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/code/JdbcAuthorizationCodeServicesTests.java
@@ -1,9 +1,24 @@
 package org.springframework.security.oauth2.provider.code;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.company.oauth2.CustomAuthentication;
+import org.company.oauth2.CustomOAuth2Authentication;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.security.oauth2.common.util.SerializationStrategy;
+import org.springframework.security.oauth2.common.util.SerializationUtils;
+import org.springframework.security.oauth2.common.util.WhitelistedSerializationStrategy;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.RequestTokenFactory;
 
 public class JdbcAuthorizationCodeServicesTests extends AuthorizationCodeServicesBaseTests {
 	private JdbcAuthorizationCodeServices authorizationCodeServices;
@@ -25,5 +40,60 @@ public class JdbcAuthorizationCodeServicesTests extends AuthorizationCodeService
 	@Override
 	AuthorizationCodeServices getAuthorizationCodeServices() {
 		return authorizationCodeServices;
+	}
+
+	@Test
+	public void testCustomImplementation() {
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request("id", false);
+		OAuth2Authentication expectedAuthentication = new CustomOAuth2Authentication(storedOAuth2Request,
+				new CustomAuthentication("test2", false));
+		String code = getAuthorizationCodeServices().createAuthorizationCode(expectedAuthentication);
+		assertNotNull(code);
+		OAuth2Authentication actualAuthentication = getAuthorizationCodeServices().consumeAuthorizationCode(code);
+		assertEquals(expectedAuthentication, actualAuthentication);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNotAllowedCustomImplementation() {
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request("id", false);
+		OAuth2Authentication expectedAuthentication = new CustomOAuth2Authentication(storedOAuth2Request,
+				new CustomAuthentication("test2", false));
+		WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy();
+		SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+		try {
+			SerializationUtils.setSerializationStrategy(newStrategy);
+			String code = getAuthorizationCodeServices().createAuthorizationCode(expectedAuthentication);
+			assertNotNull(code);
+			getAuthorizationCodeServices().consumeAuthorizationCode(code);
+		} finally {
+			SerializationUtils.setSerializationStrategy(oldStrategy);
+		}
+	}
+
+	@Test
+	public void testCustomImplementationWithCustomStrategy() {
+		OAuth2Request storedOAuth2Request = RequestTokenFactory.createOAuth2Request("id", false);
+		OAuth2Authentication expectedAuthentication = new CustomOAuth2Authentication(storedOAuth2Request,
+				new CustomAuthentication("test3", false));
+
+		AuthorizationCodeServices jdbcAuthorizationCodeServices = getAuthorizationCodeServices();
+		List<String> allowedClasses = new ArrayList<String>();
+		allowedClasses.add("java.util.");
+		allowedClasses.add("org.springframework.security.");
+		allowedClasses.add("org.company.oauth2.CustomOAuth2AccessToken");
+		allowedClasses.add("org.company.oauth2.CustomOAuth2Authentication");
+		allowedClasses.add("org.company.oauth2.CustomAuthentication");
+		WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy(allowedClasses);
+		SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+		try {
+			SerializationUtils.setSerializationStrategy(newStrategy);
+			String code = jdbcAuthorizationCodeServices.createAuthorizationCode(expectedAuthentication);
+			assertNotNull(code);
+
+			OAuth2Authentication actualAuthentication = getAuthorizationCodeServices().consumeAuthorizationCode(code);
+			assertEquals(expectedAuthentication, actualAuthentication);
+		} finally {
+			SerializationUtils.setSerializationStrategy(oldStrategy);
+		}
 	}
 }

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStoreTests.java
@@ -1,9 +1,13 @@
 package org.springframework.security.oauth2.provider.token.store;
 
-import static org.junit.Assert.assertEquals;
-
+import java.util.ArrayList;
 import java.util.Collection;
 
+import java.util.List;
+
+import org.company.oauth2.CustomAuthentication;
+import org.company.oauth2.CustomOAuth2AccessToken;
+import org.company.oauth2.CustomOAuth2Authentication;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,12 +15,17 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.util.SerializationStrategy;
+import org.springframework.security.oauth2.common.util.SerializationUtils;
+import org.springframework.security.oauth2.common.util.WhitelistedSerializationStrategy;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.RequestTokenFactory;
 
+import static org.junit.Assert.*;
+
 /**
  * @author Dave Syer
- *
+ * @author Artem Smotrakov
  */
 public class JdbcTokenStoreTests extends TokenStoreBaseTests {
 
@@ -44,6 +53,71 @@ public class JdbcTokenStoreTests extends TokenStoreBaseTests {
 
 		Collection<OAuth2AccessToken> actualOAuth2AccessTokens = getTokenStore().findTokensByUserName("test2");
 		assertEquals(1, actualOAuth2AccessTokens.size());
+	}
+
+	@Test
+	public void testCustomToken() {
+		OAuth2Authentication expectedAuthentication = new CustomOAuth2Authentication(
+				RequestTokenFactory.createOAuth2Request("id", false),
+				new TestAuthentication("test2", false));
+		OAuth2AccessToken expectedOAuth2AccessToken = new CustomOAuth2AccessToken("customToken");
+		getTokenStore().storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
+
+		Collection<OAuth2AccessToken> actualOAuth2AccessTokens = getTokenStore().findTokensByUserName("test2");
+		assertFalse(actualOAuth2AccessTokens.isEmpty());
+		for (OAuth2AccessToken token : actualOAuth2AccessTokens) {
+			if (expectedOAuth2AccessToken.equals(token)) {
+				return;
+			}
+		}
+		fail("No token found!");
+	}
+
+	@Test
+	public void testAllowedCustomTokenWithCustomStrategy() {
+		OAuth2Authentication expectedAuthentication = new CustomOAuth2Authentication(
+				RequestTokenFactory.createOAuth2Request("id", false),
+				new TestAuthentication("test3", false));
+		OAuth2AccessToken expectedOAuth2AccessToken = new CustomOAuth2AccessToken("customToken");
+		JdbcTokenStore tokenStore = getTokenStore();
+		List<String> allowedClasses = new ArrayList<String>();
+		allowedClasses.add("java.util.");
+		allowedClasses.add("org.springframework.security.");
+		allowedClasses.add("org.company.oauth2.CustomOAuth2AccessToken");
+		allowedClasses.add("org.company.oauth2.CustomOAuth2Authentication");
+		WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy(allowedClasses);
+		SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+		try {
+			SerializationUtils.setSerializationStrategy(newStrategy);
+			tokenStore.storeAccessToken(expectedOAuth2AccessToken, expectedAuthentication);
+
+			Collection<OAuth2AccessToken> actualOAuth2AccessTokens = getTokenStore().findTokensByUserName("test3");
+			assertEquals(1, actualOAuth2AccessTokens.size());
+
+			OAuth2AccessToken actualToken = actualOAuth2AccessTokens.iterator().next();
+			assertEquals(expectedOAuth2AccessToken, actualToken);
+		} finally {
+			SerializationUtils.setSerializationStrategy(oldStrategy);
+		}
+	}
+
+	@Test
+	public void testNotAllowedCustomTokenWithCustomStrategy() {
+		OAuth2Authentication authentication = new CustomOAuth2Authentication(
+				RequestTokenFactory.createOAuth2Request("id", false),
+				new CustomAuthentication("test4", false));
+		OAuth2AccessToken accessToken = new CustomOAuth2AccessToken("customToken");
+		JdbcTokenStore tokenStore = getTokenStore();
+		WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy();
+		SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+		try {
+			SerializationUtils.setSerializationStrategy(newStrategy);
+			tokenStore.storeAccessToken(accessToken, authentication);
+			Collection<OAuth2AccessToken> tokens = tokenStore.findTokensByUserName("test4");
+			assertTrue(tokens.isEmpty());
+		} finally {
+			SerializationUtils.setSerializationStrategy(oldStrategy);
+		}
 	}
 
 	@After

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStoreCustomTokenTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStoreCustomTokenTests.java
@@ -1,0 +1,125 @@
+package org.springframework.security.oauth2.provider.token.store.redis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.company.oauth2.CustomOAuth2AccessToken;
+import org.company.oauth2.CustomOAuth2Authentication;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.serializer.support.SerializationFailedException;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.util.SerializationStrategy;
+import org.springframework.security.oauth2.common.util.SerializationUtils;
+import org.springframework.security.oauth2.common.util.WhitelistedSerializationStrategy;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.oauth2.provider.RequestTokenFactory;
+import org.springframework.util.ClassUtils;
+import redis.clients.jedis.JedisShardInfo;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Artem Smotrakov
+ */
+public class RedisTokenStoreCustomTokenTests {
+
+    private static final String CLIENT_ID = "customClient";
+
+    private static final List<String> ALLOWED_CLASSES = new ArrayList<String>();
+
+    static {
+        ALLOWED_CLASSES.add("java.util.");
+        ALLOWED_CLASSES.add("org.springframework.security.");
+        ALLOWED_CLASSES.add("org.company.oauth2.CustomOAuth2AccessToken");
+        ALLOWED_CLASSES.add("org.company.oauth2.CustomOAuth2Authentication");
+    }
+
+    private RedisTokenStore tokenStore;
+
+    @Before
+    public void setup() {
+        boolean springDataRedis_2_0 = ClassUtils.isPresent(
+                "org.springframework.data.redis.connection.RedisStandaloneConfiguration",
+                this.getClass().getClassLoader());
+
+        JedisConnectionFactory connectionFactory;
+        if (springDataRedis_2_0) {
+            connectionFactory = new JedisConnectionFactory();
+        } else {
+            JedisShardInfo shardInfo = new JedisShardInfo("localhost");
+            connectionFactory = new JedisConnectionFactory(shardInfo);
+        }
+
+        tokenStore = new RedisTokenStore(connectionFactory);
+    }
+
+    @Test
+    public void testCustomToken() {
+        OAuth2Request request = RequestTokenFactory.createOAuth2Request(CLIENT_ID, false);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "password");
+
+        String token = "access-token-" + UUID.randomUUID();
+        OAuth2AccessToken oauth2AccessToken = new CustomOAuth2AccessToken(token);
+        OAuth2Authentication oauth2Authentication = new OAuth2Authentication(request, authentication);
+
+        tokenStore.storeAccessToken(oauth2AccessToken, oauth2Authentication);
+        Collection<OAuth2AccessToken> tokens = tokenStore.findTokensByClientId(request.getClientId());
+        assertNotNull(tokens);
+        assertFalse(tokens.isEmpty());
+        for (OAuth2AccessToken oAuth2AccessToken : tokens) {
+            if (token.equals(oAuth2AccessToken.getValue())) {
+                return;
+            }
+        }
+        fail("No token found!");
+    }
+
+    @Test(expected = SerializationFailedException.class)
+    public void testNotAllowedCustomToken() {
+        OAuth2Request request = RequestTokenFactory.createOAuth2Request(CLIENT_ID, false);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "password");
+
+        String token = "access-token-" + UUID.randomUUID();
+        OAuth2AccessToken oauth2AccessToken = new CustomOAuth2AccessToken(token);
+        OAuth2Authentication oauth2Authentication = new OAuth2Authentication(request, authentication);
+
+        WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy();
+        SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+        try {
+            SerializationUtils.setSerializationStrategy(newStrategy);
+            tokenStore.storeAccessToken(oauth2AccessToken, oauth2Authentication);
+            tokenStore.findTokensByClientId(request.getClientId());
+        } finally {
+            SerializationUtils.setSerializationStrategy(oldStrategy);
+        }
+    }
+
+    @Test
+    public void testCustomTokenWithCustomSerializationStrategy() {
+        OAuth2Request request = RequestTokenFactory.createOAuth2Request(CLIENT_ID, false);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "password");
+
+        OAuth2AccessToken oauth2AccessToken = new CustomOAuth2AccessToken("access-token-" + UUID.randomUUID());
+        OAuth2Authentication oauth2Authentication = new CustomOAuth2Authentication(request, authentication);
+
+        WhitelistedSerializationStrategy newStrategy = new WhitelistedSerializationStrategy(ALLOWED_CLASSES);
+        SerializationStrategy oldStrategy = SerializationUtils.getSerializationStrategy();
+        try {
+            SerializationUtils.setSerializationStrategy(newStrategy);
+            tokenStore.storeAccessToken(oauth2AccessToken, oauth2Authentication);
+
+            OAuth2AccessToken token = tokenStore.getAccessToken(oauth2Authentication);
+            assertNotNull(token);
+            assertEquals(oauth2AccessToken, token);
+        } finally {
+            SerializationUtils.setSerializationStrategy(oldStrategy);
+        }
+    }
+
+}


### PR DESCRIPTION
This patch fixes #1783

1. Moved `SaferObjectInputStream` to `org.springframework.security.oauth2.common.util`. The class allow specifying custom list of allowed classes.
2. Added `SerializationStrategy` based on `SerializationUtils`. The new class uses `SaferObjectInputStream` and defines the default list of allowed classes for deserialization. The class allow specifying custom list of allowed classes.
3. Revert changes in `SerializationUtils` and marked it as deprecated.
4. Updated JDBC services to use `SerializationStrategy` instead of `SerializationUtils`. The classes allow specifying custom `SerializationStrategy`.
5. Updated `JdkSerializationStrategy` (used with Redis)` to use `SerializationStrategy`. The class allow specifying custom list of allowed classes.