### PR TITLE
Fix check token NPE

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -24,6 +24,7 @@ import org.springframework.security.crypto.codec.Base64;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.DefaultResponseErrorHandler;
@@ -109,7 +110,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 		headers.set("Authorization", getAuthorizationHeader(clientId, clientSecret));
 		Map<String, Object> map = postForMap(checkTokenEndpointUrl, formData, headers);
 
-		if (map == null) {
+		if (CollectionUtils.isEmpty(map)) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("check_token returned empty");
 			}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -111,7 +111,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 
 		if (map == null) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("check_token returned empty: " + accessToken));
+				logger.debug("check_token returned empty: " + accessToken);
 			}
 			throw new InvalidTokenException(accessToken);
 		}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -109,6 +109,13 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 		headers.set("Authorization", getAuthorizationHeader(clientId, clientSecret));
 		Map<String, Object> map = postForMap(checkTokenEndpointUrl, formData, headers);
 
+		if (map == null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("check_token returned empty: " + accessToken));
+			}
+			throw new InvalidTokenException(accessToken);
+		}
+
 		if (map.containsKey("error")) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("check_token returned error: " + map.get("error"));

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/RemoteTokenServices.java
@@ -111,7 +111,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 
 		if (map == null) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("check_token returned empty: " + accessToken);
+				logger.debug("check_token returned empty");
 			}
 			throw new InvalidTokenException(accessToken);
 		}

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/RemoteTokenServicesTest.java
@@ -78,6 +78,16 @@ public class RemoteTokenServicesTest {
 		assertNotNull(authentication);
 	}
 
+	@Test(expected = InvalidTokenException.class)
+	public void loadAuthenticationWhenIntrospectionResponseNullThenThrowInvalidTokenException() throws Exception {
+		ResponseEntity<Map> response = new ResponseEntity<Map>(HttpStatus.REQUEST_TIMEOUT);
+		RestTemplate restTemplate = mock(RestTemplate.class);
+		when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(Class.class))).thenReturn(response);
+		this.remoteTokenServices.setRestTemplate(restTemplate);
+
+		this.remoteTokenServices.loadAuthentication("access-token-1234");
+	}
+
 	// gh-838
 	@Test(expected = InvalidTokenException.class)
 	public void loadAuthenticationWhenIntrospectionResponseContainsActiveFalseThenThrowInvalidTokenException() throws Exception {


### PR DESCRIPTION
Solve the problem of RemoteTokenServices.check_token NullPointerException.

If the auth-server cannot return correctly , postForMap will be empty


![image](https://user-images.githubusercontent.com/50090230/78123600-fb3c8d80-7440-11ea-879c-d241795c1302.png)
