### PR TITLE
Support custom OAuth2AuthenticationEntryPoint

### DIFF
--- a/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
+++ b/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/config/annotation/web/configurers/AuthorizationServerSecurityConfigurer.java
@@ -63,6 +63,8 @@ public final class AuthorizationServerSecurityConfigurer extends
 		SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
 	private AuthenticationEntryPoint authenticationEntryPoint;
+	
+	private OAuth2AuthenticationEntryPoint oauth2AuthenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
 
 	private AccessDeniedHandler accessDeniedHandler = new OAuth2AccessDeniedHandler();
 
@@ -247,10 +249,11 @@ public final class AuthorizationServerSecurityConfigurer extends
 				frameworkEndpointHandlerMapping().getServletPath("/oauth/token"));
 		clientCredentialsTokenEndpointFilter
 				.setAuthenticationManager(http.getSharedObject(AuthenticationManager.class));
-		OAuth2AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
-		authenticationEntryPoint.setTypeName("Form");
-		authenticationEntryPoint.setRealmName(realm);
-		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(authenticationEntryPoint);
+
+		oauth2AuthenticationEntryPoint.setTypeName("Form");
+		oauth2AuthenticationEntryPoint.setRealmName(realm);
+		clientCredentialsTokenEndpointFilter.setAuthenticationEntryPoint(oauth2AuthenticationEntryPoint);
+
 		clientCredentialsTokenEndpointFilter = postProcess(clientCredentialsTokenEndpointFilter);
 		http.addFilterBefore(clientCredentialsTokenEndpointFilter, BasicAuthenticationFilter.class);
 		return clientCredentialsTokenEndpointFilter;
@@ -284,4 +287,9 @@ public final class AuthorizationServerSecurityConfigurer extends
 		Assert.notNull(filters, "Custom authentication filter list must not be null");
 		this.tokenEndpointAuthenticationFilters = new ArrayList<Filter>(filters);
 	}
+	
+	public void setOauth2AuthenticationEntryPoint(OAuth2AuthenticationEntryPoint oauth2AuthenticationEntryPoint) {
+		this.oauth2AuthenticationEntryPoint = oauth2AuthenticationEntryPoint;
+	}
+	
 }


### PR DESCRIPTION
Support custom OAuth2AuthenticationEntryPoint when accessing "/oauth/token"

<!--
******************
Deprecation Notice
******************
The Spring Security OAuth project is deprecated. 
The latest OAuth 2.0 support is provided by Spring Security. 
See the OAuth 2.0 Migration Guide https://github.com/spring-projects/spring-security/wiki/OAuth-2.0-Migration-Guide
-->

<!--
For Security Vulnerabilities, please use https://spring.io/security-policy
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
