### PR TITLE
Update AuthorizationServerSecurityConfigurer.java

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
@@ -247,10 +247,10 @@ public final class AuthorizationServerSecurityConfigurer extends
 				frameworkEndpointHandlerMapping().getServletPath("/oauth/token"));
 		clientCredentialsTokenEndpointFilter
 				.setAuthenticationManager(http.getSharedObject(AuthenticationManager.class));
-		OAuth2AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
+		
 		authenticationEntryPoint.setTypeName("Form");
 		authenticationEntryPoint.setRealmName(realm);
-		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(authenticationEntryPoint);
+		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(this.authenticationEntryPoint);
 		clientCredentialsTokenEndpointFilter = postProcess(clientCredentialsTokenEndpointFilter);
 		http.addFilterBefore(clientCredentialsTokenEndpointFilter, BasicAuthenticationFilter.class);
 		return clientCredentialsTokenEndpointFilter;


### PR DESCRIPTION
use authenticationEntryPoint(cloudOAuth2AuthenticationEntryPoint) to update ClientCredentialsTokenEndpointFilter's authenticationEntryPoint use AuthenticationEntryPoint
not always AuthenticationEntryPoint 
<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://spring.io/security-policy
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
