### PR TITLE
Fix NPE in JdbcTokenStore

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/JdbcTokenStore.java
@@ -129,12 +129,14 @@ public class JdbcTokenStore implements TokenStore {
 			LOG.error("Could not extract access token for authentication " + authentication, e);
 		}
 
-		if (accessToken != null
-				&& !key.equals(authenticationKeyGenerator.extractKey(readAuthentication(accessToken.getValue())))) {
-			removeAccessToken(accessToken.getValue());
-			// Keep the store consistent (maybe the same user is represented by this authentication but the details have
-			// changed)
-			storeAccessToken(accessToken, authentication);
+		if (accessToken != null) {
+			OAuth2Authentication oldAuthentication = readAuthentication(accessToken.getValue());
+			if (oldAuthentication == null || !key.equals(authenticationKeyGenerator.extractKey(oldAuthentication))) {
+				removeAccessToken(accessToken.getValue());
+				// Keep the store consistent (maybe the same user is represented by this authentication but the details have
+				// changed)
+				storeAccessToken(accessToken, authentication);
+			}
 		}
 		return accessToken;
 	}


### PR DESCRIPTION
If an old Authentication failed to deserialize (e.g., after upgraded Spring Security core libs) during the creation of a token, a NPE would be thrown as `readAuthentication` return `null` in that case. This should fix that.