### PR TITLE
Fixed anonymous inner classes not being converted to correct XML

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/InvalidToken400Exception.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/common/exceptions/InvalidToken400Exception.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.common.exceptions;
+
+/**
+ * <p>
+ * @deprecated See the <a href="https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide">OAuth 2.0 Migration Guide</a> for Spring Security 5.
+ *
+ * @author Kason
+ */
+@SuppressWarnings("serial")
+@Deprecated
+public class InvalidToken400Exception extends ClientAuthenticationException {
+
+	public InvalidToken400Exception(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public InvalidToken400Exception(String msg) {
+		super(msg);
+	}
+
+	@Override
+	public int getHttpErrorCode() {
+		return 400;
+	}
+
+	@Override
+	public String getOAuth2ErrorCode() {
+		return "invalid_token";
+	}
+}

--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/CheckTokenEndpoint.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/endpoint/CheckTokenEndpoint.java
@@ -19,6 +19,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.exceptions.InvalidToken400Exception;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
@@ -104,14 +105,7 @@ public class CheckTokenEndpoint {
 		// unauthorized code here. The client has already authenticated
 		// successfully with basic auth and should just
 		// get back the invalid token error.
-		@SuppressWarnings("serial")
-		InvalidTokenException e400 = new InvalidTokenException(e.getMessage()) {
-			@Override
-			public int getHttpErrorCode() {
-				return 400;
-			}
-		};
-		return exceptionTranslator.translate(e400);
+		return exceptionTranslator.translate(new InvalidToken400Exception(e.getMessage()));
 	}
 
 }


### PR DESCRIPTION
Fix previous
request result:
<><error>invalid_token</error><error_description>Token
was not recognised</error_description></>

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://spring.io/security-policy
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
