### PR TITLE
Add clock skew support to AccessTokenProviderChain

### DIFF
--- a/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChainTests.java
+++ b/spring-security-oauth2/src/test/java/org/springframework/security/oauth2/client/token/AccessTokenProviderChainTests.java
@@ -145,7 +145,7 @@ public class AccessTokenProviderChainTests {
 	}
 
 	@Test
-	public void testSunnyDayWIthExpiredTokenAndValidRefreshToken() throws Exception {
+	public void testSunnyDayWithExpiredTokenAndValidRefreshToken() throws Exception {
 		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
 		accessToken.setExpiration(new Date(System.currentTimeMillis() - 1000));
 		accessToken.setRefreshToken(new DefaultOAuth2RefreshToken("EXP"));
@@ -154,10 +154,37 @@ public class AccessTokenProviderChainTests {
 		SecurityContextHolder.getContext().setAuthentication(user);
 		OAuth2AccessToken token = chain.obtainAccessToken(resource, request);
 		assertNotNull(token);
+		assertEquals(refreshedToken, token);
+	}
+
+	@Test
+	public void testSunnyDayWithTokenWithinClockSkewWindowAndValidRefreshToken() throws Exception {
+		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
+		accessToken.setExpiration(new Date(System.currentTimeMillis() + 1000));
+		accessToken.setRefreshToken(new DefaultOAuth2RefreshToken("EXP"));
+		AccessTokenRequest request = new DefaultAccessTokenRequest();
+		request.setExistingToken(accessToken);
+		SecurityContextHolder.getContext().setAuthentication(user);
+		OAuth2AccessToken token = chain.obtainAccessToken(resource, request);
+		assertNotNull(token);
+		assertEquals(refreshedToken, token);
+	}
+
+	@Test
+	public void testSunnyDayWithTokenOutsideClockSkewWindowAndValidRefreshToken() throws Exception {
+		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
+		accessToken.setExpiration(new Date(System.currentTimeMillis() + 31000));
+		accessToken.setRefreshToken(new DefaultOAuth2RefreshToken("EXP"));
+		AccessTokenRequest request = new DefaultAccessTokenRequest();
+		request.setExistingToken(accessToken);
+		SecurityContextHolder.getContext().setAuthentication(user);
+		OAuth2AccessToken token = chain.obtainAccessToken(resource, request);
+		assertNotNull(token);
+		assertEquals(accessToken, token);
 	}
 
 	@Test(expected = InvalidTokenException.class)
-	public void testSunnyDayWIthExpiredTokenAndExpiredRefreshToken() throws Exception {
+	public void testSunnyDayWithExpiredTokenAndExpiredRefreshToken() throws Exception {
 		AccessTokenProviderChain chain = new AccessTokenProviderChain(Arrays.asList(new StubAccessTokenProvider()));
 		accessToken.setExpiration(new Date(System.currentTimeMillis() - 1000));
 		DefaultOAuth2RefreshToken refreshToken = new DefaultExpiringOAuth2RefreshToken("EXP",


### PR DESCRIPTION
This fixes #1909 and adds clock skew support to AccessTokenProviderChain. As with OAuth2RestTemplate the default clock skew is set to 30s.

Background: The fix for #1287 added a clock skew to OAuth2RestTemplate but there is another expiration check in AccessTokenProviderChain that does not take this into account which renders this fix useless when used in combination with AccessTokenProviderChain.

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
