### PR TITLE
Could org.springframework.security.oauth:spring-security-oauth:2.5.3.BUILD-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/spring-security-oauth/pom.xml
+++ b/spring-security-oauth/pom.xml
@@ -106,16 +106,34 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
+			<exclusions>
+				<exclusion>
+				    <groupId>aopalliance</groupId>
+				    <artifactId>aopalliance</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-config</artifactId>
+			<exclusions>
+				<exclusion>
+				    <groupId>aopalliance</groupId>
+				    <artifactId>aopalliance</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
+			<exclusions>
+				<exclusion>
+				    <groupId>aopalliance</groupId>
+				    <artifactId>aopalliance</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/170042283-b5832910-b434-4d63-9b03-28a094019373.png)
Hi! I found the pom file of project **_org.springframework.security.oauth:spring-security-oauth:2.5.3.BUILD-SNAPSHOT_** introduced **_27_** dependencies. However, among them, **_1_** libraries (**_3%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
aopalliance:aopalliance:jar:1.0:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_aopalliance:aopalliance:jar:1.0:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_org.springframework.security.oauth:spring-security-oauth:2.5.3.BUILD-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.springframework.security.oauth:spring-security-oauth:2.5.3.BUILD-SNAPSHOT_**’s maven tests.

Best regards