### PR TITLE
fix: solving npe

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -143,6 +143,11 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 		}
 
 		OAuth2Authentication authentication = tokenStore.readAuthenticationForRefreshToken(refreshToken);
+
+		if (authentication == null) {
+			throw new InvalidGrantException("Authentication not found for this refresh token: " + refreshTokenValue);
+		}
+
 		if (this.authenticationManager != null && !authentication.isClientOnly()) {
 			// The client has already been authenticated, but the user authentication might be old now, so give it a
 			// chance to re-authenticate.

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/DefaultTokenServicesTests.java
@@ -4,8 +4,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.security.oauth2.common.DefaultOAuth2AccessToken;
+import org.springframework.security.oauth2.common.DefaultOAuth2RefreshToken;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
 
 public class DefaultTokenServicesTests {
 
@@ -30,4 +33,17 @@ public class DefaultTokenServicesTests {
 		services.loadAuthentication("FOO");
 	}
 
+	@Test(expected = InvalidGrantException.class)
+	public void testAuthenticationNofFound() {
+		//given
+		Mockito.when(tokenStore.readAuthenticationForRefreshToken(Mockito.any(DefaultOAuth2RefreshToken.class)))
+				.thenReturn(null);
+
+		Mockito.when(tokenStore.readRefreshToken(Mockito.anyString())).thenReturn(new DefaultOAuth2RefreshToken("FOO"));
+
+		//when
+		services.setSupportRefreshToken(true);
+		services.setAuthenticationManager(new OAuth2AuthenticationManager());
+		services.refreshAccessToken("1234132ed13432f3", null);
+	}
 }


### PR DESCRIPTION
Hello, @pivotal-issuemaster This is an Obvious Fix.

This pull request resolves the `NullPointerException` that occurs when calling the` refreshAccessToken` function of the `DefaultTokenServices` class as per the log below.

```
java.lang.NullPointerException: java.lang.NullPointerException

Stack trace
…provider.token.DefaultTokenServices.refreshAccessToken (DefaultTokenServices.java:146)

org.springframework.security.oauth2.provider.token.DefaultTokenServices$$FastClassBySpringCGLIB$$5a1f25c.invoke(<generated>)
     org.springframework.cglib.proxy.MethodProxy.invoke (MethodProxy.java:204)

…rk.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint (CglibAopProxy.java:718)

…ework.aop.framework.ReflectiveMethodInvocation.proceed (ReflectiveMethodInvocation.java:157)
```

I hope it is useful

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
