### PR TITLE
Delete access_to_refresh key when removing refresh token in RedisTokenStore

### DIFF
--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStoreMockTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStoreMockTests.java
@@ -67,6 +67,13 @@ public class RedisTokenStoreMockTests {
 		ArgumentCaptor<byte[]> keyArgs = ArgumentCaptor.forClass(byte[].class);
 		verify(connection, times(2)).set(keyArgs.capture(), any(byte[].class));
 
+		List<Object> result = new ArrayList<Object>();
+		result.add(Long.valueOf(1));
+		result.add(Long.valueOf(1));
+		result.add(new byte[] {42});
+		result.add(Long.valueOf(1));
+		when(connection.closePipeline()).thenReturn(result);
+
 		tokenStore.removeRefreshToken(oauth2RefreshToken);
 
 		for (byte[] key : keyArgs.getAllValues()) {

--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStoreTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/provider/token/store/redis/RedisTokenStoreTests.java
@@ -2,6 +2,8 @@ package org.springframework.security.oauth2.provider.token.store.redis;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.oauth2.common.DefaultExpiringOAuth2RefreshToken;
@@ -17,8 +19,11 @@ import org.springframework.security.oauth2.provider.token.store.TokenStoreBaseTe
 import org.springframework.util.ClassUtils;
 import redis.clients.jedis.JedisShardInfo;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -28,6 +33,8 @@ import static org.junit.Assert.*;
  */
 public class RedisTokenStoreTests extends TokenStoreBaseTests {
 
+	private JedisConnectionFactory connectionFactory;
+	private RedisTokenStoreSerializationStrategy serializationStrategy = new JdkSerializationStrategy();
 	private RedisTokenStore tokenStore;
 
 	@Override
@@ -41,7 +48,6 @@ public class RedisTokenStoreTests extends TokenStoreBaseTests {
 				"org.springframework.data.redis.connection.RedisStandaloneConfiguration",
 				this.getClass().getClassLoader());
 
-		JedisConnectionFactory connectionFactory;
 		if (springDataRedis_2_0) {
 			connectionFactory = new JedisConnectionFactory();
 		} else {
@@ -49,7 +55,9 @@ public class RedisTokenStoreTests extends TokenStoreBaseTests {
 			connectionFactory = new JedisConnectionFactory(shardInfo);
 		}
 
+		serializationStrategy = new JdkSerializationStrategy();
 		tokenStore = new RedisTokenStore(connectionFactory);
+		tokenStore.setSerializationStrategy(serializationStrategy);
 	}
 
 	@Test
@@ -109,4 +117,46 @@ public class RedisTokenStoreTests extends TokenStoreBaseTests {
 		assertTrue(oauth2AccessTokens.isEmpty());
 	}
 
+	// gh-1836
+	@Test
+	public void storeAccessTokenWithRefreshTokenRemoveRefreshTokenAndAccessTokenVerifyTokenRemoved() {
+		OAuth2Request request = RequestTokenFactory.createOAuth2Request("clientId", false);
+		TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "password");
+
+		DefaultOAuth2AccessToken oauth2AccessToken = new DefaultOAuth2AccessToken(
+				"access-token-" + UUID.randomUUID());
+		DefaultOAuth2RefreshToken oauth2RefreshToken = new DefaultOAuth2RefreshToken(
+				"refresh-token-" + UUID.randomUUID());
+		oauth2AccessToken.setRefreshToken(oauth2RefreshToken);
+
+		OAuth2Authentication oauth2Authentication = new OAuth2Authentication(request, authentication);
+
+		tokenStore.storeAccessToken(oauth2AccessToken, oauth2Authentication);
+		String accessTokenValue = getValue("refresh_to_access:" + oauth2RefreshToken.getValue());
+		assertEquals(accessTokenValue, oauth2AccessToken.getValue());
+		String refreshTokenValue = getValue("access_to_refresh:" + oauth2AccessToken.getValue());
+		assertEquals(refreshTokenValue, oauth2RefreshToken.getValue());
+
+		tokenStore.removeRefreshToken(oauth2RefreshToken);
+		accessTokenValue = getValue("refresh_to_access:" + oauth2RefreshToken.getValue());
+		assertNull("Key refresh_to_access was not deleted!", accessTokenValue);
+		refreshTokenValue = getValue("access_to_refresh:" + oauth2AccessToken.getValue());
+		assertNull("Key access_to_refresh was not deleted!", refreshTokenValue);
+
+		tokenStore.removeAccessToken(oauth2AccessToken);
+
+		Collection<OAuth2AccessToken> oauth2AccessTokens = tokenStore.findTokensByClientId(request.getClientId());
+		assertTrue(oauth2AccessTokens.isEmpty());
+	}
+
+	private String getValue(String key) {
+		RedisConnection conn = connectionFactory.getConnection();
+		try {
+			byte[] value = conn.get(key.getBytes());
+			return serializationStrategy.deserializeString(value);
+		}
+		finally {
+			conn.close();
+		}
+	}
 }


### PR DESCRIPTION
fixes gh-1836

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
