### PR TITLE
Use url-safe mode for base64 encoding

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/DefaultTokenServices.java
@@ -291,7 +291,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 		}
 		int validitySeconds = getRefreshTokenValiditySeconds(authentication.getOAuth2Request());
 		String tokenValue = new String(Base64.encodeBase64(
-				DEFAULT_TOKEN_GENERATOR.generateKey()));
+				DEFAULT_TOKEN_GENERATOR.generateKey(), true, true));
 		if (validitySeconds > 0) {
 			return new DefaultExpiringOAuth2RefreshToken(tokenValue, new Date(System.currentTimeMillis()
 					+ (validitySeconds * 1000L)));
@@ -301,7 +301,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
 
 	private OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken) {
 		String tokenValue = new String(Base64.encodeBase64(
-				DEFAULT_TOKEN_GENERATOR.generateKey()));
+				DEFAULT_TOKEN_GENERATOR.generateKey(), true, true));
 		DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken(tokenValue);
 		int validitySeconds = getAccessTokenValiditySeconds(authentication.getOAuth2Request());
 		if (validitySeconds > 0) {


### PR DESCRIPTION
Fix for https://github.com/spring-projects/spring-security-oauth/issues/1857.

I am not sure if the class `org.springframework.security.oauth.provider.token.RandomValueProviderTokenServices` also needs this fix.

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
