### PR TITLE
Correcting links

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
@@ -80,7 +80,7 @@ public class OAuth2SecurityExpressionMethods {
 
 	/**
 	 * Check if the OAuth2 client (not the user) has the role specified. To check the user's roles see
-	 * {@link #clientHasRole(String)}.
+	 * {@link #ExpressionUrlAuthorizationConfigurer.hasRole(String)}.
 	 * 
 	 * @param role the role to check
 	 * @return true if the OAuth2 client has this role
@@ -91,7 +91,7 @@ public class OAuth2SecurityExpressionMethods {
 
 	/**
 	 * Check if the OAuth2 client (not the user) has one of the roles specified. To check the user's roles see
-	 * {@link #clientHasAnyRole(String...)}.
+	 * {@link #ExpressionUrlAuthorizationConfigurer.hasAnyRole(String...)}.
 	 * 
 	 * @param roles the roles to check
 	 * @return true if the OAuth2 client has one of these roles

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
@@ -80,7 +80,7 @@ public class OAuth2SecurityExpressionMethods {
 
 	/**
 	 * Check if the OAuth2 client (not the user) has the role specified. To check the user's roles see
-	 * {@link #ExpressionUrlAuthorizationConfigurer.hasRole(String)}.
+	 * {@link ExpressionUrlAuthorizationConfigurer#hasRole(String)}.
 	 * 
 	 * @param role the role to check
 	 * @return true if the OAuth2 client has this role
@@ -91,7 +91,7 @@ public class OAuth2SecurityExpressionMethods {
 
 	/**
 	 * Check if the OAuth2 client (not the user) has one of the roles specified. To check the user's roles see
-	 * {@link #ExpressionUrlAuthorizationConfigurer.hasAnyRole(String...)}.
+	 * {@link ExpressionUrlAuthorizationConfigurer#hasAnyRole(String...)}.
 	 * 
 	 * @param roles the roles to check
 	 * @return true if the OAuth2 client has one of these roles

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/expression/OAuth2SecurityExpressionMethods.java
@@ -80,7 +80,7 @@ public class OAuth2SecurityExpressionMethods {
 
 	/**
 	 * Check if the OAuth2 client (not the user) has the role specified. To check the user's roles see
-	 * {@link ExpressionUrlAuthorizationConfigurer#hasRole(String)}.
+	 * {@link #clientHasAnyRole(String...)}.
 	 * 
 	 * @param role the role to check
 	 * @return true if the OAuth2 client has this role
@@ -91,7 +91,7 @@ public class OAuth2SecurityExpressionMethods {
 
 	/**
 	 * Check if the OAuth2 client (not the user) has one of the roles specified. To check the user's roles see
-	 * {@link ExpressionUrlAuthorizationConfigurer#hasAnyRole(String...)}.
+	 * {@link OAuth2ExpressionUtils#clientHasAnyRole(Authentication, String...)}.
 	 * 
 	 * @param roles the roles to check
 	 * @return true if the OAuth2 client has one of these roles


### PR DESCRIPTION
Adjusting documentation links.  Currently they self-reference.
(Please check syntax and correct link target!)

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
